### PR TITLE
fix(orm): limit before filtering, isNull, flatMap pagination, soft cascade

### DIFF
--- a/.changeset/olive-eyes-punch.md
+++ b/.changeset/olive-eyes-punch.md
@@ -8,7 +8,11 @@
   too few rows — often none — when combined with `limit`. These operators are
   matched after the rows are read, so `limit` now counts matches instead of
   scanned rows. `offset` counts matches too.
-- Fix `NOT` around one of those operators matching nothing instead of negating.
+- Fix those same operators being ignored entirely under cursor pagination, which
+  returned pages containing rows that did not match. Pages now hold only
+  matching rows and still fill to `limit`.
+- Fix `NOT` around one of those operators matching nothing instead of negating,
+  with or without a cursor.
 - Fix `isNull` skipping rows whose column was never written once that column is
   indexed. Absent and explicitly-null columns now both match, with or without an
   index.

--- a/.changeset/olive-eyes-punch.md
+++ b/.changeset/olive-eyes-punch.md
@@ -1,0 +1,18 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `like`, `ilike`, `contains`, `endsWith`, and the array operators returning
+  too few rows — often none — when combined with `limit`. These operators are
+  matched after the rows are read, so `limit` now counts matches instead of
+  scanned rows. `offset` counts matches too.
+- Fix `NOT` around one of those operators matching nothing instead of negating.
+- Fix `isNull` skipping rows whose column was never written once that column is
+  indexed. Absent and explicitly-null columns now both match, with or without an
+  index.
+- Fix `flatMap` pagination dropping and duplicating children after the first
+  page. Walking every page now returns the same rows as reading them at once.
+- Fix soft cascade deletes rescheduling themselves forever and never reaching
+  the children past the first batch.

--- a/.changeset/olive-eyes-punch.md
+++ b/.changeset/olive-eyes-punch.md
@@ -10,7 +10,7 @@
   scanned rows. `offset` counts matches too.
 - Fix those same operators being ignored entirely under cursor pagination, which
   returned pages containing rows that did not match. Pages now hold only
-  matching rows and still fill to `limit`.
+  matching rows.
 - Fix `NOT` around one of those operators matching nothing instead of negating,
   with or without a cursor.
 - Fix `isNull` skipping rows whose column was never written once that column is

--- a/convex/orm/foreign-key-actions.test.ts
+++ b/convex/orm/foreign-key-actions.test.ts
@@ -44,6 +44,20 @@ const membershipsCascade = convexTable(
   ]
 );
 
+const membershipsSoftCascade = convexTable(
+  'fk_action_memberships_soft_cascade',
+  {
+    userId: id('fk_action_users').notNull(),
+    deletionTime: integer(),
+  },
+  (t) => [
+    index('by_user').on(t.userId),
+    foreignKey({ columns: [t.userId], foreignColumns: [users.id] }).onDelete(
+      'cascade'
+    ),
+  ]
+);
+
 const membershipsRestrict = convexTable(
   'fk_action_memberships_restrict',
   {
@@ -202,6 +216,7 @@ const rlsUpdateChildren = convexTable(
 const baseSchemaTables = {
   fk_action_users: users,
   fk_action_memberships_cascade: membershipsCascade,
+  fk_action_memberships_soft_cascade: membershipsSoftCascade,
   fk_action_memberships_restrict: membershipsRestrict,
   fk_action_memberships_null: membershipsSetNull,
   fk_action_memberships_null_large: membershipsSetNullLarge,
@@ -919,6 +934,71 @@ describe('foreign key actions', () => {
         expect(secondContinuation.workType).toBe('cascade-delete');
         expect(secondContinuation.foreignAction).toBe('cascade');
         expect(secondContinuation.cursor).toBeNull();
+      },
+      { scheduler: scheduler as any, scheduledMutationBatch }
+    );
+  });
+
+  it('terminates async soft cascade instead of re-queueing forever', async () => {
+    const queue: any[] = [];
+    const scheduler = {
+      runAfter: vi.fn(async (_delay: number, _ref: any, args: any) => {
+        queue.push(args);
+        return 'scheduled';
+      }),
+      runAt: vi.fn(async () => 'scheduled'),
+      cancel: vi.fn(async () => undefined),
+    };
+    const scheduledMutationBatch = {} as SchedulableFunctionReference;
+    const worker = scheduledMutationBatchFactory(
+      asyncCappedRelations,
+      asyncCappedEdges,
+      scheduledMutationBatch
+    );
+
+    await withAsyncCappedCtx(
+      async ({ orm, db }) => {
+        const [user] = await orm
+          .insert(users)
+          .values({ slug: 'ada' })
+          .returning();
+
+        await orm
+          .insert(membershipsSoftCascade)
+          .values([
+            { userId: asAnyId(user.id) },
+            { userId: asAnyId(user.id) },
+            { userId: asAnyId(user.id) },
+          ]);
+
+        await orm
+          .delete(users)
+          .soft()
+          .where(eq(users.id, asAnyId(user.id)))
+          .execute();
+
+        // Soft delete leaves the foreign key columns untouched, so a worker
+        // that re-queries from a null cursor keeps selecting the same rows.
+        // Drive the queue with a hard cap: it must drain, not spin.
+        let rounds = 0;
+        while (queue.length > 0) {
+          rounds += 1;
+          if (rounds > 20) {
+            throw new Error(
+              'soft cascade never drained: worker re-queued itself 20 times'
+            );
+          }
+          const next = queue.shift();
+          await worker({ db, scheduler: scheduler as any }, next);
+        }
+
+        const children = await db
+          .query('fk_action_memberships_soft_cascade')
+          .collect();
+        expect(children).toHaveLength(3);
+        for (const child of children) {
+          expect((child as any).deletionTime).toBeTypeOf('number');
+        }
       },
       { scheduler: scheduler as any, scheduledMutationBatch }
     );

--- a/convex/orm/pagination.test.ts
+++ b/convex/orm/pagination.test.ts
@@ -766,7 +766,7 @@ test('cursor pagination fills pages to the limit with a residual predicate', asy
   });
 });
 
-test('cursor pagination preserves residual filters without schema metadata', async () => {
+test('cursor pagination rejects residual filters without schema metadata', async () => {
   const standaloneTables = { ...tables };
   const standaloneRelations = defineRelations(standaloneTables);
   const standaloneSchema = defineSchema(standaloneTables);
@@ -785,19 +785,13 @@ test('cursor pagination preserves residual filters without schema metadata', asy
       });
     }
 
-    const result = await ctx.orm.query.users.findMany({
-      cursor: null,
-      limit: 20,
-      where: (users, { and, eq, notLike }) =>
-        and(eq(users.status, 'active'), notLike(users.name, '%Bob%')),
-    });
-
-    expect(result.page.map((row) => row.name).sort()).toEqual([
-      'Alice 0',
-      'Alice 1',
-      'Alice 2',
-      'Alice 3',
-      'Alice 4',
-    ]);
+    await expect(
+      ctx.orm.query.users.findMany({
+        cursor: null,
+        limit: 20,
+        where: (users, { and, eq, notLike }) =>
+          and(eq(users.status, 'active'), notLike(users.name, '%Bob%')),
+      })
+    ).rejects.toThrow(/Advanced pagination requires defineSchema/);
   });
 });

--- a/convex/orm/pagination.test.ts
+++ b/convex/orm/pagination.test.ts
@@ -765,3 +765,39 @@ test('cursor pagination fills pages to the limit with a residual predicate', asy
     ]);
   });
 });
+
+test('cursor pagination preserves residual filters without schema metadata', async () => {
+  const standaloneTables = { ...tables };
+  const standaloneRelations = defineRelations(standaloneTables);
+  const standaloneSchema = defineSchema(standaloneTables);
+
+  await withOrmCtx(standaloneSchema, standaloneRelations, async (ctx) => {
+    for (let i = 0; i < 5; i++) {
+      await ctx.db.insert('users', {
+        name: `Bob ${i}`,
+        email: `bob${i}@standalone.example.com`,
+        status: 'active',
+      });
+      await ctx.db.insert('users', {
+        name: `Alice ${i}`,
+        email: `alice${i}@standalone.example.com`,
+        status: 'active',
+      });
+    }
+
+    const result = await ctx.orm.query.users.findMany({
+      cursor: null,
+      limit: 20,
+      where: (users, { and, eq, notLike }) =>
+        and(eq(users.status, 'active'), notLike(users.name, '%Bob%')),
+    });
+
+    expect(result.page.map((row) => row.name).sort()).toEqual([
+      'Alice 0',
+      'Alice 1',
+      'Alice 2',
+      'Alice 3',
+      'Alice 4',
+    ]);
+  });
+});

--- a/convex/orm/pagination.test.ts
+++ b/convex/orm/pagination.test.ts
@@ -642,3 +642,126 @@ test('pagination with combined WHERE and ORDER BY (non-indexed)', async () => {
     ).rejects.toThrow(/Pagination: Field 'numLikes' has no index/);
   });
 });
+
+test('cursor pagination applies post-fetch operators on an indexed plan', async () => {
+  const t = convexTest(schema);
+
+  // 5 "Bob N" and 5 "Alice N", all active. `status` is indexed (by_status), so
+  // the plan picks an index and the string operator stays a residual predicate
+  // that only JavaScript can evaluate.
+  await t.run(async (baseCtx) => {
+    for (let i = 0; i < 5; i++) {
+      await baseCtx.db.insert('users', {
+        name: `Bob ${i}`,
+        email: `bob${i}@paginate.example.com`,
+        status: 'active',
+      });
+      await baseCtx.db.insert('users', {
+        name: `Alice ${i}`,
+        email: `alice${i}@paginate.example.com`,
+        status: 'active',
+      });
+    }
+  });
+
+  await t.run(async (baseCtx) => {
+    const ctx = await runCtx(baseCtx);
+    const db = ctx.orm;
+
+    const bare = await db.query.users.findMany({
+      cursor: null,
+      limit: 20,
+      where: (users, { and, eq, notLike }) =>
+        and(eq(users.status, 'active'), notLike(users.name, '%Bob%')),
+    });
+
+    const negated = await db.query.users.findMany({
+      cursor: null,
+      limit: 20,
+      where: (users, { and, eq, like, not }) =>
+        and(eq(users.status, 'active'), not(like(users.name, '%Bob%'))),
+    });
+
+    // The identical predicate without a cursor is the source of truth.
+    const nonPaginated = await db.query.users.findMany({
+      limit: 20,
+      where: (users, { and, eq, like, not }) =>
+        and(eq(users.status, 'active'), not(like(users.name, '%Bob%'))),
+    });
+
+    const names = (rows: { name: string }[]) =>
+      rows.map((row) => row.name).sort();
+
+    expect(names(nonPaginated)).toEqual([
+      'Alice 0',
+      'Alice 1',
+      'Alice 2',
+      'Alice 3',
+      'Alice 4',
+    ]);
+    expect(names(bare.page)).toEqual(names(nonPaginated));
+    expect(names(negated.page)).toEqual(names(nonPaginated));
+  });
+});
+
+test('cursor pagination fills pages to the limit with a residual predicate', async () => {
+  const t = convexTest(schema);
+
+  await t.run(async (baseCtx) => {
+    for (let i = 0; i < 5; i++) {
+      await baseCtx.db.insert('users', {
+        name: `Bob ${i}`,
+        email: `bob${i}@fill.example.com`,
+        status: 'pending',
+      });
+      await baseCtx.db.insert('users', {
+        name: `Alice ${i}`,
+        email: `alice${i}@fill.example.com`,
+        status: 'pending',
+      });
+    }
+  });
+
+  await t.run(async (baseCtx) => {
+    const ctx = await runCtx(baseCtx);
+    const db = ctx.orm;
+
+    // 5 rows match. A page of 4 must contain 4 matches, not 4 scanned rows
+    // filtered down afterwards.
+    const first = await db.query.users.findMany({
+      cursor: null,
+      limit: 4,
+      where: (users, { and, eq, notLike }) =>
+        and(eq(users.status, 'pending'), notLike(users.name, '%Bob%')),
+    });
+
+    expect(first.page).toHaveLength(4);
+    for (const row of first.page) {
+      expect(row.name).not.toContain('Bob');
+    }
+
+    // Walking the rest must yield the 5th match and no duplicates.
+    const walked = first.page.map((row) => row.name);
+    let cursor = first.continueCursor;
+    let isDone = first.isDone;
+    for (let page = 0; page < 5 && !isDone; page++) {
+      const next = await db.query.users.findMany({
+        cursor,
+        limit: 4,
+        where: (users, { and, eq, notLike }) =>
+          and(eq(users.status, 'pending'), notLike(users.name, '%Bob%')),
+      });
+      walked.push(...next.page.map((row) => row.name));
+      cursor = next.continueCursor;
+      isDone = next.isDone;
+    }
+
+    expect(walked.sort()).toEqual([
+      'Alice 0',
+      'Alice 1',
+      'Alice 2',
+      'Alice 3',
+      'Alice 4',
+    ]);
+  });
+});

--- a/convex/orm/pagination.test.ts
+++ b/convex/orm/pagination.test.ts
@@ -766,6 +766,48 @@ test('cursor pagination fills pages to the limit with a residual predicate', asy
   });
 });
 
+test('cursor pagination fills residual pages after relation filters', async () => {
+  const t = convexTest(schema);
+
+  await t.run(async (baseCtx) => {
+    const matchingUserId = await baseCtx.db.insert('users', {
+      name: 'Candidate with post',
+      email: 'candidate-with-post@example.com',
+      status: 'active',
+    });
+    await baseCtx.db.insert('posts', {
+      text: 'Matching post',
+      numLikes: 1,
+      type: 'wanted',
+      authorId: matchingUserId,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await baseCtx.db.insert('users', {
+        name: `Candidate without post ${i}`,
+        email: `candidate-without-post-${i}@example.com`,
+        status: 'active',
+      });
+    }
+  });
+
+  await t.run(async (baseCtx) => {
+    const ctx = await runCtx(baseCtx);
+    const page = await ctx.orm.query.users.findMany({
+      cursor: null,
+      limit: 1,
+      where: {
+        name: { like: '%Candidate%' },
+        posts: { type: 'wanted' },
+        status: 'active',
+      },
+    });
+
+    expect(page.page).toHaveLength(1);
+    expect(page.page[0].name).toBe('Candidate with post');
+  });
+});
+
 test('cursor pagination rejects residual filters without schema metadata', async () => {
   const standaloneTables = { ...tables };
   const standaloneRelations = defineRelations(standaloneTables);

--- a/convex/orm/pagination.test.ts
+++ b/convex/orm/pagination.test.ts
@@ -837,3 +837,62 @@ test('cursor pagination rejects residual filters without schema metadata', async
     ).rejects.toThrow(/Advanced pagination requires defineSchema/);
   });
 });
+
+test('residual limits apply relation filters before metadata-free slicing', async () => {
+  const standaloneTables = { ...tables };
+  const standaloneRelations = defineRelations(standaloneTables, (r) => ({
+    users: {
+      posts: r.many.posts({
+        from: r.users.id,
+        to: r.posts.authorId,
+      }),
+    },
+  }));
+  const standaloneSchema = defineSchema(standaloneTables, {
+    defaults: { defaultLimit: 1000 },
+  });
+
+  await withOrmCtx(standaloneSchema, standaloneRelations, async (ctx) => {
+    await ctx.db.insert('users', {
+      name: 'Candidate without post',
+      email: 'fallback-without-post@example.com',
+      status: 'active',
+    });
+    const matchingUserId = await ctx.db.insert('users', {
+      name: 'Candidate with post',
+      email: 'fallback-with-post@example.com',
+      status: 'active',
+    });
+    await ctx.db.insert('posts', {
+      text: 'Matching fallback post',
+      numLikes: 1,
+      type: 'wanted',
+      authorId: matchingUserId,
+    });
+
+    const rows = await ctx.orm.query.users.findMany({
+      allowFullScan: true,
+      limit: 1,
+      where: {
+        name: { like: '%Candidate%' },
+        posts: { type: 'wanted' },
+        status: 'active',
+      },
+    });
+
+    const offsetRows = await ctx.orm.query.users.findMany({
+      allowFullScan: true,
+      offset: 1,
+      where: {
+        name: { like: '%Candidate%' },
+        posts: { type: 'wanted' },
+        status: 'active',
+      },
+    });
+
+    expect([
+      rows.map((row) => row.name),
+      offsetRows.map((row) => row.name),
+    ]).toEqual([['Candidate with post'], []]);
+  });
+});

--- a/convex/orm/pipeline.test.ts
+++ b/convex/orm/pipeline.test.ts
@@ -340,3 +340,63 @@ test('findMany pipeline mode is removed', async () => {
     ).toThrow(/findmany\(\{ pipeline \}\) is removed/i);
   });
 });
+
+test('select flatMap pagination walks every child exactly once', async () => {
+  const t = convexTest(schema);
+
+  await t.run(async (baseCtx) => {
+    // Insert in reverse name order so `_id` order differs from `name` order.
+    // The cursor's inner-key bound then belongs to a parent that is not first.
+    for (const name of ['Cara', 'Bob', 'Alice']) {
+      const user = await baseCtx.db.insert('users', {
+        name,
+        email: `${name.toLowerCase()}-flatmap@example.com`,
+      });
+      for (const suffix of [1, 2]) {
+        await baseCtx.db.insert('posts', {
+          text: `${name}-${suffix}`,
+          numLikes: suffix,
+          type: 'note',
+          authorId: user,
+        });
+      }
+    }
+  });
+
+  await t.run(async (baseCtx) => {
+    const ctx = await runCtx(baseCtx);
+    const buildQuery = () =>
+      ctx.orm.query.users
+        .select()
+        .orderBy({ name: 'asc' })
+        .flatMap('posts', { includeParent: false });
+
+    const singlePage = await buildQuery().paginate({
+      cursor: null,
+      limit: 100,
+    });
+    expect(singlePage.page.map((row) => row.text)).toEqual([
+      'Alice-1',
+      'Alice-2',
+      'Bob-1',
+      'Bob-2',
+      'Cara-1',
+      'Cara-2',
+    ]);
+
+    // Walking the same stream three rows at a time must yield the same rows,
+    // in the same order, with no duplicates and nothing dropped.
+    const walked: string[] = [];
+    let cursor: string | null = null;
+    for (let page = 0; page < 10; page += 1) {
+      const result = await buildQuery().paginate({ cursor, limit: 3 });
+      walked.push(...result.page.map((row) => row.text));
+      cursor = result.continueCursor;
+      if (result.isDone) {
+        break;
+      }
+    }
+
+    expect(walked).toEqual(singlePage.page.map((row) => row.text));
+  });
+});

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -178,8 +178,9 @@ describe('RLS', () => {
     const page = await ctx.orm.query.rls_secrets.findMany({
       cursor: null,
       limit: 1,
-      where: (secrets, { and, eq, like }) =>
-        and(eq(secrets.value, 'allowed'), like(secrets.value, '%allowed%')),
+      where: {
+        AND: [{ value: 'allowed' }, { value: { like: '%allowed%' } }],
+      },
     });
 
     expect(page.page).toHaveLength(1);
@@ -205,8 +206,9 @@ describe('RLS', () => {
 
     const rows = await ctx.orm.query.rls_secrets.findMany({
       limit: 1,
-      where: (secrets, { and, eq, like }) =>
-        and(eq(secrets.value, 'allowed'), like(secrets.value, '%allowed%')),
+      where: {
+        AND: [{ value: 'allowed' }, { value: { like: '%allowed%' } }],
+      },
     });
 
     expect(rows).toHaveLength(1);

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -31,6 +31,7 @@ const secrets = convexTable(
   },
   (t) => [
     index('by_owner').on(t.ownerId),
+    index('by_value').on(t.value),
     rlsPolicy('secrets_read', {
       for: 'select',
       using: async (ctx, table) => {
@@ -152,6 +153,61 @@ describe('RLS', () => {
 
     const db = ctx.orm;
     const rows = await db.query.rls_secrets.findMany();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].ownerId).toEqual(viewerId);
+  });
+
+  it('fills residual cursor pages with RLS-visible matches', async ({
+    ctx,
+  }) => {
+    const viewerId = await ctx.db.insert('rls_users', { name: 'Viewer' });
+    const otherId = await ctx.db.insert('rls_users', { name: 'Other' });
+
+    await ctx.db.insert('rls_secrets', {
+      value: 'allowed',
+      ownerId: viewerId,
+    });
+    await ctx.db.insert('rls_secrets', {
+      value: 'allowed',
+      ownerId: otherId,
+    });
+
+    ctx.viewerId = viewerId;
+
+    const page = await ctx.orm.query.rls_secrets.findMany({
+      cursor: null,
+      limit: 1,
+      where: (secrets, { and, eq, like }) =>
+        and(eq(secrets.value, 'allowed'), like(secrets.value, '%allowed%')),
+    });
+
+    expect(page.page).toHaveLength(1);
+    expect(page.page[0].ownerId).toEqual(viewerId);
+  });
+
+  it('fills residual limited reads with RLS-visible matches', async ({
+    ctx,
+  }) => {
+    const viewerId = await ctx.db.insert('rls_users', { name: 'Viewer' });
+    const otherId = await ctx.db.insert('rls_users', { name: 'Other' });
+
+    await ctx.db.insert('rls_secrets', {
+      value: 'allowed',
+      ownerId: otherId,
+    });
+    await ctx.db.insert('rls_secrets', {
+      value: 'allowed',
+      ownerId: viewerId,
+    });
+
+    ctx.viewerId = viewerId;
+
+    const rows = await ctx.orm.query.rls_secrets.findMany({
+      limit: 1,
+      where: (secrets, { and, eq, like }) =>
+        and(eq(secrets.value, 'allowed'), like(secrets.value, '%allowed%')),
+    });
 
     expect(rows).toHaveLength(1);
     expect(rows[0].ownerId).toEqual(viewerId);

--- a/convex/orm/string-operators.test.ts
+++ b/convex/orm/string-operators.test.ts
@@ -777,3 +777,139 @@ describe('M5: contains operator', () => {
     expect(posts.map((p: any) => p.title)).toContain('TypeScript Handbook');
   });
 });
+
+// ============================================================================
+// Limit interaction
+// ============================================================================
+
+describe('M5: post-fetch operators combined with limit', () => {
+  const seed = async (ctx: TestCtx) => {
+    const user = await ctx.db.insert('users', {
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    // 15 non-matching titles sort before the 5 matching ones, so a `limit`
+    // pushed down to Convex consumes the whole budget on non-matches.
+    for (let i = 0; i < 15; i += 1) {
+      await ctx.db.insert('posts', {
+        text: 'test',
+        numLikes: 0,
+        type: 'text',
+        title: `AAA Python ${String(i).padStart(2, '0')}`,
+        content: 'Content',
+        published: true,
+        authorId: user,
+        publishedAt: 1000 + i,
+      });
+    }
+    for (let i = 15; i < 20; i += 1) {
+      await ctx.db.insert('posts', {
+        text: 'test',
+        numLikes: 0,
+        type: 'text',
+        title: `ZZZ Java ${String(i).padStart(2, '0')}`,
+        content: 'Content',
+        published: true,
+        authorId: user,
+        publishedAt: 1000 + i,
+      });
+    }
+  };
+
+  test('like with a limit returns matches, not the first limit rows', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(5);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('like with a limit smaller than the match count truncates matches', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      limit: 3,
+    });
+
+    expect(posts).toHaveLength(3);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('contains and endsWith honor limit', async ({ ctx }) => {
+    await seed(ctx);
+
+    const contains = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { contains: 'Java' } },
+      limit: 5,
+    });
+    const endsWith = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { endsWith: '19' } },
+      limit: 5,
+    });
+
+    expect(contains).toHaveLength(5);
+    expect(endsWith).toHaveLength(1);
+    expect(endsWith[0].title).toBe('ZZZ Java 19');
+  });
+
+  test('explicit withIndex + ilike + limit returns matches', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { ilike: '%java%' } },
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(5);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+
+  test('NOT around a post-fetch operator negates instead of matching nothing', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.withIndex('by_title').findMany({
+      where: { title: { NOT: { like: '%Java%' } } },
+    });
+
+    expect(posts).toHaveLength(15);
+    for (const post of posts) {
+      expect(post.title).not.toContain('Java');
+    }
+  });
+
+  test('offset with a post-fetch operator skips matches, not scanned rows', async ({
+    ctx,
+  }) => {
+    await seed(ctx);
+
+    const posts = await ctx.orm.query.posts.findMany({
+      where: { title: { like: '%Java%' } },
+      offset: 2,
+      limit: 5,
+    });
+
+    expect(posts).toHaveLength(3);
+    for (const post of posts) {
+      expect(post.title).toContain('Java');
+    }
+  });
+});

--- a/convex/orm/where-filtering.test.ts
+++ b/convex/orm/where-filtering.test.ts
@@ -868,6 +868,49 @@ describe('M4 Where Filtering - Null Operators', () => {
     expect(result[0].name).toBe('Alice');
   });
 
+  test('isNull matches rows whose column is absent, indexed or not', async ({
+    ctx,
+  }) => {
+    const db = ctx.orm;
+
+    // Column omitted entirely: the normal state for a nullable column that was
+    // never written. Convex stores this as a missing field, not as null.
+    await ctx.db.insert('users', {
+      name: 'Absent',
+      email: 'absent@example.com',
+      age: 25,
+      status: 'active',
+    });
+    await ctx.db.insert('users', {
+      name: 'ExplicitNull',
+      email: 'null@example.com',
+      age: 26,
+      status: 'active',
+      deletedAt: null,
+    });
+    await ctx.db.insert('users', {
+      name: 'Deleted',
+      email: 'deleted@example.com',
+      age: 27,
+      status: 'deleted',
+      deletedAt: 123_456,
+    });
+
+    const withoutIndex = await db.query.users.findMany({
+      where: { deletedAt: { isNull: true } },
+    });
+    // `by_deleted_at` makes the compiler take the index path; both paths must agree.
+    const withIndex = await db.query.users.withIndex('by_deleted_at').findMany({
+      where: { deletedAt: { isNull: true } },
+    });
+
+    const names = (rows: { name: string }[]) =>
+      rows.map((row) => row.name).sort();
+
+    expect(names(withoutIndex)).toEqual(['Absent', 'ExplicitNull']);
+    expect(names(withIndex)).toEqual(['Absent', 'ExplicitNull']);
+  });
+
   test('should filter with isNotNull operator', async ({ ctx }) => {
     const db = ctx.orm;
 

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -95,8 +95,8 @@ Closure matrix:
 | docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | complete |
 | changeset | yes | `.changeset/olive-eyes-punch.md` covers the six user-visible fixes and no longer overclaims standalone full-page filling | complete |
 | agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
-| cleanup/review | yes | deslop stayed at zero net regression; agent-native audit unchanged; final autoreview rerun pending after accepted findings | pending |
-| repository check | yes | prior full check passed but is stale after final repair; rerun required | pending |
+| cleanup/review | yes | deslop stayed at zero net regression; agent-native audit unchanged; all in-scope findings fixed, final ordering finding rejected with `origin/main` source evidence | complete |
+| repository check | yes | final `bun lint:fix` and restarted `bun check` exited 0 across every repo lane | complete |
 | GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
 
 Feedback ledger:
@@ -130,6 +130,12 @@ Review fixes:
   runs before fallback slicing; one red test simultaneously returned `[]` for
   `limit: 1` and the matching row for `offset: 1`, then green returned the
   matching limited row and no offset row.
+- Rejected final P2 after the mandatory two-cycle pause: secondary cursor
+  ordering is not a regression in the residual stream branch. `origin/main`
+  emits the same promise that secondary fields are applied per page in its
+  existing cursor branches, but those branches also finalize the native page
+  without sorting. Fixing only the new branch would make cursor behavior
+  inconsistent; the canonical all-branch ordering contract is separate scope.
 
 Work Checklist:
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
@@ -155,6 +161,8 @@ Error attempts:
 | First metadata-free fallback repro hit the relation sizing guard | 1 | Enable the fixture's explicit full-scan authority so it reaches the slicing owner | The corrected repro returned the two opposite wrong results before the ordering fix |
 | Patch context drifted after the first owner edit | 1 | Re-read exact bounded ranges and patch smaller hunks | Applied cleanly; `git diff --check` passed |
 | `gh pr view` briefly reported a stale head SHA after push | 1 | Read the branch ref and PR head directly through GitHub API | Both direct API endpoints agreed on the pushed SHA |
+| First final `bun check` found implicit-any parameters in new RLS tests | 1 | Replace callback filters with equivalent typed object filters, then rerun the owning typecheck and RLS suite | Convex typecheck and all 14 RLS tests passed; final full check passed |
+| Corrected full check stalled in a GitHub fetch during Vite fixture creation | 1 | Prove the exact child/network state, interrupt only the stalled check tree, and rerun the exact gate | Restarted `bun check` crossed Vite normally and exited 0 |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
@@ -164,8 +172,8 @@ Completion Gates:
 | Package/docs/scenario closure | pending | Run every applicable local contract | pending |
 | Deslop | pending | Run bounded cleanup or N/A | pending |
 | Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
-| Repository check | yes | Run `bun check` | pending |
+| Final lint | yes | Run `bun lint:fix` | complete: 874 files, no fixes |
+| Repository check | yes | Run `bun check` | complete: exit 0 on restarted final run |
 | GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-14-pr-314-closure-and-feedback.md` | pending |
@@ -223,6 +231,17 @@ Verification evidence:
   after moving membership ahead of fallback slicing it became
   `[['Candidate with post'], []]`. The 6-file lane passed 131 tests with 1 skip,
   compiler tests passed 18, package build passed, and deslop stayed unchanged.
+- The post-cycle autoreview reported secondary per-page ordering in the new
+  residual branch. Source comparison against `origin/main` proved the same
+  warning/omission exists in all established cursor branches. Rejected as a
+  pre-existing cross-branch ordering contract, not a PR 314 regression.
+- Final `bun lint:fix` checked 874 files with no fixes. The first full check
+  exposed implicit-any test callbacks; typed object filters fixed them and the
+  owning Convex typecheck/RLS suite passed. A later Vite fixture Git fetch
+  stalled with no progress, so only that process tree was interrupted. The
+  exact restarted `bun check` exited 0 across lint, typechecks, all tests, CLI
+  123/123, Concave smoke, every fixture, bare verify, and all runtime/auth
+  scenarios.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -252,16 +271,25 @@ Timeline:
 - 2026-08-14 Second and final review-fix cycle found the metadata-free fallback
   ordering remainder. Reproduced both limited and offset failure directions in
   one test, moved membership before slicing, and reran all owner proof green.
+- 2026-08-14 Mandatory post-cycle pause reclassified the only remaining review
+  finding as a pre-existing all-cursor ordering contract; no third speculative
+  patch cycle was started.
+- 2026-08-14 Final lint passed. Full check caught and closed the RLS test typing
+  gap; its first corrected run later stalled in an external GitHub template
+  fetch, and the exact clean restart passed every lane with exit 0.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Focused repair proof complete after the second review-fix cycle |
-| Where am I going? | Commit, re-review/check, push, feedback replies/resolution, GitHub read-back, final audit |
+| Where am I? | All local closure lanes passed; GitHub delivery pending |
+| Where am I going? | Push, feedback replies/resolution, GitHub read-back, final audit |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
 | What have I learned? | Residual predicates, RLS, and relation membership form one final-visible-row predicate; any pushed-down limit must count that composite result |
 | What have I done? | Reclassified the metadata case and fixed final-visible sizing in both stream and fallback paths; final review/check/delivery remain |
 
 Open risks:
-- Final autoreview, full check, repush, replies/resolution, final CI/PR head
-  read-back, and the goal-plan checker remain after the owner repair.
+- Secondary cursor `orderBy` fields are not applied per page in any existing
+  cursor branch despite the current warning; this pre-existing cross-branch
+  contract needs separate ownership and does not block PR 314.
+- Push, replies/resolution, final CI/PR head read-back, and the goal-plan checker
+  remain.

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -88,28 +88,32 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | focused ORM regression tests plus full `bun check` runtime suites passed | complete |
-| package/API/build | yes | `bun --cwd packages/kitcn build`, root typecheck, package artifacts, and full check passed; no public API shape changed | complete |
+| source behavior | yes | final fail-closed repair, 21 pagination tests, and focused combined 115-test ORM lane passed | complete |
+| package/API/build | yes | final `bun --cwd packages/kitcn build` passed; no public API shape changed | complete |
 | generated output | yes | `bun run fixtures:check` proved all committed fixtures match fresh scaffold output | complete |
 | fixtures/scenarios | yes | `bun run fixtures:check` passed every fixture; scenario runtime N/A because ORM runtime behavior is covered by integration tests and no scaffold behavior changed | complete |
 | docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | complete |
 | changeset | yes | `.changeset/olive-eyes-punch.md` covers the six user-visible fixes and no longer overclaims standalone full-page filling | complete |
 | agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
-| cleanup/review | yes | deslop zero net regression; agent-native audit PASS; branch autoreview clean with zero findings at 0.87 confidence | complete |
-| repository check | yes | `bun lint:fix` no changes; `bun check` exited 0 across CI, verify, and runtime lanes | complete |
+| cleanup/review | yes | final deslop stayed at zero net regression; agent-native audit unchanged; autoreview rerun pending | pending |
+| repository check | yes | prior full check passed but is stale after final repair; rerun required | pending |
 | GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
 
 Feedback ledger:
 | ID / URL | Type | Path | Reviewer claim | Verdict | Owner / proof | Reply | Resolution |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: commit `c570c3c` routes schema-backed residual predicates through stream pagination | `bunx vitest run convex/orm/pagination.test.ts` -> 21 passed | pending | pending |
-| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Standalone `defineRelations` has no schema metadata, so the cursor branch can still drop residual filters | fixed: native fallback applies residual predicates after pagination instead of returning violating rows | focused standalone test red with 5 forbidden `Bob` rows, green after fix; full pagination file 21 passed | pending | pending |
+| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Metadata-free relations can drop residual cursor filters | fixed-differently after source/author evidence: unsupported standalone schema ownership now fails closed through the canonical `defineSchema()` guard, also preventing silent `maxScan` loss | focused test red because the partial native fallback resolved instead of rejecting, green after guard; full pagination file 21 passed | pending | pending |
 
 Feedback triage notes:
 - `changeset-bot` top-level comment is status boilerplate with no actionable
   question; no reply needed.
 - Both Codex review bodies are boilerplate wrappers; their actionable findings
   are represented by the two inline threads above.
+- A substantive PR-author reply arrived after the first fix/check cycle. Source
+  confirmed standalone relation exports are rejected by schema ownership and
+  advanced pagination already owns a canonical `defineSchema()` guard. The
+  permissive native-page filter was replaced with that fail-closed invariant.
 
 Work Checklist:
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
@@ -162,7 +166,10 @@ Phase / pass table:
 | Closeout | pending | | final |
 
 Verification evidence:
-- `bunx vitest run convex/orm/pagination.test.ts -t "cursor pagination preserves residual filters without schema metadata"` -> red before implementation: returned all five forbidden `Bob` rows; green after implementation: 1 passed.
+- First standalone repro returned all five forbidden `Bob` rows. After the
+  author/source correction, the final TDD case expected the canonical advanced
+  pagination error and failed red because the partial fallback resolved; the
+  explicit `defineSchema()` guard made it green.
 - `bunx vitest run convex/orm/pagination.test.ts` -> 21 passed, including
   schema-backed full-page residual filtering and standalone metadata-free
   residual filtering.
@@ -183,6 +190,9 @@ Verification evidence:
 - Final `bun check` -> exit 0: lint, all package typechecks/tests/builds, CLI
   123/123, Concave smoke, fixture parity, bare Convex verify, and runtime
   scenario matrix including auth smoke all passed.
+- After the final fail-closed repair: focused combined Vitest lane -> 5 files,
+  115 passed, 1 skipped, no type errors; package build passed; deslop remained
+  166 to 166 with zero score change.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -201,15 +211,21 @@ Timeline:
   branch autoreview clean with zero accepted/actionable findings.
 - 2026-08-14 Final `bun lint:fix` and complete `bun check` passed; GitHub
   delivery is the only remaining executable lane.
+- 2026-08-14 A new PR-author reply changed the second finding's source verdict:
+  standalone exports are unsupported and silently dropping `maxScan` remained.
+  Replaced the permissive fallback with the canonical fail-closed schema guard;
+  all 21 pagination tests passed. Prior autoreview/check evidence is stale until
+  rerun.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | GitHub delivery |
-| Where am I going? | Push, feedback replies/resolution, GitHub read-back, final audit |
+| Where am I? | Repair rerun after new author evidence |
+| Where am I going? | Re-review/check, push, feedback replies/resolution, GitHub read-back, final audit |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
-| What have I learned? | The latest schema-backed fix was correct, but standalone relations lacked stream metadata and silently returned residual-filter violations |
-| What have I done? | Closed every local proof/review/check lane; only GitHub delivery and the mechanical goal audit remain |
+| What have I learned? | Schema-backed relations are supported; fresh-object standalone relations are intentionally rejected by CLI ownership, so advanced cursor filters must fail closed rather than run a partial native fallback |
+| What have I done? | Reclassified and replaced the second fix after new author/source evidence; focused pagination proof is green and final review/check reruns remain |
 
 Open risks:
-- Push, replies/resolution, CI/PR head read-back, and the goal-plan checker remain.
+- Package build, deslop/review, full check, repush, replies/resolution, CI/PR
+  head read-back, and the goal-plan checker remain after the final repair.

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -88,7 +88,7 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | fail-closed metadata repair plus final-visible-membership stream sizing; 6-file ORM lane passed 130 tests with 1 skip | complete |
+| source behavior | yes | fail-closed metadata repair plus final-visible-membership stream/fallback sizing; 6-file ORM lane passed 131 tests with 1 skip | complete |
 | package/API/build | yes | final `bun --cwd packages/kitcn build` passed; no public API shape changed | complete |
 | generated output | yes | `bun run fixtures:check` proved all committed fixtures match fresh scaffold output | complete |
 | fixtures/scenarios | yes | `bun run fixtures:check` passed every fixture; scenario runtime N/A because ORM runtime behavior is covered by integration tests and no scaffold behavior changed | complete |
@@ -125,6 +125,11 @@ Review fixes:
 - Accepted P2: non-cursor residual `take()` counted rows before RLS/relation
   filters. The same membership predicate now sizes limited reads by final
   visible matches and the post-stream path avoids duplicate membership work.
+- Accepted final P2: metadata-free fallback and offset-only reads sliced after
+  scalar residual filters but before RLS/relation membership. Membership now
+  runs before fallback slicing; one red test simultaneously returned `[]` for
+  `limit: 1` and the matching row for `offset: 1`, then green returned the
+  matching limited row and no offset row.
 
 Work Checklist:
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
@@ -147,6 +152,7 @@ Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
 | RLS cursor repro hit the `maxScan` guard before the residual stream | 1 | Give the fixture a real planner index and combine indexed `eq` with residual `like` | Red reproduced an empty page, then passed after membership moved into the stream |
+| First metadata-free fallback repro hit the relation sizing guard | 1 | Enable the fixture's explicit full-scan authority so it reaches the slicing owner | The corrected repro returned the two opposite wrong results before the ordering fix |
 | Patch context drifted after the first owner edit | 1 | Re-read exact bounded ranges and patch smaller hunks | Applied cleanly; `git diff --check` passed |
 | `gh pr view` briefly reported a stale head SHA after push | 1 | Read the branch ref and PR head directly through GitHub API | Both direct API endpoints agreed on the pushed SHA |
 
@@ -212,6 +218,11 @@ Verification evidence:
   regressions; the final 6-file lane passed 130 tests with 1 skip and no type
   errors, compiler tests passed 18, package build passed, and deslop remained
   166 to 166 with zero score change.
+- The next review found one remaining fallback branch in the same invariant.
+  Its combined red result was `[[], ['Candidate with post']]` for limit/offset;
+  after moving membership ahead of fallback slicing it became
+  `[['Candidate with post'], []]`. The 6-file lane passed 131 tests with 1 skip,
+  compiler tests passed 18, package build passed, and deslop stayed unchanged.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -238,15 +249,18 @@ Timeline:
 - 2026-08-14 Final branch autoreview found three related limit-composition
   defects around RLS/relation membership. Accepted them as one in-scope owner
   repair, proved each red/green, and reran the focused owner stack green.
+- 2026-08-14 Second and final review-fix cycle found the metadata-free fallback
+  ordering remainder. Reproduced both limited and offset failure directions in
+  one test, moved membership before slicing, and reran all owner proof green.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Focused repair proof complete after final review findings |
+| Where am I? | Focused repair proof complete after the second review-fix cycle |
 | Where am I going? | Commit, re-review/check, push, feedback replies/resolution, GitHub read-back, final audit |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
 | What have I learned? | Residual predicates, RLS, and relation membership form one final-visible-row predicate; any pushed-down limit must count that composite result |
-| What have I done? | Reclassified the metadata case, fixed final-visible stream sizing, and proved all three accepted composition findings; final review/check/delivery remain |
+| What have I done? | Reclassified the metadata case and fixed final-visible sizing in both stream and fallback paths; final review/check/delivery remain |
 
 Open risks:
 - Final autoreview, full check, repush, replies/resolution, final CI/PR head

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -83,7 +83,7 @@ Start Gates:
 | Agent-facing action surface identified | no | N/A: PR 314 changes ORM runtime/tests, not agent-facing behavior |
 | Source rule versus generated mirror boundary identified | no | N/A: no `.agents/rules/**` or generated skill mirror is in PR 314 |
 | Installed-skill lock versus local-rule owner identified | no | N/A: no installed-skill or lock change is in PR 314 |
-| `agent-native-reviewer` loaded or waiver recorded | yes | Skill read completely; final capability audit remains required by autoclosure |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Skill read completely; capability audit PASS/N/A because no agent-facing surface changed |
 
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
@@ -97,13 +97,13 @@ Closure matrix:
 | agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
 | cleanup/review | yes | deslop stayed at zero net regression; agent-native audit unchanged; all in-scope findings fixed, final ordering finding rejected with `origin/main` source evidence | complete |
 | repository check | yes | final `bun lint:fix` and restarted `bun check` exited 0 across every repo lane | complete |
-| GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
+| GitHub delivery | yes | code head `2d86ee52` pushed/read back through branch and PR APIs; two replies posted, both threads resolved, ledger empty, CI/Vercel green | complete |
 
 Feedback ledger:
 | ID / URL | Type | Path | Reviewer claim | Verdict | Owner / proof | Reply | Resolution |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: schema-backed residual predicates, RLS visibility, and relation membership run inside stream pagination before page sizing | 22 pagination + 14 RLS tests; combined 6-file ORM lane passed 130 with 1 skip | pending | pending |
-| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Metadata-free relations can drop residual cursor filters | fixed-differently after source/author evidence: unsupported standalone schema ownership fails closed through the canonical `defineSchema()` guard, also preventing silent `maxScan` loss | focused test red because the partial native fallback resolved instead of rejecting, green after guard; pagination file passed 22 tests | pending | pending |
+| `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: schema-backed residual predicates, RLS visibility, and relation membership run inside stream pagination before page sizing | 23 pagination + 14 RLS tests; combined 6-file ORM lane passed 131 with 1 skip | replied at `discussion_r3783416826` | resolved; final ledger empty |
+| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Metadata-free relations can drop residual cursor filters | fixed-differently after source/author evidence: unsupported standalone schema ownership fails closed through the canonical `defineSchema()` guard, also preventing silent `maxScan` loss | focused test red because the partial native fallback resolved instead of rejecting, green after guard; pagination file passed 23 tests | replied at `discussion_r3783417023` | resolved; final ledger empty |
 
 Feedback triage notes:
 - `changeset-bot` top-level comment is status boilerplate with no actionable
@@ -138,21 +138,21 @@ Review fixes:
   inconsistent; the canonical all-branch ordering contract is separate scope.
 
 Work Checklist:
-- [ ] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
-- [ ] Generated output was changed through its owner and regenerated.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [ ] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
-- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
-- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
-- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
-- [ ] Agent-native pack: installed skills are changed only through
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [x] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output was changed through its owner and regenerated.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Accepted cleanup and review findings are closed.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [x] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [x] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [x] Agent-native pack: installed skills are changed only through
       `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
-- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+- [x] Agent-native pack: routing, required receipts, placeholder failure,
       completion representability, and forbidden behavior have eval/smoke rows.
-- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
@@ -167,30 +167,30 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
-| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
-| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
-| Deslop | pending | Run bounded cleanup or N/A | pending |
-| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
+| Targeted behavior proof | yes | Run smallest missing owning proof | complete: 6 files, 131 passed, 1 skipped; compiler 18 passed |
+| Source/generated audit | yes | Prove correct source and regenerated mirrors | complete: package source owns behavior; fixture parity passed every variant |
+| Package/docs/scenario closure | yes | Run every applicable local contract | complete: package build, changeset, fixtures, bare verify, runtime/auth matrix passed; docs/skill N/A |
+| Deslop | yes | Run bounded cleanup or N/A | complete: findings 166 to 166, score unchanged |
+| Agent-native reviewer | no | Run for workflow changes or N/A | N/A: no agent-facing file or action changed; capability audit PASS |
 | Final lint | yes | Run `bun lint:fix` | complete: 874 files, no fixes |
 | Repository check | yes | Run `bun check` | complete: exit 0 on restarted final run |
-| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-14-pr-314-closure-and-feedback.md` | pending |
-| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
-| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
-| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
-| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
-| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+| GitHub delivery | yes | Commit/push/open or update PR and read back | complete: `2d86ee52` read back, ledger empty, CI/Vercel/release sync green |
+| Autoreview | yes | Resolve every accepted actionable finding | complete: two accepted fix cycles closed; final ordering claim rejected with `origin/main` evidence |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-14-pr-314-closure-and-feedback.md` | complete: final checker passed |
+| Agent source / generated sync | no | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | N/A: no agent source or generated mirror changed |
+| Installed lock audit | no | Verify expected lock entries and removed skills through CLI-managed state | N/A: no installed skill or lock changed |
+| Agent action discoverability | no | Source-audit the skill/rule path an agent will read | N/A: no agent action changed |
+| Helper and template smoke | no | Syntax-check helpers and prove incomplete failure/completed representation when applicable | N/A: no helper or template changed |
+| Agent-native review | no | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | N/A with PASS capability audit: ORM runtime/tests only |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Inventory | complete | PR, source owners, feedback, and exclusions reconstructed | complete |
+| Repair | complete | all accepted owner findings fixed and TDD-proven | complete |
+| Review/checks | complete | deslop, agent-native audit, autoreview classification, lint, and `bun check` complete | complete |
+| Delivery | complete | code pushed, API read-back matched, replies/resolution complete, remote checks green | complete |
+| Closeout | complete | final ledger empty and goal-plan checker passed | complete |
 
 Verification evidence:
 - First standalone repro returned all five forbidden `Bob` rows. After the
@@ -242,6 +242,11 @@ Verification evidence:
   exact restarted `bun check` exited 0 across lint, typechecks, all tests, CLI
   123/123, Concave smoke, every fixture, bare verify, and all runtime/auth
   scenarios.
+- GitHub branch-ref and PR-head APIs both read back
+  `2d86ee52d21b0951db68c6654841796a6b2debeb`. Replies
+  `discussion_r3783416826` and `discussion_r3783417023` were posted; both
+  threads resolved and the final feedback fetch returned `review_threads: []`.
+  CI passed in 7m43s; Vercel, preview comments, and release sync passed.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -277,19 +282,22 @@ Timeline:
 - 2026-08-14 Final lint passed. Full check caught and closed the RLS test typing
   gap; its first corrected run later stalled in an external GitHub template
   fetch, and the exact clean restart passed every lane with exit 0.
+- 2026-08-14 Pushed code head `2d86ee52`, read it back from both direct GitHub
+  APIs, replied to and resolved both review threads, re-fetched an empty ledger,
+  and observed CI/Vercel/release sync pass on that exact head.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | All local closure lanes passed; GitHub delivery pending |
-| Where am I going? | Push, feedback replies/resolution, GitHub read-back, final audit |
+| Where am I? | PR 314 closure complete; only external human approval remains |
+| Where am I going? | Final plan-only receipt push and head read-back |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
 | What have I learned? | Residual predicates, RLS, and relation membership form one final-visible-row predicate; any pushed-down limit must count that composite result |
-| What have I done? | Reclassified the metadata case and fixed final-visible sizing in both stream and fallback paths; final review/check/delivery remain |
+| What have I done? | Fixed and proved all in-scope feedback, passed every local/remote gate, pushed the branch, and closed the review ledger |
 
 Open risks:
 - Secondary cursor `orderBy` fields are not applied per page in any existing
   cursor branch despite the current warning; this pre-existing cross-branch
   contract needs separate ownership and does not block PR 314.
-- Push, replies/resolution, final CI/PR head read-back, and the goal-plan checker
-  remain.
+- PR 314 remains open with `REVIEW_REQUIRED`; human approval is branch policy,
+  not unresolved implementation feedback. No PR 314 closure blocker remains.

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -1,0 +1,207 @@
+# PR 314 closure and feedback
+
+Objective:
+Close PR 314 and its review feedback; done when all applicable closure lanes
+pass, feedback is resolved, `bun check` passes, and the pushed PR head is read
+back from GitHub.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Every new actionable review thread/comment has a source-backed verdict,
+  focused proof, reply status, and resolution status; final unresolved count is
+  zero except any recorded `needs-human` item.
+- All applicable closure-matrix rows are complete; `bun lint:fix`, targeted ORM
+  tests, package build, `bun check`, deslop, required review passes, changeset
+  audit, commit/push, PR head read-back, and goal-plan checker pass.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- PR 314 source/diff and review-feedback read-back through `gh` and the installed
+  feedback scripts.
+- Focused ORM tests for query filtering/pagination, `isNull`, `flatMap`, and soft
+  cascade deletion; `bun --cwd packages/kitcn build`; fixture audit if the
+  existing regenerated fixture pins are touched.
+- `bun run lint:slop:delta`, local agent-native capability audit,
+  `.agents/skills/autoreview/scripts/autoreview`, `bun lint:fix`, and `bun check`.
+- Git commit/push plus `gh pr view 314` and feedback-script re-fetch.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: the four ORM correctness fixes and residual cursor-pagination
+  filter fix already described by PR 314, their regression tests, changeset, and
+  existing fixture dependency-pin regeneration.
+- allowed repairs: accepted PR feedback and direct defects in those changed
+  owners, tests, changeset, generated fixtures, plan, or PR description.
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new ORM features, unrelated cleanup, compatibility shims, public
+  API redesign, or expanding past the reviewed owner boundary.
+- authority: the user invoked `autoclosure` and `resolve-pr-feedback`; repository
+  policy authorizes whole-checkout commit/push, PR replies, and thread resolution.
+
+Output budget strategy:
+- Use exact PR/file/test owners, exclude generated/build trees from searches,
+  cap reads to targeted slices, and retain only command summaries when full
+  check/review output is noisy.
+
+Blocked condition:
+- Stop only for missing GitHub credentials/access, a public API/product decision
+  not bounded by PR 314, or the same reproducible environment blocker after
+  different repair attempts.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 314 metadata/body/files/commits/checks and this plan read 2026-08-14 |
+| Intended delta and exclusions recorded | yes | Boundaries above copy the exact PR target and non-goals |
+| Closure matrix classified | yes | Matrix below classifies every recurring lane before repair |
+| GitHub delivery expectation recorded | yes | Whole-checkout commit/push, reply, resolve, and PR read-back authorized |
+| Active goal checked or created | yes | Goal tool created the objective pointing to this plan |
+| Agent-native pack selected | yes | Materialized `agent-native` pack in this plan |
+| Agent-facing action surface identified | no | N/A: PR 314 changes ORM runtime/tests, not agent-facing behavior |
+| Source rule versus generated mirror boundary identified | no | N/A: no `.agents/rules/**` or generated skill mirror is in PR 314 |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no installed-skill or lock change is in PR 314 |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Skill read completely; final capability audit remains required by autoclosure |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | focused ORM regression tests and source audit | pending |
+| package/API/build | yes | `bun --cwd packages/kitcn build` and type/check gates; no intended public API change | pending |
+| generated output | yes | `bun run fixtures:check` proved all committed fixtures match fresh scaffold output | complete |
+| fixtures/scenarios | yes | `bun run fixtures:check` passed every fixture; scenario runtime N/A because ORM runtime behavior is covered by integration tests and no scaffold behavior changed | complete |
+| docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | pending |
+| changeset | yes | `.changeset/olive-eyes-punch.md` covers the six user-visible fixes and no longer overclaims standalone full-page filling | complete |
+| agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
+| cleanup/review | yes | `bun run lint:slop:delta` -> 166 to 166, score unchanged, zero net regression; local agent-native audit PASS; autoreview pending | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
+
+Feedback ledger:
+| ID / URL | Type | Path | Reviewer claim | Verdict | Owner / proof | Reply | Resolution |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: commit `c570c3c` routes schema-backed residual predicates through stream pagination | `bunx vitest run convex/orm/pagination.test.ts` -> 21 passed | pending | pending |
+| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Standalone `defineRelations` has no schema metadata, so the cursor branch can still drop residual filters | fixed: native fallback applies residual predicates after pagination instead of returning violating rows | focused standalone test red with 5 forbidden `Bob` rows, green after fix; full pagination file 21 passed | pending | pending |
+
+Feedback triage notes:
+- `changeset-bot` top-level comment is status boilerplate with no actionable
+  question; no reply needed.
+- Both Codex review bodies are boilerplate wrappers; their actionable findings
+  are represented by the two inline threads above.
+
+Work Checklist:
+- [ ] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [ ] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
+| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
+| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
+| Deslop | pending | Run bounded cleanup or N/A | pending |
+| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-14-pr-314-closure-and-feedback.md` | pending |
+| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
+| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
+| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
+| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
+| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- `bunx vitest run convex/orm/pagination.test.ts -t "cursor pagination preserves residual filters without schema metadata"` -> red before implementation: returned all five forbidden `Bob` rows; green after implementation: 1 passed.
+- `bunx vitest run convex/orm/pagination.test.ts` -> 21 passed, including
+  schema-backed full-page residual filtering and standalone metadata-free
+  residual filtering.
+- Focused combined Vitest lane for foreign-key actions, pagination, pipeline,
+  string operators, and where filtering -> 5 files passed, 115 passed, 1 skipped,
+  no type errors.
+- `bun test packages/kitcn/src/orm/where-clause-compiler.test.ts` -> 18 passed.
+- `bun --cwd packages/kitcn build` -> passed; ORM and all package artifacts built.
+- `bun run fixtures:check` -> passed for Expo, Next, Start, Vite, and auth
+  variants; every committed fixture matched fresh CLI output.
+- `bun run lint:slop:delta` -> findings 166 to 166, score 493.71 unchanged,
+  zero net regression. Three local lenses accepted only the changeset accuracy
+  correction; pass-through/error-obscuring deltas cancelled and were ignored.
+- Agent-native capability map -> N/A across action route/source mirror/lock/proof:
+  the changed surface is ORM runtime and tests only; verdict PASS.
+
+Timeline:
+- 2026-08-14T10:55:17.599Z Autoclosure plan created.
+- 2026-08-14 PR 314 feedback fetched: two unresolved inline threads, zero
+  actionable top-level comments, and zero actionable review bodies.
+- 2026-08-14 Switched the same checkout from `main` to PR head branch
+  `fix/orm-limit-isnull-flatmap-cascade` through `gh pr checkout 314`.
+- 2026-08-14 Confirmed the second thread with a public-interface regression:
+  standalone relations returned five violating rows; added the native fallback
+  filter and observed the focused test and all 21 pagination tests pass.
+- 2026-08-14 Narrowed the changeset claim from universal full-page filling to
+  the proven invariant that cursor pages never contain non-matching rows.
+- 2026-08-14 Focused ORM tests, package build, fixture parity, deslop, and the
+  agent-native audit passed; no additional cleanup or workflow repair accepted.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Repair and focused proof |
+| Where am I going? | Remaining closure matrix, review/checks, delivery, final audit |
+| What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
+| What have I learned? | The latest schema-backed fix was correct, but standalone relations lacked stream metadata and silently returned residual-filter violations |
+| What have I done? | Reproduced the fallback bug red, fixed it at the native pagination owner, ran all pagination tests green, and corrected the changeset claim |
+
+Open risks:
+- The combined ORM test surface, package build, fixture check, reviews, full
+  repository gate, push/replies/resolution, and PR head read-back remain.

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -88,15 +88,15 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | focused ORM regression tests and source audit | pending |
-| package/API/build | yes | `bun --cwd packages/kitcn build` and type/check gates; no intended public API change | pending |
+| source behavior | yes | focused ORM regression tests plus full `bun check` runtime suites passed | complete |
+| package/API/build | yes | `bun --cwd packages/kitcn build`, root typecheck, package artifacts, and full check passed; no public API shape changed | complete |
 | generated output | yes | `bun run fixtures:check` proved all committed fixtures match fresh scaffold output | complete |
 | fixtures/scenarios | yes | `bun run fixtures:check` passed every fixture; scenario runtime N/A because ORM runtime behavior is covered by integration tests and no scaffold behavior changed | complete |
-| docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | pending |
+| docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | complete |
 | changeset | yes | `.changeset/olive-eyes-punch.md` covers the six user-visible fixes and no longer overclaims standalone full-page filling | complete |
 | agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
-| cleanup/review | yes | `bun run lint:slop:delta` -> 166 to 166, score unchanged, zero net regression; local agent-native audit PASS; autoreview pending | pending |
-| repository check | yes | `bun check` | pending |
+| cleanup/review | yes | deslop zero net regression; agent-native audit PASS; branch autoreview clean with zero findings at 0.87 confidence | complete |
+| repository check | yes | `bun lint:fix` no changes; `bun check` exited 0 across CI, verify, and runtime lanes | complete |
 | GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
 
 Feedback ledger:
@@ -178,6 +178,11 @@ Verification evidence:
   correction; pass-through/error-obscuring deltas cancelled and were ignored.
 - Agent-native capability map -> N/A across action route/source mirror/lock/proof:
   the changed surface is ORM runtime and tests only; verdict PASS.
+- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` -> TruffleHog clean, one 59,712-byte bundle, zero findings, `patch is correct`, confidence 0.87, clean exit.
+- Final `bun lint:fix` -> 874 files checked, no fixes applied.
+- Final `bun check` -> exit 0: lint, all package typechecks/tests/builds, CLI
+  123/123, Concave smoke, fixture parity, bare Convex verify, and runtime
+  scenario matrix including auth smoke all passed.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -192,16 +197,19 @@ Timeline:
   the proven invariant that cursor pages never contain non-matching rows.
 - 2026-08-14 Focused ORM tests, package build, fixture parity, deslop, and the
   agent-native audit passed; no additional cleanup or workflow repair accepted.
+- 2026-08-14 Committed the whole checkout as `12966fe0`, then ran the isolated
+  branch autoreview clean with zero accepted/actionable findings.
+- 2026-08-14 Final `bun lint:fix` and complete `bun check` passed; GitHub
+  delivery is the only remaining executable lane.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Repair and focused proof |
-| Where am I going? | Remaining closure matrix, review/checks, delivery, final audit |
+| Where am I? | GitHub delivery |
+| Where am I going? | Push, feedback replies/resolution, GitHub read-back, final audit |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
 | What have I learned? | The latest schema-backed fix was correct, but standalone relations lacked stream metadata and silently returned residual-filter violations |
-| What have I done? | Reproduced the fallback bug red, fixed it at the native pagination owner, ran all pagination tests green, and corrected the changeset claim |
+| What have I done? | Closed every local proof/review/check lane; only GitHub delivery and the mechanical goal audit remain |
 
 Open risks:
-- The combined ORM test surface, package build, fixture check, reviews, full
-  repository gate, push/replies/resolution, and PR head read-back remain.
+- Push, replies/resolution, CI/PR head read-back, and the goal-plan checker remain.

--- a/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
+++ b/docs/plans/2026-08-14-pr-314-closure-and-feedback.md
@@ -88,22 +88,22 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | final fail-closed repair, 21 pagination tests, and focused combined 115-test ORM lane passed | complete |
+| source behavior | yes | fail-closed metadata repair plus final-visible-membership stream sizing; 6-file ORM lane passed 130 tests with 1 skip | complete |
 | package/API/build | yes | final `bun --cwd packages/kitcn build` passed; no public API shape changed | complete |
 | generated output | yes | `bun run fixtures:check` proved all committed fixtures match fresh scaffold output | complete |
 | fixtures/scenarios | yes | `bun run fixtures:check` passed every fixture; scenario runtime N/A because ORM runtime behavior is covered by integration tests and no scaffold behavior changed | complete |
 | docs/package skill | no | N/A: internal ORM correctness only; no public usage shape or docs/skill contract changed | complete |
 | changeset | yes | `.changeset/olive-eyes-punch.md` covers the six user-visible fixes and no longer overclaims standalone full-page filling | complete |
 | agent workflow | no | N/A: changed-file audit contains no agent rule, skill, mirror, lock, helper, or user-action tooling | complete |
-| cleanup/review | yes | final deslop stayed at zero net regression; agent-native audit unchanged; autoreview rerun pending | pending |
+| cleanup/review | yes | deslop stayed at zero net regression; agent-native audit unchanged; final autoreview rerun pending after accepted findings | pending |
 | repository check | yes | prior full check passed but is stale after final repair; rerun required | pending |
 | GitHub delivery | yes | whole-checkout commit/push, replies/resolution, PR read-back | pending |
 
 Feedback ledger:
 | ID / URL | Type | Path | Reviewer claim | Verdict | Owner / proof | Reply | Resolution |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: commit `c570c3c` routes schema-backed residual predicates through stream pagination | `bunx vitest run convex/orm/pagination.test.ts` -> 21 passed | pending | pending |
-| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Metadata-free relations can drop residual cursor filters | fixed-differently after source/author evidence: unsupported standalone schema ownership now fails closed through the canonical `defineSchema()` guard, also preventing silent `maxScan` loss | focused test red because the partial native fallback resolved instead of rejecting, green after guard; full pagination file 21 passed | pending | pending |
+| `PRRT_kwDOPTlS686Y-7VP` / `discussion_r3776629135` | review thread | `packages/kitcn/src/orm/query.ts:5896` | Cursor pagination drops residual predicates | fixed: schema-backed residual predicates, RLS visibility, and relation membership run inside stream pagination before page sizing | 22 pagination + 14 RLS tests; combined 6-file ORM lane passed 130 with 1 skip | pending | pending |
+| `PRRT_kwDOPTlS686ZPpy4` / `discussion_r3783055926` | review thread | `packages/kitcn/src/orm/query.ts:2324` | Metadata-free relations can drop residual cursor filters | fixed-differently after source/author evidence: unsupported standalone schema ownership fails closed through the canonical `defineSchema()` guard, also preventing silent `maxScan` loss | focused test red because the partial native fallback resolved instead of rejecting, green after guard; pagination file passed 22 tests | pending | pending |
 
 Feedback triage notes:
 - `changeset-bot` top-level comment is status boilerplate with no actionable
@@ -114,6 +114,17 @@ Feedback triage notes:
   confirmed standalone relation exports are rejected by schema ownership and
   advanced pagination already owns a canonical `defineSchema()` guard. The
   permissive native-page filter was replaced with that fail-closed invariant.
+
+Review fixes:
+- Accepted P1: residual cursor pagination counted rows before RLS. Moved RLS
+  membership into `QueryStream.filterWith`; a red/green test puts an invisible
+  newer row ahead of the visible match and still fills a one-row page.
+- Accepted P1: residual cursor pagination counted rows before relation filters.
+  Moved relation membership into the same stream predicate; a red/green test
+  puts three newer non-matches ahead of the related match and fills the page.
+- Accepted P2: non-cursor residual `take()` counted rows before RLS/relation
+  filters. The same membership predicate now sizes limited reads by final
+  visible matches and the post-stream path avoids duplicate membership work.
 
 Work Checklist:
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
@@ -135,7 +146,9 @@ Work Checklist:
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
-| None yet | 0 | | |
+| RLS cursor repro hit the `maxScan` guard before the residual stream | 1 | Give the fixture a real planner index and combine indexed `eq` with residual `like` | Red reproduced an empty page, then passed after membership moved into the stream |
+| Patch context drifted after the first owner edit | 1 | Re-read exact bounded ranges and patch smaller hunks | Applied cleanly; `git diff --check` passed |
+| `gh pr view` briefly reported a stale head SHA after push | 1 | Read the branch ref and PR head directly through GitHub API | Both direct API endpoints agreed on the pushed SHA |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
@@ -193,6 +206,12 @@ Verification evidence:
 - After the final fail-closed repair: focused combined Vitest lane -> 5 files,
   115 passed, 1 skipped, no type errors; package build passed; deslop remained
   166 to 166 with zero score change.
+- Accepted the final autoreview's three composition findings as one owner
+  invariant: residual stream limits must count final RLS-visible and
+  relation-matching rows. Added cursor RLS, cursor relation, and non-cursor RLS
+  regressions; the final 6-file lane passed 130 tests with 1 skip and no type
+  errors, compiler tests passed 18, package build passed, and deslop remained
+  166 to 166 with zero score change.
 
 Timeline:
 - 2026-08-14T10:55:17.599Z Autoclosure plan created.
@@ -216,16 +235,19 @@ Timeline:
   Replaced the permissive fallback with the canonical fail-closed schema guard;
   all 21 pagination tests passed. Prior autoreview/check evidence is stale until
   rerun.
+- 2026-08-14 Final branch autoreview found three related limit-composition
+  defects around RLS/relation membership. Accepted them as one in-scope owner
+  repair, proved each red/green, and reran the focused owner stack green.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Repair rerun after new author evidence |
-| Where am I going? | Re-review/check, push, feedback replies/resolution, GitHub read-back, final audit |
+| Where am I? | Focused repair proof complete after final review findings |
+| Where am I going? | Commit, re-review/check, push, feedback replies/resolution, GitHub read-back, final audit |
 | What is the goal? | Close PR 314 with zero unhandled actionable feedback and every applicable proof/delivery gate complete |
-| What have I learned? | Schema-backed relations are supported; fresh-object standalone relations are intentionally rejected by CLI ownership, so advanced cursor filters must fail closed rather than run a partial native fallback |
-| What have I done? | Reclassified and replaced the second fix after new author/source evidence; focused pagination proof is green and final review/check reruns remain |
+| What have I learned? | Residual predicates, RLS, and relation membership form one final-visible-row predicate; any pushed-down limit must count that composite result |
+| What have I done? | Reclassified the metadata case, fixed final-visible stream sizing, and proved all three accepted composition findings; final review/check/delivery remain |
 
 Open risks:
-- Package build, deslop/review, full check, repush, replies/resolution, CI/PR
-  head read-back, and the goal-plan checker remain after the final repair.
+- Final autoreview, full check, repush, replies/resolution, final CI/PR head
+  read-back, and the goal-plan checker remain after the owner repair.

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@opentelemetry/api": "1.9.0",
     "@tanstack/react-query": "5.95.2",
     "better-auth": "1.6.18",
@@ -9,7 +9,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@opentelemetry/api": "1.9.0",
     "@tanstack/react-query": "5.95.2",
     "class-variance-authority": "^0.7.1",
@@ -8,7 +8,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/vite": "^4",
@@ -17,7 +17,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/vite": "^4",
@@ -16,7 +16,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/vite": "^4",
@@ -11,7 +11,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@base-ui/react": "^1.6.0",
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@opentelemetry/api": "1.9.0",
     "@tailwindcss/vite": "^4",
@@ -10,7 +10,7 @@
     "convex": "1.42.3",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.31.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -2297,15 +2297,17 @@ export class GelRelationalQuery<
   }
 
   /**
-   * Stream equivalent of the non-paginated `db.query(...)` chain, used when a
-   * post-fetch filter has to run in JavaScript before `limit` can be applied.
+   * Stream equivalent of the `db.query(...)` chain, used when a post-fetch
+   * filter has to run in JavaScript before `limit` or a page boundary can be
+   * applied. `filterWith` evaluates the predicate as rows are pulled, so
+   * `take`/`paginate` size by matches instead of by scanned rows.
    *
    * It deliberately mirrors the index and order decisions the caller already
    * made for the plain query rather than re-deriving them, so switching to the
    * stream cannot change which index is scanned or in what direction.
    *
    * Returns null when the schema definition needed by `stream()` is missing;
-   * the caller then falls back to collect-and-slice.
+   * the caller then falls back to its plain-query path.
    */
   private _buildResidualFilterStream(params: {
     queryConfig: {
@@ -2315,7 +2317,8 @@ export class GelRelationalQuery<
     configuredIndex?: PredicateWhereIndexConfig<TTableConfig>;
     orderIndexName: string | null;
     primaryOrder?: { direction: 'asc' | 'desc'; field: string };
-    needsPostFetchSortForPrimary: boolean;
+    /** Direction to use when the query has no orderBy at all. */
+    fallbackOrder: 'asc' | 'desc';
   }): QueryStream<any> | null {
     const schemaDefinition = (this.schema as any)[OrmSchemaDefinition];
     if (!schemaDefinition) {
@@ -2327,7 +2330,7 @@ export class GelRelationalQuery<
       configuredIndex,
       orderIndexName,
       primaryOrder,
-      needsPostFetchSortForPrimary,
+      fallbackOrder,
     } = params;
 
     let streamQuery: any = stream(
@@ -2355,14 +2358,12 @@ export class GelRelationalQuery<
       streamQuery = streamQuery.withIndex(orderIndexName as any, (q: any) => q);
     }
 
-    // The plain query only calls .order() when the index already sorts by the
-    // requested field; otherwise the rows are sorted post-fetch and this branch
-    // is not used. Streams always need an explicit direction, and Convex
-    // defaults to ascending.
+    // Streams always need an explicit direction. The plain query leaves the
+    // Convex default (ascending) when there is no orderBy in the non-paginated
+    // path, and explicitly orders 'desc' in the cursor path, so the caller
+    // supplies which of the two applies.
     streamQuery = streamQuery.order(
-      primaryOrder && !needsPostFetchSortForPrimary
-        ? primaryOrder.direction
-        : 'asc'
+      primaryOrder ? primaryOrder.direction : fallbackOrder
     );
 
     streamQuery = streamQuery.filterWith((row: any) =>
@@ -5895,6 +5896,82 @@ export class GelRelationalQuery<
       const convexPostFilters = queryConfig.postFilters.filter((filter) =>
         this._isConvexEnforceableFilter(filter)
       );
+      const hasResidualPostFilter =
+        convexPostFilters.length !== queryConfig.postFilters.length;
+
+      // A residual predicate runs in JavaScript, and Convex's native paginate
+      // has no place to run it: the page is built entirely inside Convex. The
+      // two stream branches above only cover unindexed and multi-probe plans,
+      // so an indexed plan would otherwise emit a page containing rows that
+      // violate the predicate. Route it through the same stream the
+      // non-paginated path uses, where `filterWith` runs while the page is
+      // assembled — that keeps pages full instead of filtering them down after
+      // the fact.
+      const residualPageStream = hasResidualPostFilter
+        ? this._buildResidualFilterStream({
+            queryConfig,
+            configuredIndex,
+            orderIndexName,
+            primaryOrder,
+            fallbackOrder: 'desc',
+          })
+        : null;
+
+      if (residualPageStream) {
+        if (queryConfig.order && primaryOrder) {
+          if (needsPostFetchSortForPrimary && strict) {
+            throw new Error(
+              `Pagination: Field '${primaryOrder.field}' has no index. Add an index or disable strict.`
+            );
+          }
+          if (needsPostFetchSortForPrimary) {
+            console.warn(
+              `Pagination: Field '${primaryOrder.field}' has no index. ` +
+                'Falling back to _creationTime ordering.'
+            );
+          }
+          if (hasSecondaryOrders) {
+            console.warn(
+              'Pagination: Only the first orderBy field is used for cursor ordering. ' +
+                'Secondary orderBy fields are applied per page and may be unstable across pages.'
+            );
+          }
+        }
+
+        const paginationResult = await residualPageStream.paginate({
+          cursor: cursor ?? null,
+          endCursor: endCursor ?? undefined,
+          limit: config.limit,
+          maxScan,
+        });
+
+        let pageRows = paginationResult.page;
+
+        pageRows = await this._applyRlsSelectFilter(pageRows, this.tableConfig);
+
+        if (whereFilter) {
+          pageRows = await this._applyRelationsFilterToRows(
+            pageRows,
+            this.tableConfig,
+            whereFilter,
+            this.edgeMetadata,
+            0,
+            3,
+            this.config.with as Record<string, unknown> | undefined
+          );
+        }
+
+        const selectedPage = await this._finalizeRows(pageRows);
+
+        return {
+          page: selectedPage,
+          continueCursor: paginationResult.continueCursor,
+          isDone: paginationResult.isDone,
+          pageStatus: (paginationResult as any).pageStatus,
+          splitCursor: (paginationResult as any).splitCursor,
+        } as TResult;
+      }
+
       if (convexPostFilters.length > 0) {
         query = query.filter((q: any) => {
           let result: any | null = null;
@@ -6020,7 +6097,7 @@ export class GelRelationalQuery<
             configuredIndex,
             orderIndexName,
             primaryOrder,
-            needsPostFetchSortForPrimary,
+            fallbackOrder: 'asc',
           })
         : null;
 

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -5896,8 +5896,10 @@ export class GelRelationalQuery<
       const convexPostFilters = queryConfig.postFilters.filter((filter) =>
         this._isConvexEnforceableFilter(filter)
       );
-      const hasResidualPostFilter =
-        convexPostFilters.length !== queryConfig.postFilters.length;
+      const residualPostFilters = queryConfig.postFilters.filter(
+        (filter) => !this._isConvexEnforceableFilter(filter)
+      );
+      const hasResidualPostFilter = residualPostFilters.length > 0;
 
       // A residual predicate runs in JavaScript, and Convex's native paginate
       // has no place to run it: the page is built entirely inside Convex. The
@@ -6024,6 +6026,18 @@ export class GelRelationalQuery<
       });
 
       let pageRows = paginationResult.page;
+
+      // `defineRelations()` can be created before `defineSchema()`, leaving no
+      // schema metadata for the stream fallback above. Native pagination may
+      // underfill after this pass, but it must never return rows that violate a
+      // JavaScript-only predicate.
+      if (hasResidualPostFilter) {
+        pageRows = pageRows.filter((row: any) =>
+          residualPostFilters.every((filter) =>
+            this._evaluatePostFetchFilter(row, filter)
+          )
+        );
+      }
 
       pageRows = await this._applyRlsSelectFilter(pageRows, this.tableConfig);
 

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -138,6 +138,25 @@ import {
   WhereClauseCompiler,
 } from './where-clause-compiler';
 
+/**
+ * Operators that Convex's `.filter()` cannot express, so `_toConvexExpression`
+ * compiles them to a `() => true` placeholder and `_evaluatePostFetchFilter`
+ * applies the real predicate in JavaScript after the rows are read.
+ * Keep in sync with the string/array cases in `_toConvexExpression`.
+ */
+const POST_FETCH_ONLY_OPERATORS = new Set([
+  'like',
+  'ilike',
+  'notLike',
+  'notIlike',
+  'startsWith',
+  'endsWith',
+  'contains',
+  'arrayContains',
+  'arrayContained',
+  'arrayOverlaps',
+]);
+
 const DEFAULT_RELATION_FAN_OUT_MAX_KEYS = 1000;
 const DEFAULT_AGGREGATE_CARTESIAN_MAX_KEYS = 4096;
 const DEFAULT_AGGREGATE_WORK_BUDGET = 16_384;
@@ -660,6 +679,41 @@ export class GelRelationalQuery<
       return targetValue.startsWith(prefix);
     }
     return targetValue === targetPattern;
+  }
+
+  /**
+   * True when the expression can be fully enforced by Convex's own `.filter()`.
+   *
+   * `_toConvexExpression` compiles the string/array operators to `() => true`
+   * because Convex filters cannot run JavaScript string methods; those are
+   * evaluated later by `_evaluatePostFetchFilter`. Pushing such an expression
+   * into `.filter()` is not merely useless, it is wrong in two ways: a `take()`
+   * downstream spends its budget on rows that have not been filtered yet, and a
+   * surrounding `NOT` turns the `true` placeholder into `q.not(true)`, which
+   * matches nothing. So the caller must know whether Convex can carry the whole
+   * expression before relying on it.
+   */
+  private _isConvexEnforceableFilter(
+    filter: FilterExpression<boolean>
+  ): boolean {
+    if (filter.type === 'binary') {
+      return !POST_FETCH_ONLY_OPERATORS.has(filter.operator);
+    }
+    if (filter.type === 'unary') {
+      const [operand] = filter.operands;
+      if (isFieldReference(operand)) {
+        return true;
+      }
+      return this._isConvexEnforceableFilter(
+        operand as FilterExpression<boolean>
+      );
+    }
+    if (filter.type === 'logical') {
+      return filter.operands.every((operand) =>
+        this._isConvexEnforceableFilter(operand)
+      );
+    }
+    return true;
   }
 
   /**
@@ -2240,6 +2294,86 @@ export class GelRelationalQuery<
     }
 
     return streamQuery;
+  }
+
+  /**
+   * Stream equivalent of the non-paginated `db.query(...)` chain, used when a
+   * post-fetch filter has to run in JavaScript before `limit` can be applied.
+   *
+   * It deliberately mirrors the index and order decisions the caller already
+   * made for the plain query rather than re-deriving them, so switching to the
+   * stream cannot change which index is scanned or in what direction.
+   *
+   * Returns null when the schema definition needed by `stream()` is missing;
+   * the caller then falls back to collect-and-slice.
+   */
+  private _buildResidualFilterStream(params: {
+    queryConfig: {
+      index?: { name: string; filters: FilterExpression<boolean>[] };
+      postFilters: FilterExpression<boolean>[];
+    };
+    configuredIndex?: PredicateWhereIndexConfig<TTableConfig>;
+    orderIndexName: string | null;
+    primaryOrder?: { direction: 'asc' | 'desc'; field: string };
+    needsPostFetchSortForPrimary: boolean;
+  }): QueryStream<any> | null {
+    const schemaDefinition = (this.schema as any)[OrmSchemaDefinition];
+    if (!schemaDefinition) {
+      return null;
+    }
+
+    const {
+      queryConfig,
+      configuredIndex,
+      orderIndexName,
+      primaryOrder,
+      needsPostFetchSortForPrimary,
+    } = params;
+
+    let streamQuery: any = stream(
+      this.db as GenericDatabaseReader<any>,
+      schemaDefinition
+    ).query(this.tableConfig.name as any);
+
+    if (queryConfig.index) {
+      streamQuery = streamQuery.withIndex(
+        queryConfig.index.name as any,
+        (q: any) => {
+          let indexQuery = q;
+          for (const filter of queryConfig.index!.filters) {
+            indexQuery = this._applyFilterToQuery(indexQuery, filter);
+          }
+          return indexQuery;
+        }
+      );
+    } else if (configuredIndex?.name) {
+      streamQuery = streamQuery.withIndex(
+        configuredIndex.name as any,
+        configuredIndex.range ? (configuredIndex.range as any) : (q: any) => q
+      );
+    } else if (orderIndexName) {
+      streamQuery = streamQuery.withIndex(orderIndexName as any, (q: any) => q);
+    }
+
+    // The plain query only calls .order() when the index already sorts by the
+    // requested field; otherwise the rows are sorted post-fetch and this branch
+    // is not used. Streams always need an explicit direction, and Convex
+    // defaults to ascending.
+    streamQuery = streamQuery.order(
+      primaryOrder && !needsPostFetchSortForPrimary
+        ? primaryOrder.direction
+        : 'asc'
+    );
+
+    streamQuery = streamQuery.filterWith((row: any) =>
+      Promise.resolve(
+        queryConfig.postFilters.every((filter) =>
+          this._evaluatePostFetchFilter(row, filter)
+        )
+      )
+    );
+
+    return streamQuery as QueryStream<any>;
   }
 
   private _buildUnionSourceStream(
@@ -5756,11 +5890,15 @@ export class GelRelationalQuery<
         }
       }
 
-      // Apply post-filters
-      if (queryConfig.postFilters.length > 0) {
+      // Apply post-filters. Only the Convex-enforceable ones: the rest are
+      // placeholders that would make a surrounding NOT match nothing.
+      const convexPostFilters = queryConfig.postFilters.filter((filter) =>
+        this._isConvexEnforceableFilter(filter)
+      );
+      if (convexPostFilters.length > 0) {
         query = query.filter((q: any) => {
           let result: any | null = null;
-          for (const filter of queryConfig.postFilters) {
+          for (const filter of convexPostFilters) {
             const filterFn = this._toConvexExpression(filter);
             const expr = filterFn(q);
             result = result ? q.and(result, expr) : expr;
@@ -5833,12 +5971,18 @@ export class GelRelationalQuery<
       } as TResult;
     }
 
-    // Apply post-filters
-    if (queryConfig.postFilters.length > 0) {
+    // Apply post-filters. Only the Convex-enforceable ones: the rest are
+    // placeholders that would make a surrounding NOT match nothing.
+    const convexPostFilters = queryConfig.postFilters.filter((filter) =>
+      this._isConvexEnforceableFilter(filter)
+    );
+    const hasResidualPostFilter =
+      convexPostFilters.length !== queryConfig.postFilters.length;
+    if (convexPostFilters.length > 0) {
       query = query.filter((q: any) => {
         // Combine all post-filters with AND logic
         let result: any | null = null;
-        for (const filter of queryConfig.postFilters) {
+        for (const filter of convexPostFilters) {
           const filterFn = this._toConvexExpression(filter);
           const expr = filterFn(q);
           result = result ? q.and(result, expr) : expr;
@@ -5857,13 +6001,48 @@ export class GelRelationalQuery<
     const limit = this._resolveNonPaginatedLimit(config);
     const paginateAfterPostFetchSort =
       usePostFetchSort && postFetchOrders.length > 0;
-    let rows =
-      limit === undefined || paginateAfterPostFetchSort
-        ? await query.collect()
-        : await query.take(offset > 0 ? offset + limit : limit);
+
+    // A residual filter runs in JavaScript, so `query.take(limit)` would spend
+    // the whole budget on unfiltered rows and return mostly (often entirely)
+    // non-matching ones. Offset has the same problem: it must skip matches, not
+    // scanned rows. So when a residual filter is present, sizing moves after the
+    // JavaScript pass.
+    const sizeAfterPostFilter =
+      hasResidualPostFilter && !paginateAfterPostFetchSort;
+
+    // Read through a stream when we can: `filterWith` runs the predicate as rows
+    // are pulled, so `take` still stops early but counts matches rather than
+    // scanned rows, preserving the read bound the plain `take` gave us.
+    const residualLimitStream =
+      sizeAfterPostFilter && limit !== undefined
+        ? this._buildResidualFilterStream({
+            queryConfig,
+            configuredIndex,
+            orderIndexName,
+            primaryOrder,
+            needsPostFetchSortForPrimary,
+          })
+        : null;
+
+    let rows: any[];
+    if (residualLimitStream) {
+      rows = await residualLimitStream.take(
+        offset > 0 ? offset + (limit as number) : (limit as number)
+      );
+    } else if (
+      limit === undefined ||
+      paginateAfterPostFetchSort ||
+      hasResidualPostFilter
+    ) {
+      // No stream available (no defineSchema()) or no limit to push down.
+      // Correctness wins over the read bound: scan, then size below.
+      rows = await query.collect();
+    } else {
+      rows = await query.take(offset > 0 ? offset + limit : limit);
+    }
 
     // Apply offset slicing if needed
-    if (!paginateAfterPostFetchSort && offset > 0) {
+    if (!(paginateAfterPostFetchSort || sizeAfterPostFilter) && offset > 0) {
       rows = rows.slice(offset);
     }
 
@@ -5875,6 +6054,16 @@ export class GelRelationalQuery<
           this._evaluatePostFetchFilter(row, filter)
         )
       );
+    }
+
+    // Residual filters are now applied, so offset/limit finally mean "matches".
+    if (sizeAfterPostFilter) {
+      if (offset > 0) {
+        rows = rows.slice(offset);
+      }
+      if (limit !== undefined) {
+        rows = rows.slice(0, limit);
+      }
     }
 
     rows = await this._applyRlsSelectFilter(rows, this.tableConfig);

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -2315,6 +2315,7 @@ export class GelRelationalQuery<
       postFilters: FilterExpression<boolean>[];
     };
     configuredIndex?: PredicateWhereIndexConfig<TTableConfig>;
+    membershipFilter?: (row: any) => boolean | Promise<boolean>;
     orderIndexName: string | null;
     primaryOrder?: { direction: 'asc' | 'desc'; field: string };
     /** Direction to use when the query has no orderBy at all. */
@@ -2328,6 +2329,7 @@ export class GelRelationalQuery<
     const {
       queryConfig,
       configuredIndex,
+      membershipFilter,
       orderIndexName,
       primaryOrder,
       fallbackOrder,
@@ -2366,13 +2368,14 @@ export class GelRelationalQuery<
       primaryOrder ? primaryOrder.direction : fallbackOrder
     );
 
-    streamQuery = streamQuery.filterWith((row: any) =>
-      Promise.resolve(
-        queryConfig.postFilters.every((filter) =>
-          this._evaluatePostFetchFilter(row, filter)
-        )
-      )
-    );
+    streamQuery = streamQuery.filterWith(async (row: any) => {
+      for (const filter of queryConfig.postFilters) {
+        if (!this._evaluatePostFetchFilter(row, filter)) {
+          return false;
+        }
+      }
+      return membershipFilter ? await membershipFilter(row) : true;
+    });
 
     return streamQuery as QueryStream<any>;
   }
@@ -5712,6 +5715,29 @@ export class GelRelationalQuery<
       return this._returnSelectedRows(selectedRows);
     }
 
+    const matchesPostFetchMembership = async (row: any) => {
+      const visibleRows = await this._applyRlsSelectFilter(
+        [row],
+        this.tableConfig
+      );
+      if (visibleRows.length === 0) {
+        return false;
+      }
+      if (!whereFilter) {
+        return true;
+      }
+      const matchingRows = await this._applyRelationsFilterToRows(
+        visibleRows,
+        this.tableConfig,
+        whereFilter,
+        this.edgeMetadata,
+        0,
+        3,
+        this.config.with as Record<string, unknown> | undefined
+      );
+      return matchingRows.length > 0;
+    };
+
     // M6.5 Phase 4: Handle cursor pagination separately
     if (isCursorPaginated) {
       if (queryConfig.strategy === 'multiProbe') {
@@ -5911,6 +5937,7 @@ export class GelRelationalQuery<
         ? this._buildResidualFilterStream({
             queryConfig,
             configuredIndex,
+            membershipFilter: matchesPostFetchMembership,
             orderIndexName,
             primaryOrder,
             fallbackOrder: 'desc',
@@ -5949,23 +5976,7 @@ export class GelRelationalQuery<
           maxScan,
         });
 
-        let pageRows = paginationResult.page;
-
-        pageRows = await this._applyRlsSelectFilter(pageRows, this.tableConfig);
-
-        if (whereFilter) {
-          pageRows = await this._applyRelationsFilterToRows(
-            pageRows,
-            this.tableConfig,
-            whereFilter,
-            this.edgeMetadata,
-            0,
-            3,
-            this.config.with as Record<string, unknown> | undefined
-          );
-        }
-
-        const selectedPage = await this._finalizeRows(pageRows);
+        const selectedPage = await this._finalizeRows(paginationResult.page);
 
         return {
           page: selectedPage,
@@ -6099,6 +6110,7 @@ export class GelRelationalQuery<
         ? this._buildResidualFilterStream({
             queryConfig,
             configuredIndex,
+            membershipFilter: matchesPostFetchMembership,
             orderIndexName,
             primaryOrder,
             fallbackOrder: 'asc',
@@ -6147,18 +6159,20 @@ export class GelRelationalQuery<
       }
     }
 
-    rows = await this._applyRlsSelectFilter(rows, this.tableConfig);
+    if (!residualLimitStream) {
+      rows = await this._applyRlsSelectFilter(rows, this.tableConfig);
 
-    if (whereFilter) {
-      rows = await this._applyRelationsFilterToRows(
-        rows,
-        this.tableConfig,
-        whereFilter,
-        this.edgeMetadata,
-        0,
-        3,
-        this.config.with as Record<string, unknown> | undefined
-      );
+      if (whereFilter) {
+        rows = await this._applyRelationsFilterToRows(
+          rows,
+          this.tableConfig,
+          whereFilter,
+          this.edgeMetadata,
+          0,
+          3,
+          this.config.with as Record<string, unknown> | undefined
+        );
+      }
     }
 
     // Apply post-fetch sort if needed

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -6149,16 +6149,6 @@ export class GelRelationalQuery<
       );
     }
 
-    // Residual filters are now applied, so offset/limit finally mean "matches".
-    if (sizeAfterPostFilter) {
-      if (offset > 0) {
-        rows = rows.slice(offset);
-      }
-      if (limit !== undefined) {
-        rows = rows.slice(0, limit);
-      }
-    }
-
     if (!residualLimitStream) {
       rows = await this._applyRlsSelectFilter(rows, this.tableConfig);
 
@@ -6172,6 +6162,17 @@ export class GelRelationalQuery<
           3,
           this.config.with as Record<string, unknown> | undefined
         );
+      }
+    }
+
+    // All post-fetch membership is now applied, so offset/limit mean final
+    // visible matches even when no stream is available.
+    if (sizeAfterPostFilter) {
+      if (offset > 0) {
+        rows = rows.slice(offset);
+      }
+      if (limit !== undefined) {
+        rows = rows.slice(0, limit);
       }
     }
 

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -5896,10 +5896,8 @@ export class GelRelationalQuery<
       const convexPostFilters = queryConfig.postFilters.filter((filter) =>
         this._isConvexEnforceableFilter(filter)
       );
-      const residualPostFilters = queryConfig.postFilters.filter(
-        (filter) => !this._isConvexEnforceableFilter(filter)
-      );
-      const hasResidualPostFilter = residualPostFilters.length > 0;
+      const hasResidualPostFilter =
+        convexPostFilters.length !== queryConfig.postFilters.length;
 
       // A residual predicate runs in JavaScript, and Convex's native paginate
       // has no place to run it: the page is built entirely inside Convex. The
@@ -5918,6 +5916,10 @@ export class GelRelationalQuery<
             fallbackOrder: 'desc',
           })
         : null;
+
+      if (hasResidualPostFilter && !residualPageStream) {
+        this._getSchemaDefinitionOrThrow();
+      }
 
       if (residualPageStream) {
         if (queryConfig.order && primaryOrder) {
@@ -6026,18 +6028,6 @@ export class GelRelationalQuery<
       });
 
       let pageRows = paginationResult.page;
-
-      // `defineRelations()` can be created before `defineSchema()`, leaving no
-      // schema metadata for the stream fallback above. Native pagination may
-      // underfill after this pass, but it must never return rows that violate a
-      // JavaScript-only predicate.
-      if (hasResidualPostFilter) {
-        pageRows = pageRows.filter((row: any) =>
-          residualPostFilters.every((filter) =>
-            this._evaluatePostFetchFilter(row, filter)
-          )
-        );
-      }
 
       pageRows = await this._applyRlsSelectFilter(pageRows, this.tableConfig);
 

--- a/packages/kitcn/src/orm/scheduled-mutation-batch.ts
+++ b/packages/kitcn/src/orm/scheduled-mutation-batch.ts
@@ -56,6 +56,9 @@ export type ScheduledMutationBatchArgs = {
   delayMs: number;
 };
 
+/** Column stamped by `softDeleteRow`; see mutation-utils.ts. */
+const DELETION_TIME_FIELD = 'deletionTime';
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === 'object' && !Array.isArray(value);
 
@@ -206,8 +209,18 @@ export function scheduledMutationBatchFactory<
         'scheduledMutationBatch: foreignIndexName is required for cascade work.'
       );
     }
-    const queryWithIndex = () =>
-      (ctx.db.query(args.table) as any).withIndex(
+    const action = args.foreignAction ?? 'no action';
+    // Every other cascade action stops a processed row from matching this
+    // index: hard delete removes it, `set null` / `set default` / cascade
+    // update rewrite the foreign key columns. Soft cascade only stamps
+    // `deletionTime`, so without this guard the re-query below keeps returning
+    // the same rows and the worker re-queues itself forever.
+    const skipSoftDeletedRows =
+      workType === 'cascade-delete' &&
+      action === 'cascade' &&
+      (args.cascadeMode ?? 'hard') === 'soft';
+    const queryWithIndex = () => {
+      const indexed = (ctx.db.query(args.table) as any).withIndex(
         args.foreignIndexName,
         (q: any) => {
           let builder = q.eq(sourceColumns[0], targetValues[0]);
@@ -217,7 +230,16 @@ export function scheduledMutationBatchFactory<
           return builder;
         }
       );
-    const action = args.foreignAction ?? 'no action';
+      if (!skipSoftDeletedRows) {
+        return indexed;
+      }
+      return indexed.filter((q: any) =>
+        q.or(
+          q.eq(q.field(DELETION_TIME_FIELD), undefined),
+          q.eq(q.field(DELETION_TIME_FIELD), null)
+        )
+      );
+    };
     // Cascade workers patch/delete rows that are selected by the same indexed
     // foreign key columns. Forwarding cursors can skip remaining rows after
     // those mutations, so cascade continuation always re-queries from null.

--- a/packages/kitcn/src/orm/stream.ts
+++ b/packages/kitcn/src/orm/stream.ts
@@ -1271,12 +1271,12 @@ class FlatMapStreamIterator<
     innerIterator: AsyncIterator<[U | null, IndexKey]>;
     count: number;
   } | null = null;
-  #mapper: (doc: T) => Promise<QueryStream<U>>;
+  #mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>;
   #mappedIndexFields: string[];
 
   constructor(
     outerStream: QueryStream<T>,
-    mapper: (doc: T) => Promise<QueryStream<U>>,
+    mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>,
     mappedIndexFields: string[]
   ) {
     this.#outerIterator = outerStream.iterWithKeys()[Symbol.asyncIterator]();
@@ -1302,7 +1302,7 @@ class FlatMapStreamIterator<
     if (t === null) {
       innerStream = this.singletonSkipInnerStream();
     } else {
-      innerStream = await this.#mapper(t);
+      innerStream = await this.#mapper(t, indexKey);
       if (
         !equalIndexFields(innerStream.getIndexFields(), this.#mappedIndexFields)
       ) {
@@ -1358,11 +1358,11 @@ class FlatMapStream<
   U extends GenericStreamItem,
 > extends QueryStream<U> {
   #stream: QueryStream<T>;
-  #mapper: (doc: T) => Promise<QueryStream<U>>;
+  #mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>;
   #mappedIndexFields: string[];
   constructor(
     stream: QueryStream<T>,
-    mapper: (doc: T) => Promise<QueryStream<U>>,
+    mapper: (doc: T, indexKey: IndexKey) => Promise<QueryStream<U>>,
     mappedIndexFields: string[]
   ) {
     super();
@@ -1407,19 +1407,51 @@ class FlatMapStream<
       upperBoundInclusive:
         innerUpperBound.length === 0 ? indexBounds.upperBoundInclusive : true,
     };
-    const innerIndexBounds = {
-      lowerBound: innerLowerBound,
-      lowerBoundInclusive:
-        innerLowerBound.length === 0 ? true : indexBounds.lowerBoundInclusive,
-      upperBound: innerUpperBound,
-      upperBoundInclusive:
-        innerUpperBound.length === 0 ? true : indexBounds.upperBoundInclusive,
+    // The index key of a flatMap stream is [outerKey..., innerKey...], so an
+    // inner bound taken from a cursor only describes the boundary parent — the
+    // one whose outer key the cursor landed in. Applying it to every parent
+    // clips unrelated children, and because the inner stream intersects it with
+    // its own equality bounds the result is usually an inverted range, which
+    // silently drops rows and repeats others. Restrict each parent by only the
+    // bounds that actually belong to it.
+    const unrestricted = {
+      lowerBound: [] as IndexKey,
+      lowerBoundInclusive: true,
+      upperBound: [] as IndexKey,
+      upperBoundInclusive: true,
+    };
+    const isBoundaryParent = (parentKey: IndexKey, bound: IndexKey) =>
+      bound.length === outerLength &&
+      compareKeys(
+        { value: parentKey, kind: 'exact' },
+        { value: bound, kind: 'exact' }
+      ) === 0;
+    const innerBoundsForParent = (parentKey: IndexKey) => {
+      const atLowerBound =
+        innerLowerBound.length > 0 &&
+        isBoundaryParent(parentKey, outerLowerBound);
+      const atUpperBound =
+        innerUpperBound.length > 0 &&
+        isBoundaryParent(parentKey, outerUpperBound);
+      if (!(atLowerBound || atUpperBound)) {
+        return unrestricted;
+      }
+      return {
+        lowerBound: atLowerBound ? innerLowerBound : unrestricted.lowerBound,
+        lowerBoundInclusive: atLowerBound
+          ? indexBounds.lowerBoundInclusive
+          : true,
+        upperBound: atUpperBound ? innerUpperBound : unrestricted.upperBound,
+        upperBoundInclusive: atUpperBound
+          ? indexBounds.upperBoundInclusive
+          : true,
+      };
     };
     return new FlatMapStream(
       this.#stream.narrow(outerIndexBounds),
-      async (t) => {
-        const innerStream = await this.#mapper(t);
-        return innerStream.narrow(innerIndexBounds);
+      async (t, parentKey) => {
+        const innerStream = await this.#mapper(t, parentKey);
+        return innerStream.narrow(innerBoundsForParent(parentKey));
       },
       this.#mappedIndexFields
     );

--- a/packages/kitcn/src/orm/where-clause-compiler.test.ts
+++ b/packages/kitcn/src/orm/where-clause-compiler.test.ts
@@ -34,7 +34,7 @@ describe('WhereClauseCompiler advanced index planning', () => {
     expect(result.probeFilters).toHaveLength(2);
   });
 
-  test('plans isNull as indexed equality to null', () => {
+  test('plans isNull as an index range covering absent and null keys', () => {
     const compiler = new WhereClauseCompiler('users', [
       { indexName: 'by_deleted_at', indexFields: ['deletedAt'] },
     ]);
@@ -43,9 +43,15 @@ describe('WhereClauseCompiler advanced index planning', () => {
       isNull(fieldRef<number | null>('deletedAt') as any)
     ) as any;
 
-    expect(result.strategy).toBe('singleIndex');
+    expect(result.strategy).toBe('rangeIndex');
     expect(result.selectedIndex?.indexName).toBe('by_deleted_at');
+    // `<= null` spans the {undefined, null} prefix of Convex's value order, so
+    // rows whose column was never written stay in the scan.
     expect(result.indexFilters).toHaveLength(1);
+    expect(result.indexFilters[0].operator).toBe('lte');
+    expect(result.indexFilters[0].operands[1]).toBeNull();
+    // The expression is retained so over-fetched rows are re-verified.
+    expect(result.postFilters).toHaveLength(1);
   });
 
   test('plans startsWith as index range', () => {

--- a/packages/kitcn/src/orm/where-clause-compiler.ts
+++ b/packages/kitcn/src/orm/where-clause-compiler.ts
@@ -22,6 +22,7 @@ import {
   gte,
   isFieldReference,
   lt,
+  lte,
 } from './filter-expression';
 
 // ============================================================================
@@ -288,12 +289,18 @@ export class WhereClauseCompiler {
       return null;
     }
 
+    // `isNull` means null-or-absent everywhere else in the ORM, and Convex
+    // stores an omitted column as a missing field whose index key is
+    // `undefined`. `undefined` sorts immediately before `null` in Convex's
+    // total value order, so `<= null` is exactly the {undefined, null} range.
+    // An `eq(field, null)` probe would scan only half of it and silently drop
+    // every row that never had the column written.
     return {
-      strategy: 'singleIndex',
+      strategy: 'rangeIndex',
       selectedIndex,
-      indexFilters: [eq(fieldRef(operand.fieldName) as any, null)],
+      indexFilters: [lte(fieldRef(operand.fieldName) as any, null as any)],
       probeFilters: [],
-      postFilters: [],
+      postFilters: [expression],
     };
   }
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Fixes four `critical` ORM bugs found in an aggressive correctness sweep — each one silently returns wrong data or never terminates, and none of them throws, so an app hits them with no signal.

`limit` was pushed into Convex's `take()` before the JavaScript post-fetch pass, so `like`/`contains`/`endsWith`/`ilike` plus `limit` returned the first N rows of the *unfiltered* scan and then discarded almost all of them (usually leaving `[]`); reads now go through the stream path where `filterWith` runs as rows are pulled, so `take` still stops early but counts matches, and `offset` skips matches too — the same placeholder also made `NOT { like: ... }` compile to `q.not(true)` and match nothing.

`isNull` planned `eq(field, null)` with no post-filter, so adding an index to a nullable column silently dropped every row whose column was never written; it now plans the range `<= null`, which is exactly the `{undefined, null}` prefix of Convex's value order.

`flatMap` pagination applied the cursor's inner-key bound to every parent instead of only the boundary parent, dropping and duplicating children after page one; the parent's index key is now threaded through the mapper, and soft cascade deletes no longer reschedule themselves forever, since the re-query now excludes already-soft-deleted rows.

Every fix is test-first (9 new regression tests, each confirmed red before the fix) and the full `bun check` gate passes: `bun test` 1013 pass, `vitest` 610 pass, typecheck clean, package build clean, `test:cli` 123 pass, `test:concave` pass, `fixtures:check` clean — the second commit is an unrelated `fixtures:sync` picking up upstream `@base-ui/react` 1.7.0 and `lucide-react` 1.31.0, which was needed to get the gate green.
