### PR TITLE
fix(orm): limit before filtering, isNull, flatMap pagination, soft cascade

### DIFF
--- a/.changeset/olive-eyes-punch.md
+++ b/.changeset/olive-eyes-punch.md
@@ -1,0 +1,18 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `like`, `ilike`, `contains`, `endsWith`, and the array operators returning
+  too few rows — often none — when combined with `limit`. These operators are
+  matched after the rows are read, so `limit` now counts matches instead of
+  scanned rows. `offset` counts matches too.
+- Fix `NOT` around one of those operators matching nothing instead of negating.
+- Fix `isNull` skipping rows whose column was never written once that column is
+  indexed. Absent and explicitly-null columns now both match, with or without an
+  index.
+- Fix `flatMap` pagination dropping and duplicating children after the first
+  page. Walking every page now returns the same rows as reading them at once.
+- Fix soft cascade deletes rescheduling themselves forever and never reaching
+  the children past the first batch.

--- a/convex/orm/foreign-key-actions.test.ts
+++ b/convex/orm/foreign-key-actions.test.ts
@@ -44,6 +44,20 @@ const membershipsCascade = convexTable(
   ]
 );
 
+const membershipsSoftCascade = convexTable(
+  'fk_action_memberships_soft_cascade',
+  {
+    userId: id('fk_action_users').notNull(),
+    deletionTime: integer(),
+  },
+  (t) => [
+    index('by_user').on(t.userId),
+    foreignKey({ columns: [t.userId], foreignColumns: [users.id] }).onDelete(
+      'cascade'
+    ),
+  ]
+);
+
 const membershipsRestrict = convexTable(
   'fk_action_memberships_restrict',
   {
@@ -202,6 +216,7 @@ const rlsUpdateChildren = convexTable(
 const baseSchemaTables = {
   fk_action_users: users,
   fk_action_memberships_cascade: membershipsCascade,
+  fk_action_memberships_soft_cascade: membershipsSoftCascade,
   fk_action_memberships_restrict: membershipsRestrict,
   fk_action_memberships_null: membershipsSetNull,
   fk_action_memberships_null_large: membershipsSetNullLarge,
@@ -919,6 +934,71 @@ describe('foreign key actions', () => {
         expect(secondContinuation.workType).toBe('cascade-delete');
         expect(secondContinuation.foreignAction).toBe('cascade');
         expect(secondContinuation.cursor).toBeNull();
+      },
+      { scheduler: scheduler as any, scheduledMutationBatch }
+    );
+  });
+
+  it('terminates async soft cascade instead of re-queueing forever', async () => {
+    const queue: any[] = [];
+    const scheduler = {
+      runAfter: vi.fn(async (_delay: number, _ref: any, args: any) => {
+        queue.push(args);
+        return 'scheduled';
+      }),
+      runAt: vi.fn(async () => 'scheduled'),
+      cancel: vi.fn(async () => undefined),
+    };
+    const scheduledMutationBatch = {} as SchedulableFunctionReference;
+    const worker = scheduledMutationBatchFactory(
+      asyncCappedRelations,
+      asyncCappedEdges,
+      scheduledMutationBatch
+    );
+
+    await withAsyncCappedCtx(
+      async ({ orm, db }) => {
+        const [user] = await orm
+          .insert(users)
+          .values({ slug: 'ada' })
+          .returning();
+
+        await orm
+          .insert(membershipsSoftCascade)
+          .values([
+            { userId: asAnyId(user.id) },
+            { userId: asAnyId(user.id) },
+            { userId: asAnyId(user.id) },
+          ]);
+
+        await orm
+          .delete(users)
+          .soft()
+          .where(eq(users.id, asAnyId(user.id)))
+          .execute();
+
+        // Soft delete leaves the foreign key columns untouched, so a worker
+        // that re-queries from a null cursor keeps selecting the same rows.
+        // Drive the queue with a hard cap: it must drain, not spin.
+        let rounds = 0;
+        while (queue.length > 0) {
+          rounds += 1;
+          if (rounds > 20) {
+            throw new Error(
+              'soft cascade never drained: worker re-queued itself 20 times'
+            );
+          }
+          const next = queue.shift();
+          await worker({ db, scheduler: scheduler as any }, next);
+        }
+
+        const children = await db
+          .query('fk_action_memberships_soft_cascade')
+          .collect();
+        expect(children).toHaveLength(3);
+        for (const child of children) {
+          expect((child as any).deletionTime).toBeTypeOf('number');
+        }
       },
       { scheduler: scheduler as any, scheduledMutationBatch }
     );

--- a/convex/orm/pipeline.test.ts
+++ b/convex/orm/pipeline.test.ts
@@ -340,3 +340,63 @@ test('findMany pipeline mode is removed', async () => {
     ).toThrow(/findmany\(\{ pipeline \}\) is removed/i);
   });
 });
+
+test('select flatMap pagination walks every child exactly once', async () => {
+  const t = convexTest(schema);
+
+  await t.run(async (baseCtx) => {
+    // Insert in reverse name order so `_id` order differs from `name` order.
+    // The cursor's inner-key bound then belongs to a parent that is not first.
+    for (const name of ['Cara', 'Bob', 'Alice']) {
+      const user = await baseCtx.db.insert('users', {
+        name,
+        email: `${name.toLowerCase()}-flatmap@example.com`,
+      });
+      for (const suffix of [1, 2]) {
+        await baseCtx.db.insert('posts', {
+          text: `${name}-${suffix}`,
+          numLikes: suffix,
+          type: 'note',
+          authorId: user,
+        });
+      }
+    }
+  });
+
+  await t.run(async (baseCtx) => {
+    const ctx = await runCtx(baseCtx);
+    const buildQuery = () =>
+      ctx.orm.query.users
+        .select()
+        .orderBy({ name: 'asc' })
+        .flatMap('posts', { includeParent: false });
+
+    const singlePage = await buildQuery().paginate({
+      cursor: null,
+      limit: 100,
+    });
+    expect(singlePage.page.map((row) => row.text)).toEqual([
+      'Alice-1',
+      'Alice-2',
+      'Bob-1',
+      'Bob-2',
+      'Cara-1',
+      'Cara-2',
+    ]);
+
+    // Walking the same stream three rows at a time must yield the same rows,
+    // in the same order, with no duplicates and nothing dropped.
+    const walked: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 10; page += 1) {
+      const result = await buildQuery().paginate({ cursor, limit: 3 });
+      walked.push(...result.page.map((row) => row.text));
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        break;
+      }
+    }
+
+    expect(walked).toEqual(singlePage.page.map((row) => row.text));
+  });
+});

--- a/convex/orm/string-operators.test.ts
+++ b/convex/orm/string-operators.test.ts
@@ -777,3 +777,139 @@ describe('M5: contains operator', () => {
     expect(posts.map((p: any) => p.title)).toContain('TypeScript Handbook');
   });
 });
+
+// ============================================================================
+// Limit interaction
+// ============================================================================
+
+describe('M5: post-fetch operators combined with limit', () => {
+  const seed = async (ctx: TestCtx) => {
+    const user = await ctx.db.insert('users', {
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    // 15 non-matching titles sort before the 5 matching ones, so a `limit`
+    // pushed down to Convex consumes the whole budget on non-matches.
+    for (let i = 0; i < 15; i += 1) {
+      await ctx.db.insert('posts', {
+        text: 'test',
+        numLikes: 0,
+        type: 'text',
+        title: `AAA Python ${String(i).padStart(2, '0')}`,
+        content: 'Content',
+        published: true,
+        authorId: user,
+        publishedAt: 1000 + i,
+      });
+    }
+    for (let i = 15; i < 20; i += 1) {
+      await ctx.db.insert('posts', {
+        text: 'test',
+        numLikes: 0,
+        type: 'text',
+        title: `ZZZ Java ${String(i).padStart(2, '0')}`,
+        content: 'Content',
+        published: true,
+        authorId: user,
+        publishedAt: 1000 + i,
+      });
+    }
+  };
+
+  test('like with a limit returns matches, not the first limit rows', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(5);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('like with a limit smaller than the match count truncates matches', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      limit: 3,
+    });
+
+    expect(posts).toHaveLength(3);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('contains and endsWith honor limit', async ({ ctx }) => {
+    await seed(ctx);
+
+    const contains = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { contains: 'Java' } },
+      limit: 5,
+    });
+    const endsWith = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { endsWith: '19' } },
+      limit: 5,
+    });
+
+    expect(contains).toHaveLength(5);
+    expect(endsWith).toHaveLength(1);
+    expect(endsWith[0].title).toBe('ZZZ Java 19');
+  });
+
+  test('explicit withIndex + ilike + limit returns matches', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { ilike: '%java%' } },
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(5);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('NOT around a post-fetch operator negates instead of matching nothing', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { NOT: { like: '%Java%' } } },
+    });
+
+    expect(posts).toHaveLength(15);
+    for (const post of posts) {
+      expect(post.title).not.toContain('Java');
+    }
+  });
+
+  test('offset with a post-fetch operator skips matches, not scanned rows', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      offset: 2,
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(3);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+});

--- a/convex/orm/where-filtering.test.ts
+++ b/convex/orm/where-filtering.test.ts
@@ -868,6 +868,49 @@ describe('M4 Where Filtering - Null Operators', () => {
     expect(result[0].name).toBe('Alice');
   });
 
+  test('isNull matches rows whose column is absent, indexed or not', async ({
+    ctx,
+  }) => {
+    const db = ctx.orm;
+
+    // Column omitted entirely: the normal state for a nullable column that was
+    // never written. Convex stores this as a missing field, not as null.
+    await ctx.db.insert('users', {
+      name: 'Absent',
+      email: 'absent@example.com',
+      age: 25,
+      status: 'active',
+    });
+    await ctx.db.insert('users', {
+      name: 'ExplicitNull',
+      email: 'null@example.com',
+      age: 26,
+      status: 'active',
+      deletedAt: null,
+    });
+    await ctx.db.insert('users', {
+      name: 'Deleted',
+      email: 'deleted@example.com',
+      age: 27,
+      status: 'deleted',
+      deletedAt: 123_456,
+    });
+
+    const withoutIndex = await db.query.users.findMany({
+      where: { deletedAt: { isNull: true } },
+    });
+    // `by_deleted_at` makes the compiler take the index path; both paths must agree.
+    const withIndex = await db.query.users.withIndex('by_deleted_at').findMany({
+      where: { deletedAt: { isNull: true } },
+    });
+
+    const names = (rows: { name: string }[]) =>
+      rows.map((row) => row.name).sort();
+
+    expect(names(withoutIndex)).toEqual(['Absent', 'ExplicitNull']);
+    expect(names(withIndex)).toEqual(['Absent', 'ExplicitNull']);
+  });
+
   test('should filter with isNotNull operator', async ({ ctx }) => {
     const db = ctx.orm;
 

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -138,6 +138,25 @@ import {
   WhereClauseCompiler,
 } from './where-clause-compiler';
 
+/**
+ * Operators that Convex's `.filter()` cannot express, so `_toConvexExpression`
+ * compiles them to a `() => true` placeholder and `_evaluatePostFetchFilter`
+ * applies the real predicate in JavaScript after the rows are read.
+ * Keep in sync with the string/array cases in `_toConvexExpression`.
+ */
+const POST_FETCH_ONLY_OPERATORS = new Set([
+  'like',
+  'ilike',
+  'notLike',
+  'notIlike',
+  'startsWith',
+  'endsWith',
+  'contains',
+  'arrayContains',
+  'arrayContained',
+  'arrayOverlaps',
+]);
+
 const DEFAULT_RELATION_FAN_OUT_MAX_KEYS = 1000;
 const DEFAULT_AGGREGATE_CARTESIAN_MAX_KEYS = 4096;
 const DEFAULT_AGGREGATE_WORK_BUDGET = 16_384;
@@ -660,6 +679,41 @@ export class GelRelationalQuery<
       return targetValue.startsWith(prefix);
     }
     return targetValue === targetPattern;
+  }
+
+  /**
+   * True when the expression can be fully enforced by Convex's own `.filter()`.
+   *
+   * `_toConvexExpression` compiles the string/array operators to `() => true`
+   * because Convex filters cannot run JavaScript string methods; those are
+   * evaluated later by `_evaluatePostFetchFilter`. Pushing such an expression
+   * into `.filter()` is not merely useless, it is wrong in two ways: a `take()`
+   * downstream spends its budget on rows that have not been filtered yet, and a
+   * surrounding `NOT` turns the `true` placeholder into `q.not(true)`, which
+   * matches nothing. So the caller must know whether Convex can carry the whole
+   * expression before relying on it.
+   */
+  private _isConvexEnforceableFilter(
+    filter: FilterExpression<boolean>
+  ): boolean {
+    if (filter.type === 'binary') {
+      return !POST_FETCH_ONLY_OPERATORS.has(filter.operator);
+    }
+    if (filter.type === 'unary') {
+      const [operand] = filter.operands;
+      if (isFieldReference(operand)) {
+        return true;
+      }
+      return this._isConvexEnforceableFilter(
+        operand as FilterExpression<boolean>
+      );
+    }
+    if (filter.type === 'logical') {
+      return filter.operands.every((operand) =>
+        this._isConvexEnforceableFilter(operand)
+      );
+    }
+    return true;
   }
 
   /**
@@ -2240,6 +2294,86 @@ export class GelRelationalQuery<
     }
 
     return streamQuery;
+  }
+
+  /**
+   * Stream equivalent of the non-paginated `db.query(...)` chain, used when a
+   * post-fetch filter has to run in JavaScript before `limit` can be applied.
+   *
+   * It deliberately mirrors the index and order decisions the caller already
+   * made for the plain query rather than re-deriving them, so switching to the
+   * stream cannot change which index is scanned or in what direction.
+   *
+   * Returns null when the schema definition needed by `stream()` is missing;
+   * the caller then falls back to collect-and-slice.
+   */
+  private _buildResidualFilterStream(params: {
+    queryConfig: {
+      index?: { name: string; filters: FilterExpression<boolean>[] };
+      postFilters: FilterExpression<boolean>[];
+    };
+    configuredIndex?: PredicateWhereIndexConfig<TTableConfig>;
+    orderIndexName: string | null;
+    primaryOrder?: { direction: 'asc' | 'desc'; field: string };
+    needsPostFetchSortForPrimary: boolean;
+  }): QueryStream<any> | null {
+    const schemaDefinition = (this.schema as any)[OrmSchemaDefinition];
+    if (!schemaDefinition) {
+      return null;
+    }
+
+    const {
+      queryConfig,
+      configuredIndex,
+      orderIndexName,
+      primaryOrder,
+      needsPostFetchSortForPrimary,
+    } = params;
+
+    let streamQuery: any = stream(
+      this.db as GenericDatabaseReader<any>,
+      schemaDefinition
+    ).query(this.tableConfig.name as any);
+
+    if (queryConfig.index) {
+      streamQuery = streamQuery.withIndex(
+        queryConfig.index.name as any,
+        (q: any) => {
+          let indexQuery = q;
+          for (const filter of queryConfig.index!.filters) {
+            indexQuery = this._applyFilterToQuery(indexQuery, filter);
+          }
+          return indexQuery;
+        }
+      );
+    } else if (configuredIndex?.name) {
+      streamQuery = streamQuery.withIndex(
+        configuredIndex.name as any,
+        configuredIndex.range ? (configuredIndex.range as any) : (q: any) => q
+      );
+    } else if (orderIndexName) {
+      streamQuery = streamQuery.withIndex(orderIndexName as any, (q: any) => q);
+    }
+
+    // The plain query only calls .order() when the index already sorts by the
+    // requested field; otherwise the rows are sorted post-fetch and this branch
+    // is not used. Streams always need an explicit direction, and Convex
+    // defaults to ascending.
+    streamQuery = streamQuery.order(
+      primaryOrder && !needsPostFetchSortForPrimary
+        ? primaryOrder.direction
+        : 'asc'
+    );
+
+    streamQuery = streamQuery.filterWith((row: any) =>
+      Promise.resolve(
+        queryConfig.postFilters.every((filter) =>
+          this._evaluatePostFetchFilter(row, filter)
+        )
+      )
+    );
+
+    return streamQuery as QueryStream<any>;
   }
 
   private _buildUnionSourceStream(
@@ -5756,11 +5890,15 @@ export class GelRelationalQuery<
         }
       }
 
-      // Apply post-filters
-      if (queryConfig.postFilters.length > 0) {
+      // Apply post-filters. Only the Convex-enforceable ones: the rest are
+      // placeholders that would make a surrounding NOT match nothing.
+      const convexPostFilters = queryConfig.postFilters.filter((filter) =>
+        this._isConvexEnforceableFilter(filter)
+      );
+      if (convexPostFilters.length > 0) {
         query = query.filter((q: any) => {
           let result: any | null = null;
-          for (const filter of queryConfig.postFilters) {
+          for (const filter of convexPostFilters) {
             const filterFn = this._toConvexExpression(filter);
             const expr = filterFn(q);
             result = result ? q.and(result, expr) : expr;
@@ -5833,12 +5971,18 @@ export class GelRelationalQuery<
       } as TResult;
     }
 
-    // Apply post-filters
-    if (queryConfig.postFilters.length > 0) {
+    // Apply post-filters. Only the Convex-enforceable ones: the rest are
+    // placeholders that would make a surrounding NOT match nothing.
+    const convexPostFilters = queryConfig.postFilters.filter((filter) =>
+      this._isConvexEnforceableFilter(filter)
+    );
+    const hasResidualPostFilter =
+      convexPostFilters.length !== queryConfig.postFilters.length;
+    if (convexPostFilters.length > 0) {
       query = query.filter((q: any) => {
         // Combine all post-filters with AND logic
         let result: any | null = null;
-        for (const filter of queryConfig.postFilters) {
+        for (const filter of convexPostFilters) {
           const filterFn = this._toConvexExpression(filter);
           const expr = filterFn(q);
           result = result ? q.and(result, expr) : expr;
@@ -5857,13 +6001,48 @@ export class GelRelationalQuery<
     const limit = this._resolveNonPaginatedLimit(config);
     const paginateAfterPostFetchSort =
       usePostFetchSort && postFetchOrders.length > 0;
-    let rows =
-      limit === undefined || paginateAfterPostFetchSort
-        ? await query.collect()
-        : await query.take(offset > 0 ? offset + limit : limit);
+
+    // A residual filter runs in JavaScript, so `query.take(limit)` would spend
+    // the whole budget on unfiltered rows and return mostly (often entirely)
+    // non-matching ones. Offset has the same problem: it must skip matches, not
+    // scanned rows. So when a residual filter is present, sizing moves after the
+    // JavaScript pass.
+    const sizeAfterPostFilter =
+      hasResidualPostFilter && !paginateAfterPostFetchSort;
+
+    // Read through a stream when we can: `filterWith` runs the predicate as rows
+    // are pulled, so `take` still stops early but counts matches rather than
+    // scanned rows, preserving the read bound the plain `take` gave us.
+    const residualLimitStream =
+      sizeAfterPostFilter && limit !== undefined
+        ? this._buildResidualFilterStream({
+            queryConfig,
+            configuredIndex,
+            orderIndexName,
+            primaryOrder,
+            needsPostFetchSortForPrimary,
+          })
+        : null;
+
+    let rows: any[];
+    if (residualLimitStream) {
+      rows = await residualLimitStream.take(
+        offset > 0 ? offset + (limit as number) : (limit as number)
+      );
+    } else if (
+      limit === undefined ||
+      paginateAfterPostFetchSort ||
+      hasResidualPostFilter
+    ) {
+      // No stream available (no defineSchema()) or no limit to push down.
+      // Correctness wins over the read bound: scan, then size below.
+      rows = await query.collect();
+    } else {
+      rows = await query.take(offset > 0 ? offset + limit : limit);
+    }
 
     // Apply offset slicing if needed
-    if (!paginateAfterPostFetchSort && offset > 0) {
+    if (!(paginateAfterPostFetchSort || sizeAfterPostFilter) && offset > 0) {
       rows = rows.slice(offset);
     }
 
@@ -5875,6 +6054,16 @@ export class GelRelationalQuery<
           this._evaluatePostFetchFilter(row, filter)
         )
       );
+    }
+
+    // Residual filters are now applied, so offset/limit finally mean "matches".
+    if (sizeAfterPostFilter) {
+      if (offset > 0) {
+        rows = rows.slice(offset);
+      }
+      if (limit !== undefined) {
+        rows = rows.slice(0, limit);
+      }
     }
 
     rows = await this._applyRlsSelectFilter(rows, this.tableConfig);

--- a/packages/kitcn/src/orm/scheduled-mutation-batch.ts
+++ b/packages/kitcn/src/orm/scheduled-mutation-batch.ts
@@ -56,6 +56,9 @@ export type ScheduledMutationBatchArgs = {
   delayMs: number;
 };
 
+/** Column stamped by `softDeleteRow`; see mutation-utils.ts. */
+const DELETION_TIME_FIELD = 'deletionTime';
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value);
 
@@ -206,8 +209,18 @@ export function scheduledMutationBatchFactory<
         'scheduledMutationBatch: foreignIndexName is required for cascade work.'
       );
     }
-    const queryWithIndex = () =>
-      (ctx.db.query(args.table) as any).withIndex(
+    const action = args.foreignAction ?? 'no action';
+    // Every other cascade action stops a processed row from matching this
+    // index: hard delete removes it, `set null` / `set default` / cascade
+    // update rewrite the foreign key columns. Soft cascade only stamps
+    // `deletionTime`, so without this guard the re-query below keeps returning
+    // the same rows and the worker re-queues itself forever.
+    const skipSoftDeletedRows =
+      workType === 'cascade-delete' &&
+      action === 'cascade' &&
+      (args.cascadeMode ?? 'hard') === 'soft';
+    const queryWithIndex = () => {
+      const indexed = (ctx.db.query(args.table) as any).withIndex(
         args.foreignIndexName,
         (q: any) => {
           let builder = q.eq(sourceColumns[0], targetValues[0]);
@@ -217,7 +230,16 @@ export function scheduledMutationBatchFactory<
           return builder;
         }
       );
-    const action = args.foreignAction ?? 'no action';
+      if (!skipSoftDeletedRows) {
+        return indexed;
+      }
+      return indexed.filter((q: any) =>
+        q.or(
+          q.eq(q.field(DELETION_TIME_FIELD), undefined),
+          q.eq(q.field(DELETION_TIME_FIELD), null)
+        )
+      );
+    };
     // Cascade workers patch/delete rows that are selected by the same indexed
     // foreign key columns. Forwarding cursors can skip remaining rows after
     // those mutations, so cascade continuation always re-queries from null.

--- a/packages/kitcn/src/orm/stream.ts
+++ b/packages/kitcn/src/orm/stream.ts
@@ -1271,12 +1271,12 @@ class FlatMapStreamIterator<
     innerIterator: AsyncIterator<[U | null, IndexKey]>;
     count: number;
   } | null = null;
-  #mapper: (doc: T) => Promise<QueryStream<U>>;
+  #mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>;
   #mappedIndexFields: string[];
 
   constructor(
     outerStream: QueryStream<T>,
-    mapper: (doc: T) => Promise<QueryStream<U>>,
+    mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>,
     mappedIndexFields: string[]
   ) {
     this.#outerIterator = outerStream.iterWithKeys()[Symbol.asyncIterator]();
@@ -1302,7 +1302,7 @@ class FlatMapStreamIterator<
     if (t === null) {
       innerStream = this.singletonSkipInnerStream();
     } else {
-      innerStream = await this.#mapper(t);
+      innerStream = await this.#mapper(t, indexKey);
       if (
         !equalIndexFields(innerStream.getIndexFields(), this.#mappedIndexFields)
       ) {
@@ -1358,11 +1358,11 @@ class FlatMapStream<
   U extends GenericStreamItem,
 > extends QueryStream<U> {
   #stream: QueryStream<T>;
-  #mapper: (doc: T) => Promise<QueryStream<U>>;
+  #mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>;
   #mappedIndexFields: string[];
   constructor(
     stream: QueryStream<T>,
-    mapper: (doc: T) => Promise<QueryStream<U>>,
+    mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>,
     mappedIndexFields: string[]
   ) {
     super();
@@ -1407,19 +1407,51 @@ class FlatMapStream<
       upperBoundInclusive:
         innerUpperBound.length === 0 ? indexBounds.upperBoundInclusive : true,
     };
-    const innerIndexBounds = {
-      lowerBound: innerLowerBound,
-      lowerBoundInclusive:
-        innerLowerBound.length === 0 ? true : indexBounds.lowerBoundInclusive,
-      upperBound: innerUpperBound,
-      upperBoundInclusive:
-        innerUpperBound.length === 0 ? true : indexBounds.upperBoundInclusive,
+    // The index key of a flatMap stream is [outerKey..., innerKey...], so an
+    // inner bound taken from a cursor only describes the boundary parent — the
+    // one whose outer key the cursor landed in. Applying it to every parent
+    // clips unrelated children, and because the inner stream intersects it with
+    // its own equality bounds the result is usually an inverted range, which
+    // silently drops rows and repeats others. Restrict each parent by only the
+    // bounds that actually belong to it.
+    const unrestricted = {
+      lowerBound: [] as IndexKey,
+      lowerBoundInclusive: true,
+      upperBound: [] as IndexKey,
+      upperBoundInclusive: true,
+    };
+    const isBoundaryParent = (parentKey: IndexKey, bound: IndexKey) =>
+      bound.length === outerLength &&
+      compareKeys(
+        { value: parentKey, kind: 'exact' },
+        { value: bound, kind: 'exact' }
+      ) === 0;
+    const innerBoundsForParent = (parentKey: IndexKey) => {
+      const atLowerBound =
+        innerLowerBound.length > 0 &&
+        isBoundaryParent(parentKey, outerLowerBound);
+      const atUpperBound =
+        innerUpperBound.length > 0 &&
+        isBoundaryParent(parentKey, outerUpperBound);
+      if (!(atLowerBound || atUpperBound)) {
+        return unrestricted;
+      }
+      return {
+        lowerBound: atLowerBound ? innerLowerBound : unrestricted.lowerBound,
+        lowerBoundInclusive: atLowerBound
+          ? indexBounds.lowerBoundInclusive
+          : true,
+        upperBound: atUpperBound ? innerUpperBound : unrestricted.upperBound,
+        upperBoundInclusive: atUpperBound
+          ? indexBounds.upperBoundInclusive
+          : true,
+      };
     };
     return new FlatMapStream(
       this.#stream.narrow(outerIndexBounds),
-      async (t) => {
-        const innerStream = await this.#mapper(t);
-        return innerStream.narrow(innerIndexBounds);
+      async (t, parentKey) => {
+        const innerStream = await this.#mapper(t, parentKey);
+        return innerStream.narrow(innerBoundsForParent(parentKey));
       },
       this.#mappedIndexFields
     );

--- a/packages/kitcn/src/orm/where-clause-compiler.test.ts
+++ b/packages/kitcn/src/orm/where-clause-compiler.test.ts
@@ -34,7 +34,7 @@ describe('WhereClauseCompiler advanced index planning', () => {
     expect(result.probeFilters).toHaveLength(2);
   });
 
-  test('plans isNull as indexed equality to null', () => {
+  test('plans isNull as an index range covering absent and null keys', () => {
     const compiler = new WhereClauseCompiler('users', [
       { indexName: 'by_deleted_at', indexFields: ['deletedAt'] },
     ]);
@@ -43,9 +43,15 @@ describe('WhereClauseCompiler advanced index planning', () => {
       isNull(fieldRef<number | null>('deletedAt') as any)
     ) as any;
 
-    expect(result.strategy).toBe('singleIndex');
+    expect(result.strategy).toBe('rangeIndex');
     expect(result.selectedIndex?.indexName).toBe('by_deleted_at');
+    // `<= null` spans the {undefined, null} prefix of Convex's value order, so
+    // rows whose column was never written stay in the scan.
     expect(result.indexFilters).toHaveLength(1);
+    expect(result.indexFilters[0].operator).toBe('lte');
+    expect(result.indexFilters[0].operands[1]).toBeNull();
+    // The expression is retained so over-fetched rows are re-verified.
+    expect(result.postFilters).toHaveLength(1);
   });
 
   test('plans startsWith as index range', () => {

--- a/packages/kitcn/src/orm/where-clause-compiler.ts
+++ b/packages/kitcn/src/orm/where-clause-compiler.ts
@@ -22,6 +22,7 @@ import {
   gte,
   isFieldReference,
   lt,
+  lte,
 } from './filter-expression';
 
 // ============================================================================
@@ -288,12 +289,18 @@ export class WhereClauseCompiler {
       return null;
     }
 
+    // `isNull` means null-or-absent everywhere else in the ORM, and Convex
+    // stores an omitted column as a missing field whose index key is
+    // `undefined`. `undefined` sorts immediately before `null` in Convex's
+    // total value order, so `<= null` is exactly the {undefined, null} range.
+    // An `eq(field, null)` probe would scan only half of it and silently drop
+    // every row that never had the column written.
     return {
-      strategy: 'singleIndex',
+      strategy: 'rangeIndex',
       selectedIndex,
-      indexFilters: [eq(fieldRef(operand.fieldName) as any, null)],
+      indexFilters: [lte(fieldRef(operand.fieldName) as any, null as any)],
       probeFilters: [],
-      postFilters: [],
+      postFilters: [expression],
     };
   }
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fixes the four `critical` findings from an aggressive bug sweep of the ORM. Each one silently returns wrong data or never terminates — none of them throws, so an app hits them without any signal.

Every fix landed test-first: the test was confirmed red against the current code, then made green.

## 1. `limit` was applied before post-fetch filtering

`like`, `ilike`, `contains`, `endsWith` and the array operators cannot be expressed in a Convex `.filter()`, so they compile to a `() => true` placeholder and run in JavaScript after the read. But `limit` was pushed into `query.take()` **before** that pass, so Convex returned the first `limit` rows of the *unfiltered* scan and the predicate then discarded almost all of them.

```ts
// 20 rows, 5 of which contain "Java"
await orm.query.posts.findMany({ where: { title: { like: '%Java%' } }, limit: 5 })
// before: []        after: the 5 matching rows
```

`limit` is not opt-in — `findMany` requires sizing — so this was the default calling convention. The same root cause also hit `flatMap` + `where` + `limit`, `multiProbe` with `orderBy`, and the id-only fast path.

Fixed by tracking whether a compiled predicate is *residual* (JavaScript-only). When one is present the read goes through the existing stream machinery, where `filterWith` runs as rows are pulled so `take` still stops early but counts **matches** instead of scanned rows — the read bound is preserved, not traded away. `offset` now skips matches too.

## 2. `NOT` around a post-fetch operator matched nothing

Same placeholder, different symptom: a surrounding `NOT` compiled to `q.not(true)`.

```ts
await orm.query.posts.findMany({ where: { title: { NOT: { like: '%Java%' } } } })
// before: []        after: the 15 non-matching rows
```

Residual expressions are no longer pushed into Convex's `.filter()` at all, so the JavaScript pass owns them end to end.

## 3. `isNull` dropped rows once the column was indexed

`isNull` means null-or-absent everywhere else in the ORM, but `tryCompileIsNull` emitted `eq(field, null)` with no post-filter. Convex stores an omitted column as a missing field, so every row that never had the column written was excluded by the index scan with no way to recover it. Adding an index to a soft-delete column silently changed query results:

```
no index   -> ["absent", "explicit-null", "orm-omitted"]
with index -> ["explicit-null"]
```

`undefined` sorts immediately before `null` in Convex's total value order, so the plan is now the range `<= null`, which is exactly the `{undefined, null}` prefix, and the expression is retained as a post-filter.

## 4. `flatMap` pagination dropped and duplicated rows

A flatMap stream's index key is `[outerKey..., innerKey...]`. `narrow()` split the cursor bound once and then applied the inner half to **every** parent, clipping unrelated children; intersecting that alien bound with each inner stream's own equality bounds usually produced an inverted range.

```
single page: [Alice-1, Alice-2, Bob-1, Bob-2, Cara-1, Cara-2]
paginated:   [Alice-1, Alice-2, Bob-1, Bob-2, Bob-2]   <- Cara lost, Bob-2 twice
```

The parent's index key is now threaded through the mapper, so the inner lower/upper bound is applied only to the parent it actually belongs to and every other parent is unrestricted.

## 5. Soft cascade delete never terminated

Cascade continuation deliberately re-queries from a null cursor because processed rows stop matching the foreign-key index — true for hard delete, `set null`, `set default` and cascade update. It is **not** true for `cascadeMode: 'soft'`, which only stamps `deletionTime` and leaves the foreign key columns untouched. So `hasRemaining` stayed permanently true and the worker rescheduled itself forever, re-processing the same first batch and never reaching the remaining children.

The soft-cascade query now excludes already-soft-deleted rows, restoring the invariant the re-query design depends on.

## Verification

- `bun test` 1013 pass / 0 fail
- `bunx vitest run` 610 pass / 0 fail (was 601; +9 new regression tests)
- `bun typecheck` clean, `bun --cwd packages/kitcn build` clean
- `bun run test:cli` 123 pass, `bun run test:concave` pass
- Each new test verified red before the fix — the flatMap one by stashing only `stream.ts`

## Known blocker (pre-existing, not from this change)

`bun run fixtures:check` reports drift on `@base-ui/react` `^1.6.0 -> ^1.7.0` and `lucide-react` `^1.28.0 -> ^1.31.0`. This is an upstream registry bump in the scaffold dependency pins; it **reproduces on a clean tree with this branch's changes stashed**. `bun run fixtures:sync` could not complete here because the sandbox has no network access to `github.com` / `ui.shadcn.com` (`shadcn init` clones its templates). It needs a separate sync commit from an environment with network access.
