### PR TITLE
fix(orm): RLS fails closed for roles, nullish values, junction tables

### DIFF
--- a/.agents/skills/kitcn/references/features/orm.md
+++ b/.agents/skills/kitcn/references/features/orm.md
@@ -922,11 +922,21 @@ rlsPolicy("admin_only", {
   using: (ctx, t) => eq(t.ownerId, ctx.viewerId),
 });
 
-// Provide roleResolver
+// roleResolver is required by any policy scoped to a named role
 const ormDb = orm.db(ctx, {
   rls: { ctx, roleResolver: (ctx) => ctx.roles ?? [] },
 });
 ```
+
+**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
+
+### Null handling
+
+Policy expressions use SQL null semantics: a comparison against a missing document field or a missing context value is unknown, and unknown denies. An unauthenticated caller (`ctx.viewerId` is `undefined`) never matches rows whose column is unset. Use `isNull` to match absent columns on purpose.
+
+### Relations
+
+`with` enforces the related table's policies, and for many-to-many relations the junction table's policies as well, so a caller only traverses links it may read.
 
 **Important:** `ctx.db` bypasses RLS. Only `ctx.orm` enforces policies. FK cascade fan-out also bypasses child-table RLS.
 

--- a/.agents/skills/kitcn/references/features/orm.md
+++ b/.agents/skills/kitcn/references/features/orm.md
@@ -928,7 +928,7 @@ const ormDb = orm.db(ctx, {
 });
 ```
 
-**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
+**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. Queries and mutations validate this per table before reading rows, so an empty table throws too. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
 
 ### Null handling
 

--- a/.changeset/orm-rls-fail-closed.md
+++ b/.changeset/orm-rls-fail-closed.md
@@ -6,9 +6,11 @@
 
 - Require `rls.roleResolver` for policies scoped with `to`. A role-scoped policy
   previously applied to every caller when no resolver was configured; it now
-  throws `RLS_ROLE_RESOLVER_REQUIRED`. SQL pseudo-roles (`public`,
-  `current_user`, `current_role`, `session_user`) apply to everyone and still
-  need no resolver.
+  throws `RLS_ROLE_RESOLVER_REQUIRED`. Queries and mutations check this for
+  every table they touch before reading rows, so the error depends only on
+  configuration and not on whether the table holds rows. SQL pseudo-roles
+  (`public`, `current_user`, `current_role`, `session_user`) apply to everyone
+  and still need no resolver.
 
 ```ts
 // Before

--- a/.changeset/orm-rls-fail-closed.md
+++ b/.changeset/orm-rls-fail-closed.md
@@ -1,0 +1,47 @@
+---
+"kitcn": minor
+---
+
+## Breaking changes
+
+- Require `rls.roleResolver` for policies scoped with `to`. A role-scoped policy
+  previously applied to every caller when no resolver was configured; it now
+  throws `RLS_ROLE_RESOLVER_REQUIRED`. SQL pseudo-roles (`public`,
+  `current_user`, `current_role`, `session_user`) apply to everyone and still
+  need no resolver.
+
+```ts
+// Before
+const ormDb = orm.db(ctx, { rls: { ctx } });
+
+// After
+const ormDb = orm.db(ctx, {
+  rls: { ctx, roleResolver: (ctx) => ctx.roles ?? [] },
+});
+```
+
+- Deny RLS policy comparisons against a missing value, following SQL null
+  semantics. A policy written as `eq(column, null)` now denies instead of
+  matching explicitly-null columns, and an unauthenticated caller no longer
+  matches rows whose owner column was never set. Use `isNull` to match absent
+  or null columns.
+
+```ts
+// Before
+rlsPolicy('read_unassigned', {
+  for: 'select',
+  using: (ctx, t) => eq(t.ownerId, null),
+});
+
+// After
+rlsPolicy('read_unassigned', {
+  for: 'select',
+  using: (ctx, t) => isNull(t.ownerId),
+});
+```
+
+## Patches
+
+- Fix many-to-many relations ignoring the junction table's RLS policies, which
+  revealed which rows other users were linked to. Loading a relation with `with`
+  now enforces the junction table's policies alongside the related table's.

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -12,6 +12,7 @@ import {
   extractRelationsConfig,
   id,
   index,
+  notInArray,
   rlsPolicy,
   rlsRole,
   text,
@@ -75,6 +76,20 @@ const nullableSecrets = convexTable(
     rlsPolicy('nullable_insert_own', {
       for: 'insert',
       withCheck: (ctx) => eq(t.ownerId, ctx.viewerId),
+    }),
+  ]
+);
+
+const excludedSecrets = convexTable(
+  'rls_excluded_secrets',
+  {
+    value: text().notNull(),
+    ownerId: id('rls_users').notNull(),
+  },
+  (t) => [
+    rlsPolicy('excluded_read', {
+      for: 'select',
+      using: (ctx) => notInArray(t.ownerId, [ctx.viewerId]),
     }),
   ]
 );
@@ -179,6 +194,7 @@ const tables = {
   rls_users: users,
   rls_secrets: secrets,
   rls_nullable_secrets: nullableSecrets,
+  rls_excluded_secrets: excludedSecrets,
   rls_orgs: orgs,
   rls_memberships: memberships,
   rls_tasks: tasks,
@@ -196,6 +212,7 @@ const schema = defineSchema(tables, {
 const relations = defineRelations(tables, (r) => ({
   rls_secrets: {},
   rls_nullable_secrets: {},
+  rls_excluded_secrets: {},
   rls_orgs: {},
   rls_memberships: {},
   rls_tasks: {},
@@ -547,6 +564,11 @@ describe('RLS', () => {
       await expect(
         ctx.orm.query.rls_users.findMany({ with: { roleDocs: true } })
       ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+      await expect(
+        ctx.orm.query.rls_users.findMany({
+          where: { roleDocs: { value: 'allowed' } },
+        })
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
     });
   });
 
@@ -631,6 +653,19 @@ describe('RLS', () => {
     await expect(async () => {
       await ctx.orm.insert(nullableSecrets).values({ value: 'ownerless' });
     }).rejects.toThrowError(/RLS/);
+  });
+
+  it('denies notInArray policies when a context list member is nullish', async ({
+    ctx,
+  }) => {
+    const ownerId = await ctx.db.insert('rls_users', { name: 'Owner' });
+    await ctx.db.insert('rls_excluded_secrets', {
+      value: 'private',
+      ownerId,
+    });
+
+    const anonymous = await ctx.orm.query.rls_excluded_secrets.findMany();
+    expect(anonymous).toHaveLength(0);
   });
 
   it('applies through-table policies when loading many-to-many relations', async ({

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -60,6 +60,44 @@ const secrets = convexTable(
   ]
 );
 
+const nullableSecrets = convexTable(
+  'rls_nullable_secrets',
+  {
+    value: text().notNull(),
+    ownerId: id('rls_users'),
+  },
+  (t) => [
+    index('by_owner').on(t.ownerId),
+    rlsPolicy('nullable_read_own', {
+      for: 'select',
+      using: (ctx) => eq(t.ownerId, ctx.viewerId),
+    }),
+    rlsPolicy('nullable_insert_own', {
+      for: 'insert',
+      withCheck: (ctx) => eq(t.ownerId, ctx.viewerId),
+    }),
+  ]
+);
+
+const orgs = convexTable('rls_orgs', {
+  name: text().notNull(),
+});
+
+const memberships = convexTable(
+  'rls_memberships',
+  {
+    userId: id('rls_users').notNull(),
+    orgId: id('rls_orgs').notNull(),
+  },
+  (t) => [
+    index('by_user').on(t.userId),
+    rlsPolicy('memberships_read_own', {
+      for: 'select',
+      using: (ctx) => eq(t.userId, ctx.viewerId),
+    }),
+  ]
+);
+
 const linked = convexTable.withRLS('rls_linked', {
   value: text().notNull(),
 });
@@ -75,6 +113,20 @@ const roleDocs = convexTable(
     rlsPolicy('role_read', {
       for: 'select',
       to: adminRole,
+      using: () => eq(t.value, 'allowed'),
+    }),
+  ]
+);
+
+const pseudoRoleDocs = convexTable(
+  'rls_pseudo_role_docs',
+  {
+    value: text().notNull(),
+  },
+  (t) => [
+    rlsPolicy('pseudo_role_read', {
+      for: 'select',
+      to: 'current_user',
       using: () => eq(t.value, 'allowed'),
     }),
   ]
@@ -108,17 +160,38 @@ const locked = convexTable.withRLS('rls_locked', {
 const tables = {
   rls_users: users,
   rls_secrets: secrets,
+  rls_nullable_secrets: nullableSecrets,
+  rls_orgs: orgs,
+  rls_memberships: memberships,
   rls_tasks: tasks,
   rls_locked: locked,
   rls_linked: linked,
   rls_role_docs: roleDocs,
+  rls_pseudo_role_docs: pseudoRoleDocs,
 };
 const schema = defineSchema(tables, {
   defaults: {
     defaultLimit: 100,
   },
 });
-const relations = defineRelations(tables);
+const relations = defineRelations(tables, (r) => ({
+  rls_secrets: {},
+  rls_nullable_secrets: {},
+  rls_orgs: {},
+  rls_memberships: {},
+  rls_tasks: {},
+  rls_locked: {},
+  rls_linked: {},
+  rls_role_docs: {},
+  rls_pseudo_role_docs: {},
+  rls_users: {
+    orgs: r.many.rls_orgs({
+      from: r.rls_users.id.through(r.rls_memberships.userId),
+      to: r.rls_orgs.id.through(r.rls_memberships.orgId),
+      alias: 'rls-user-orgs',
+    }),
+  },
+}));
 const edges = extractRelationsConfig(relations);
 
 const it = baseIt.extend<{ ctx: any }>({
@@ -391,6 +464,106 @@ describe('RLS', () => {
     ctx.roles = ['admin'];
     const allowed = await ctx.orm.query.rls_role_docs.findMany();
     expect(allowed).toHaveLength(1);
+  });
+
+  it('throws instead of granting role-scoped policies without a roleResolver', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      // No roleResolver wired: a `to:` policy must never apply to everyone.
+      const ctx = withOrm(baseCtx, relations);
+      await ctx.db.insert('rls_role_docs', { value: 'allowed' });
+
+      await expect(ctx.orm.query.rls_role_docs.findMany()).rejects.toThrow(
+        /RLS_ROLE_RESOLVER_REQUIRED/
+      );
+    });
+  });
+
+  it('applies SQL pseudo-role policies without a roleResolver', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      // `current_user` always resolves to the caller, so it needs no resolver.
+      const ctx = withOrm(baseCtx, relations);
+      await ctx.db.insert('rls_pseudo_role_docs', { value: 'allowed' });
+      await ctx.db.insert('rls_pseudo_role_docs', { value: 'blocked' });
+
+      const rows = await ctx.orm.query.rls_pseudo_role_docs.findMany();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].value).toBe('allowed');
+    });
+  });
+
+  it('applies SQL pseudo-role policies when a roleResolver returns no roles', async ({
+    ctx,
+  }) => {
+    await ctx.db.insert('rls_pseudo_role_docs', { value: 'allowed' });
+    await ctx.db.insert('rls_pseudo_role_docs', { value: 'blocked' });
+
+    ctx.roles = [];
+    const rows = await ctx.orm.query.rls_pseudo_role_docs.findMany();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value).toBe('allowed');
+  });
+
+  it('still bypasses role-scoped policies via skipRules without a roleResolver', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const ctx = withOrm(baseCtx, relations);
+      await ctx.db.insert('rls_role_docs', { value: 'allowed' });
+
+      const rows = await ctx.orm.skipRules.query.rls_role_docs.findMany();
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  it('denies reads when the policy column and context value are both nullish', async ({
+    ctx,
+  }) => {
+    const viewerId = await ctx.db.insert('rls_users', { name: 'Viewer' });
+    await ctx.db.insert('rls_nullable_secrets', { value: 'ownerless' });
+    await ctx.db.insert('rls_nullable_secrets', {
+      value: 'owned',
+      ownerId: viewerId,
+    });
+
+    // Unauthenticated caller: ctx.viewerId is undefined.
+    const anonymous = await ctx.orm.query.rls_nullable_secrets.findMany();
+    expect(anonymous).toHaveLength(0);
+
+    ctx.viewerId = viewerId;
+    const owned = await ctx.orm.query.rls_nullable_secrets.findMany();
+    expect(owned).toHaveLength(1);
+    expect(owned[0].value).toBe('owned');
+  });
+
+  it('blocks anonymous inserts of rows with a nullish policy column', async ({
+    ctx,
+  }) => {
+    await expect(async () => {
+      await ctx.orm.insert(nullableSecrets).values({ value: 'ownerless' });
+    }).rejects.toThrowError(/RLS/);
+  });
+
+  it('applies through-table policies when loading many-to-many relations', async ({
+    ctx,
+  }) => {
+    const viewerId = await ctx.db.insert('rls_users', { name: 'Viewer' });
+    const otherId = await ctx.db.insert('rls_users', { name: 'Other' });
+    const orgId = await ctx.db.insert('rls_orgs', { name: 'Acme' });
+
+    await ctx.db.insert('rls_memberships', { userId: viewerId, orgId });
+    await ctx.db.insert('rls_memberships', { userId: otherId, orgId });
+
+    ctx.viewerId = viewerId;
+
+    const rows = await ctx.orm.query.rls_users.findMany({
+      with: { orgs: true },
+    });
+
+    const orgCountByUser = Object.fromEntries(
+      rows.map((row: any) => [row.name, row.orgs.length])
+    );
+    expect(orgCountByUser).toEqual({ Viewer: 1, Other: 0 });
   });
 
   it('allows bypass via ctx.orm.skipRules', async ({ ctx }) => {

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -520,6 +520,25 @@ describe('RLS', () => {
     });
   });
 
+  it('validates role-scoped policies before starting the root read', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const guardedDb = new Proxy(baseCtx.db, {
+        get(target, property, receiver) {
+          if (property === 'query' || property === 'get') {
+            throw new Error('ROOT_READ_STARTED');
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const ctx = withOrm({ ...baseCtx, db: guardedDb }, relations);
+
+      await expect(ctx.orm.query.rls_role_docs.findMany()).rejects.toThrow(
+        /RLS_ROLE_RESOLVER_REQUIRED/
+      );
+    });
+  });
+
   it('throws for role-scoped relation targets when the parent has no rows', async () => {
     const t = convexTest(schema);
     await t.run(async (baseCtx) => {

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -108,12 +108,30 @@ const roleDocs = convexTable(
   'rls_role_docs',
   {
     value: text().notNull(),
+    ownerId: id('rls_users'),
   },
   (t) => [
+    index('by_owner').on(t.ownerId),
     rlsPolicy('role_read', {
       for: 'select',
       to: adminRole,
       using: () => eq(t.value, 'allowed'),
+    }),
+  ]
+);
+
+const roleWrites = convexTable(
+  'rls_role_writes',
+  {
+    value: text().notNull(),
+  },
+  (t) => [
+    index('by_value').on(t.value),
+    rlsPolicy('role_write', {
+      for: 'all',
+      to: adminRole,
+      using: () => eq(t.value, 'allowed'),
+      withCheck: () => eq(t.value, 'allowed'),
     }),
   ]
 );
@@ -167,6 +185,7 @@ const tables = {
   rls_locked: locked,
   rls_linked: linked,
   rls_role_docs: roleDocs,
+  rls_role_writes: roleWrites,
   rls_pseudo_role_docs: pseudoRoleDocs,
 };
 const schema = defineSchema(tables, {
@@ -183,12 +202,18 @@ const relations = defineRelations(tables, (r) => ({
   rls_locked: {},
   rls_linked: {},
   rls_role_docs: {},
+  rls_role_writes: {},
   rls_pseudo_role_docs: {},
   rls_users: {
     orgs: r.many.rls_orgs({
       from: r.rls_users.id.through(r.rls_memberships.userId),
       to: r.rls_orgs.id.through(r.rls_memberships.orgId),
       alias: 'rls-user-orgs',
+    }),
+    roleDocs: r.many.rls_role_docs({
+      from: r.rls_users.id,
+      to: r.rls_role_docs.ownerId,
+      alias: 'rls-user-role-docs',
     }),
   },
 }));
@@ -476,6 +501,51 @@ describe('RLS', () => {
       await expect(ctx.orm.query.rls_role_docs.findMany()).rejects.toThrow(
         /RLS_ROLE_RESOLVER_REQUIRED/
       );
+    });
+  });
+
+  it('throws for role-scoped policies on an empty table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      // Same misconfiguration as above with no stored rows: configuration
+      // errors must not wait for the table's first insert.
+      const ctx = withOrm(baseCtx, relations);
+
+      await expect(ctx.orm.query.rls_role_docs.findMany()).rejects.toThrow(
+        /RLS_ROLE_RESOLVER_REQUIRED/
+      );
+      await expect(ctx.orm.query.rls_role_docs.findFirst()).rejects.toThrow(
+        /RLS_ROLE_RESOLVER_REQUIRED/
+      );
+    });
+  });
+
+  it('throws for role-scoped relation targets when the parent has no rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const ctx = withOrm(baseCtx, relations);
+
+      await expect(
+        ctx.orm.query.rls_users.findMany({ with: { roleDocs: true } })
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+    });
+  });
+
+  it('throws for role-scoped policies on writes that match no rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const ctx = withOrm(baseCtx, relations);
+
+      await expect(
+        ctx.orm
+          .update(roleWrites)
+          .set({ value: 'allowed' })
+          .where(eq(roleWrites.value, 'missing'))
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+
+      await expect(
+        ctx.orm.delete(roleWrites).where(eq(roleWrites.value, 'missing'))
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
     });
   });
 

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -8,6 +8,7 @@ import {
   convexTable,
   defineRelations,
   defineSchema,
+  discriminator,
   eq,
   extractRelationsConfig,
   id,
@@ -151,6 +152,16 @@ const roleWrites = convexTable(
   ]
 );
 
+const auditEvents = convexTable('rls_audit_events', {
+  eventType: discriminator({
+    variants: {
+      role_doc: {
+        roleDocId: id('rls_role_docs').notNull(),
+      },
+    },
+  }),
+});
+
 const pseudoRoleDocs = convexTable(
   'rls_pseudo_role_docs',
   {
@@ -202,6 +213,7 @@ const tables = {
   rls_linked: linked,
   rls_role_docs: roleDocs,
   rls_role_writes: roleWrites,
+  rls_audit_events: auditEvents,
   rls_pseudo_role_docs: pseudoRoleDocs,
 };
 const schema = defineSchema(tables, {
@@ -226,6 +238,13 @@ const relations = defineRelations(tables, (r) => ({
   rls_linked: {},
   rls_role_docs: {},
   rls_role_writes: {},
+  rls_audit_events: {
+    roleDoc: r.one.rls_role_docs({
+      from: r.rls_audit_events.roleDocId,
+      to: r.rls_role_docs.id,
+      optional: true,
+    }),
+  },
   rls_pseudo_role_docs: {},
   rls_users: {
     orgs: r.many.rls_orgs({
@@ -591,6 +610,38 @@ describe('RLS', () => {
             },
           },
         })
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+    });
+  });
+
+  it('throws for RLS relation counts when the parent has no rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const ctx = withOrm(baseCtx, relations);
+
+      await expect(
+        ctx.orm.query.rls_users.findMany({
+          with: { _count: { roleDocs: true } },
+        })
+      ).rejects.toThrow(/COUNT_RLS_UNSUPPORTED/);
+    });
+  });
+
+  it('preflights RLS relations added by withVariants before reading', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const guardedDb = new Proxy(baseCtx.db, {
+        get(target, property, receiver) {
+          if (property === 'query' || property === 'get') {
+            throw new Error('ROOT_READ_STARTED');
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const ctx = withOrm({ ...baseCtx, db: guardedDb }, relations);
+
+      await expect(
+        ctx.orm.query.rls_audit_events.findMany({ withVariants: true })
       ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
     });
   });

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -590,6 +590,31 @@ describe('RLS', () => {
     });
   });
 
+  it('validates mutation roles before collecting candidate rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const guardedDb = new Proxy(baseCtx.db, {
+        get(target, property, receiver) {
+          if (property === 'query' || property === 'get') {
+            throw new Error('MUTATION_READ_STARTED');
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      const ctx = withOrm({ ...baseCtx, db: guardedDb }, relations);
+
+      await expect(
+        ctx.orm
+          .update(roleWrites)
+          .set({ value: 'allowed' })
+          .where(eq(roleWrites.value, 'missing'))
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+      await expect(
+        ctx.orm.delete(roleWrites).where(eq(roleWrites.value, 'missing'))
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+    });
+  });
+
   it('applies SQL pseudo-role policies without a roleResolver', async () => {
     const t = convexTest(schema);
     await t.run(async (baseCtx) => {

--- a/convex/orm/rls.test.ts
+++ b/convex/orm/rls.test.ts
@@ -213,7 +213,13 @@ const relations = defineRelations(tables, (r) => ({
   rls_secrets: {},
   rls_nullable_secrets: {},
   rls_excluded_secrets: {},
-  rls_orgs: {},
+  rls_orgs: {
+    users: r.many.rls_users({
+      from: r.rls_orgs.id.through(r.rls_memberships.orgId),
+      to: r.rls_users.id.through(r.rls_memberships.userId),
+      alias: 'rls-org-users',
+    }),
+  },
   rls_memberships: {},
   rls_tasks: {},
   rls_locked: {},
@@ -567,6 +573,23 @@ describe('RLS', () => {
       await expect(
         ctx.orm.query.rls_users.findMany({
           where: { roleDocs: { value: 'allowed' } },
+        })
+      ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
+    });
+  });
+
+  it('throws for nested relation filters when the root has no rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const ctx = withOrm(baseCtx, relations);
+
+      await expect(
+        ctx.orm.query.rls_orgs.findMany({
+          with: {
+            users: {
+              where: { roleDocs: { value: 'allowed' } },
+            },
+          },
         })
       ).rejects.toThrow(/RLS_ROLE_RESOLVER_REQUIRED/);
     });

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -76,8 +76,8 @@ Closure matrix:
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | seventh GitHub finding fixed; final autoreview rerun pending |
-| repository check | yes | `bun check` | rerun pending after count/variant preflight repairs |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: final autoreview clean at 0.97 confidence; GitHub thread resolution pending |
+| repository check | yes | `bun check` | passed after count/variant preflight repairs |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -111,9 +111,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | rerun pending after count/variant preflight repairs |
+| Repository check | yes | Run `bun check` | passed end to end after count/variant preflight repairs |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after count/variant preflight repairs |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: no accepted/actionable findings, correctness confidence 0.97 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | in_progress | seven GitHub findings fixed; 30 RLS + 23 evaluator tests and build/types/lint passed | final autoreview and `bun check` |
+| Review/checks | completed | seven GitHub findings fixed; 30 RLS + 23 evaluator tests, build/types/lint, autoreview, and `bun check` passed | publish and resolve threads |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -159,6 +159,8 @@ Verification evidence:
 - Count/variant preflight repair proof -> two red regressions resolved to 30
   passing RLS tests; 23 evaluator tests, package build, root typecheck, and lint
   pass.
+- Final count/variant autoreview -> no accepted/actionable findings,
+  correctness confidence 0.97; exact `bun check` passed end to end.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -172,12 +174,13 @@ Timeline:
 - 2026-08-14T21:37:00Z Added nested relation-filter preflight after a fresh GitHub review finding.
 - 2026-08-14T21:43:00Z Final autoreview and repository check passed after the nested-filter repair.
 - 2026-08-14T21:54:00Z Added empty-parent count and pre-read withVariants validation after two fresh GitHub findings.
+- 2026-08-14T22:00:00Z Final autoreview and repository check passed after all seven review repairs.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Final autoreview/check, publish fixes, resolve GitHub threads, merge |
+| Where am I? | Delivery |
+| Where am I going? | Publish fixes, resolve GitHub threads, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -69,15 +69,15 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 28 Vitest RLS + 23 Bun evaluator tests |
+| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 30 Vitest RLS + 23 Bun evaluator tests |
 | package/API/build | yes | Package build/types | passed |
 | generated output | yes | Package skill owner to `.agents` mirror audit | passed: regenerated and byte-identical |
 | fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: final autoreview clean at 0.98 confidence; GitHub thread resolution pending |
-| repository check | yes | `bun check` | passed after nested relation-filter repair |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | seventh GitHub finding fixed; final autoreview rerun pending |
+| repository check | yes | `bun check` | rerun pending after count/variant preflight repairs |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -105,15 +105,15 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused RLS tests | passed: 28 RLS + 23 evaluator tests; includes query/mutation pre-read, nested relation-where, and null-list guards |
+| Targeted behavior proof | yes | Run focused RLS tests | passed: 30 RLS + 23 evaluator tests; includes query/mutation pre-read, nested relation-where, count, withVariants, and null-list guards |
 | Source/generated audit | yes | Prove package skill to `.agents` mirror parity | passed: sync command plus `cmp` |
 | Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | passed; scenarios N/A because scaffold output unchanged |
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | passed end to end after nested relation-filter repair |
+| Repository check | yes | Run `bun check` | rerun pending after count/variant preflight repairs |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | passed: no accepted/actionable findings, correctness confidence 0.98 |
+| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after count/variant preflight repairs |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | completed | five GitHub findings fixed; 28 RLS + 23 evaluator tests, build/types/lint, autoreview, and `bun check` passed | publish and resolve thread |
+| Review/checks | in_progress | seven GitHub findings fixed; 30 RLS + 23 evaluator tests and build/types/lint passed | final autoreview and `bun check` |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -156,6 +156,9 @@ Verification evidence:
   RLS tests; 23 evaluator tests, package build, root typecheck, and lint pass.
 - Final nested-filter autoreview -> no accepted/actionable findings,
   correctness confidence 0.98; exact `bun check` passed end to end.
+- Count/variant preflight repair proof -> two red regressions resolved to 30
+  passing RLS tests; 23 evaluator tests, package build, root typecheck, and lint
+  pass.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -168,12 +171,13 @@ Timeline:
 - 2026-08-14T21:34:00Z Final autoreview and exact repository check passed after all four repairs.
 - 2026-08-14T21:37:00Z Added nested relation-filter preflight after a fresh GitHub review finding.
 - 2026-08-14T21:43:00Z Final autoreview and repository check passed after the nested-filter repair.
+- 2026-08-14T21:54:00Z Added empty-parent count and pre-read withVariants validation after two fresh GitHub findings.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Publish fix, resolve GitHub thread, merge |
+| Where am I? | Review/checks |
+| Where am I going? | Final autoreview/check, publish fixes, resolve GitHub threads, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
@@ -202,3 +206,9 @@ Review fixes:
 - Nested relation `where` filters were absent from recursive preflight ->
   accepted -> each relation merges its derived filter plan with explicit `with`
   before recursion; empty-parent regression proof added.
+- RLS relation counts skipped validation on empty parents -> accepted ->
+  selected count targets and required junction tables validate before root
+  reads; empty-parent regression proof added.
+- `withVariants` relations were added only during finalization -> accepted ->
+  execute resolves the effective polymorphic relation plan before the root
+  read; guarded regression proof added.

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -76,8 +76,8 @@ Closure matrix:
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | third GitHub finding fixed; autoreview rerun pending |
-| repository check | yes | `bun check` | rerun pending after mutation preflight repair |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: final autoreview clean at 0.98 confidence; GitHub thread resolution pending |
+| repository check | yes | `bun check` | passed after the mutation preflight repair |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -111,9 +111,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | rerun pending after mutation preflight repair |
+| Repository check | yes | Run `bun check` | passed end to end after the mutation preflight repair |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after mutation preflight repair |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: no accepted/actionable findings, correctness confidence 0.98 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | in_progress | third GitHub finding fixed; 27 RLS + 23 evaluator tests, build/types/lint passed | autoreview and `bun check` rerun |
+| Review/checks | completed | four GitHub findings fixed; 27 RLS + 23 evaluator tests, build/types/lint, autoreview, and `bun check` passed | publish and resolve threads |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -150,6 +150,8 @@ Verification evidence:
   0.94; exact `bun check` rerun passed end to end.
 - Mutation preflight repair proof -> 27 RLS Vitest tests and 23 evaluator Bun
   tests passed; package build, root typecheck, and lint passed again.
+- Final autoreview -> no accepted/actionable findings, correctness confidence
+  0.98; exact `bun check` passed end to end after the last repair.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -159,12 +161,13 @@ Timeline:
 - 2026-08-14T21:19:00Z Fixed `NOT IN` null-member semantics and relational-where preflight gaps from GitHub review.
 - 2026-08-14T21:26:00Z Fresh autoreview and exact repository check passed after both feedback repairs.
 - 2026-08-14T21:28:00Z Moved update/delete role validation ahead of every candidate-row read.
+- 2026-08-14T21:34:00Z Final autoreview and exact repository check passed after all four repairs.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Fresh autoreview/check, publish fixes, resolve threads, merge |
+| Where am I? | Delivery |
+| Where am I going? | Publish fixes, resolve GitHub threads, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -69,15 +69,15 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused ORM RLS tests | passed: 25 Vitest tests and type errors clean |
+| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 26 Vitest RLS + 23 Bun evaluator tests |
 | package/API/build | yes | Package build/types | passed |
 | generated output | yes | Package skill owner to `.agents` mirror audit | passed: regenerated and byte-identical |
 | fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: no accepted findings |
-| repository check | yes | `bun check` | passed end to end |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | accepted GitHub findings fixed; autoreview rerun pending |
+| repository check | yes | `bun check` | prior pass predates feedback fixes; rerun pending |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -85,7 +85,7 @@ Work Checklist:
 - [x] Each lane is proven or N/A with a concrete reason.
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [x] Accepted cleanup and review findings are closed.
+- [ ] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: package skill source owner and generated mirror are identified.
@@ -105,15 +105,15 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused RLS tests | passed: 25 tests; includes pre-read guard |
+| Targeted behavior proof | yes | Run focused RLS tests | passed: 26 RLS + 23 evaluator tests; includes pre-read, relation-where, and null-list guards |
 | Source/generated audit | yes | Prove package skill to `.agents` mirror parity | passed: sync command plus `cmp` |
 | Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | passed; scenarios N/A because scaffold output unchanged |
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | passed end to end |
+| Repository check | yes | Run `bun check` | rerun pending after feedback fixes |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | passed: clean branch review, confidence 0.97 |
+| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after feedback fixes |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | completed | focused proof, build, types, lint, deslop, skill sync, Intent gates, agent-native review, autoreview, and `bun check` passed | delivery |
+| Review/checks | in_progress | two GitHub findings fixed; focused proof/build/types/lint passed again | autoreview and `bun check` rerun |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -144,18 +144,21 @@ Verification evidence:
   correctness confidence 0.97.
 - `bun check` -> passed end to end, including all fixtures, verification, and
   runtime scenarios.
+- GitHub feedback repair proof -> 26 RLS Vitest tests and 23 mutation-utils Bun
+  tests passed; package build, root typecheck, and lint passed again.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
 - 2026-08-14T21:04:00Z Rebased onto current main and reconstructed the fail-closed RLS delta.
 - 2026-08-14T21:07:00Z Closed the pre-read validation gap and passed focused/package/agent-native gates.
 - 2026-08-14T21:16:00Z Independent autoreview and exact `bun check` passed.
+- 2026-08-14T21:19:00Z Fixed `NOT IN` null-member semantics and relational-where preflight gaps from GitHub review.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Push, GitHub checks, merge, read-back, final audit |
+| Where am I? | Review/checks |
+| Where am I going? | Autoreview and repository-check reruns, delivery, final audit |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
@@ -173,3 +176,9 @@ Review fixes:
 - Docs promised pre-read policy validation but root reads validated only during
   finalization -> accepted -> moved explicit plan validation before the first
   database read and added a `query`/`get` guard regression test.
+- `notInArray` with a nullish list member returned true for non-matches ->
+  accepted -> SQL tri-state `IN`/`NOT IN` now returns unknown unless a concrete
+  match decides the result; focused evaluator and RLS tests added.
+- Named-role tables referenced only through relational `where` were skipped by
+  empty roots -> accepted -> preflight now walks the relation plan derived from
+  `where`; empty-root regression proof added.

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -76,8 +76,8 @@ Closure matrix:
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | accepted GitHub findings fixed; autoreview rerun pending |
-| repository check | yes | `bun check` | prior pass predates feedback fixes; rerun pending |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | accepted GitHub findings fixed; autoreview clean, confidence 0.94; thread resolution pending |
+| repository check | yes | `bun check` | passed end to end after feedback fixes |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -111,9 +111,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | rerun pending after feedback fixes |
+| Repository check | yes | Run `bun check` | passed end to end after feedback fixes |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after feedback fixes |
+| Autoreview | yes | Resolve every accepted actionable finding | passed rerun: clean, confidence 0.94 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | in_progress | two GitHub findings fixed; focused proof/build/types/lint passed again | autoreview and `bun check` rerun |
+| Review/checks | completed | two GitHub findings fixed; focused proof/build/types/lint, autoreview, and `bun check` passed again | resolve threads and deliver |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -146,6 +146,8 @@ Verification evidence:
   runtime scenarios.
 - GitHub feedback repair proof -> 26 RLS Vitest tests and 23 mutation-utils Bun
   tests passed; package build, root typecheck, and lint passed again.
+- Autoreview rerun -> no accepted/actionable findings, correctness confidence
+  0.94; exact `bun check` rerun passed end to end.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -153,12 +155,13 @@ Timeline:
 - 2026-08-14T21:07:00Z Closed the pre-read validation gap and passed focused/package/agent-native gates.
 - 2026-08-14T21:16:00Z Independent autoreview and exact `bun check` passed.
 - 2026-08-14T21:19:00Z Fixed `NOT IN` null-member semantics and relational-where preflight gaps from GitHub review.
+- 2026-08-14T21:26:00Z Fresh autoreview and exact repository check passed after both feedback repairs.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Autoreview and repository-check reruns, delivery, final audit |
+| Where am I? | Delivery |
+| Where am I going? | Publish fixes, resolve threads, wait checks, merge, read back |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -76,8 +76,8 @@ Closure matrix:
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | fifth GitHub finding fixed; final autoreview rerun pending |
-| repository check | yes | `bun check` | rerun pending after nested relation-filter repair |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: final autoreview clean at 0.98 confidence; GitHub thread resolution pending |
+| repository check | yes | `bun check` | passed after nested relation-filter repair |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -111,9 +111,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | rerun pending after nested relation-filter repair |
+| Repository check | yes | Run `bun check` | passed end to end after nested relation-filter repair |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after nested relation-filter repair |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: no accepted/actionable findings, correctness confidence 0.98 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | in_progress | five GitHub findings fixed; 28 RLS + 23 evaluator tests and build/types/lint passed | final autoreview and `bun check` |
+| Review/checks | completed | five GitHub findings fixed; 28 RLS + 23 evaluator tests, build/types/lint, autoreview, and `bun check` passed | publish and resolve thread |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -154,6 +154,8 @@ Verification evidence:
   0.98; exact `bun check` passed end to end after the last repair.
 - Nested relation-filter repair proof -> red regression resolved to 28 passing
   RLS tests; 23 evaluator tests, package build, root typecheck, and lint pass.
+- Final nested-filter autoreview -> no accepted/actionable findings,
+  correctness confidence 0.98; exact `bun check` passed end to end.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -165,12 +167,13 @@ Timeline:
 - 2026-08-14T21:28:00Z Moved update/delete role validation ahead of every candidate-row read.
 - 2026-08-14T21:34:00Z Final autoreview and exact repository check passed after all four repairs.
 - 2026-08-14T21:37:00Z Added nested relation-filter preflight after a fresh GitHub review finding.
+- 2026-08-14T21:43:00Z Final autoreview and repository check passed after the nested-filter repair.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Final autoreview/check, publish fix, resolve GitHub thread, merge |
+| Where am I? | Delivery |
+| Where am I going? | Publish fix, resolve GitHub thread, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -69,15 +69,15 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 26 Vitest RLS + 23 Bun evaluator tests |
+| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 27 Vitest RLS + 23 Bun evaluator tests |
 | package/API/build | yes | Package build/types | passed |
 | generated output | yes | Package skill owner to `.agents` mirror audit | passed: regenerated and byte-identical |
 | fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | accepted GitHub findings fixed; autoreview clean, confidence 0.94; thread resolution pending |
-| repository check | yes | `bun check` | passed end to end after feedback fixes |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | third GitHub finding fixed; autoreview rerun pending |
+| repository check | yes | `bun check` | rerun pending after mutation preflight repair |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -105,15 +105,15 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused RLS tests | passed: 26 RLS + 23 evaluator tests; includes pre-read, relation-where, and null-list guards |
+| Targeted behavior proof | yes | Run focused RLS tests | passed: 27 RLS + 23 evaluator tests; includes query/mutation pre-read, relation-where, and null-list guards |
 | Source/generated audit | yes | Prove package skill to `.agents` mirror parity | passed: sync command plus `cmp` |
 | Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | passed; scenarios N/A because scaffold output unchanged |
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | passed end to end after feedback fixes |
+| Repository check | yes | Run `bun check` | rerun pending after mutation preflight repair |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | passed rerun: clean, confidence 0.94 |
+| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after mutation preflight repair |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | completed | two GitHub findings fixed; focused proof/build/types/lint, autoreview, and `bun check` passed again | resolve threads and deliver |
+| Review/checks | in_progress | third GitHub finding fixed; 27 RLS + 23 evaluator tests, build/types/lint passed | autoreview and `bun check` rerun |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -148,6 +148,8 @@ Verification evidence:
   tests passed; package build, root typecheck, and lint passed again.
 - Autoreview rerun -> no accepted/actionable findings, correctness confidence
   0.94; exact `bun check` rerun passed end to end.
+- Mutation preflight repair proof -> 27 RLS Vitest tests and 23 evaluator Bun
+  tests passed; package build, root typecheck, and lint passed again.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -156,12 +158,13 @@ Timeline:
 - 2026-08-14T21:16:00Z Independent autoreview and exact `bun check` passed.
 - 2026-08-14T21:19:00Z Fixed `NOT IN` null-member semantics and relational-where preflight gaps from GitHub review.
 - 2026-08-14T21:26:00Z Fresh autoreview and exact repository check passed after both feedback repairs.
+- 2026-08-14T21:28:00Z Moved update/delete role validation ahead of every candidate-row read.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Publish fixes, resolve threads, wait checks, merge, read back |
+| Where am I? | Review/checks |
+| Where am I going? | Fresh autoreview/check, publish fixes, resolve threads, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
@@ -185,3 +188,5 @@ Review fixes:
 - Named-role tables referenced only through relational `where` were skipped by
   empty roots -> accepted -> preflight now walks the relation plan derived from
   `where`; empty-root regression proof added.
+- Update/delete collected candidates before role validation -> accepted -> both
+  builders now validate before `query` or `get`; guarded regression proof added.

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -55,7 +55,7 @@ Blocked condition:
 Start Gates:
 | Gate | Applies | Evidence |
 | --- | --- | --- |
-| Active source/plan reconstructed | yes | PR 316 body/files/checks read |
+| Active source/plan reconstructed | yes | PR 316 body, two commits, nine changed files, and prior checks read after rebase onto merge `eddfc083` |
 | Intended delta and exclusions recorded | yes | Objective and Boundaries |
 | Closure matrix classified | yes | Matrix below |
 | GitHub delivery expectation recorded | yes | Merge before PR 317; no auto-release |
@@ -69,76 +69,88 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused ORM RLS tests | pending |
-| package/API/build | yes | Package build/types | pending |
-| generated output | yes | Package skill owner to `.agents` mirror audit | pending |
+| source behavior | yes | Focused ORM RLS tests | passed: 25 Vitest tests and type errors clean |
+| package/API/build | yes | Package build/types | passed |
+| generated output | yes | Package skill owner to `.agents` mirror audit | passed: regenerated and byte-identical |
 | fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
-| docs/package skill | yes | www/package skill/mirror agreement | pending |
-| changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | pending |
-| agent workflow | yes | Published skill discoverability and mirror parity | pending |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | pending |
+| docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
+| changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
+| agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | deslop and agent-native review passed; autoreview pending |
 | repository check | yes | `bun check` | pending |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
 - [ ] Each lane is proven or N/A with a concrete reason.
-- [ ] Generated output was changed through its owner and regenerated.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Generated output was changed through its owner and regenerated.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
 - [ ] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: package skill source owner and generated mirror are identified.
-- [ ] Agent-native pack: ORM RLS action/constraints remain discoverable.
-- [ ] Agent-native pack: package skill mirror parity is proved; `.agents/rules/**` is N/A.
+- [x] Agent-native pack: ORM RLS action/constraints remain discoverable.
+- [x] Agent-native pack: package skill mirror parity is proved; `.agents/rules/**` is N/A.
 - [x] Agent-native pack: installed skill membership is unchanged.
-- [ ] Agent-native pack: package skill guidance represents required behavior and forbidden fail-open behavior.
-- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+- [x] Agent-native pack: package skill guidance represents required behavior and forbidden fail-open behavior.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
-| None yet | 0 | | |
+| Focused `bun test` path omitted `./` and matched no files | 1 | Pass an explicit path | Reached the file; exposed Vitest-only `import.meta.glob` setup |
+| Direct Bun execution cannot provide Vitest `import.meta.glob` | 1 | Run the repository's Vitest owner | `bunx vitest run convex/orm/rls.test.ts` passed |
+| Root `bunx intent validate skills` resolved the unrelated npm package with no binary | 1 | Use the package-local Intent binary | `packages/kitcn/node_modules/.bin/intent validate skills` passed |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused RLS tests | pending |
-| Source/generated audit | yes | Prove package skill to `.agents` mirror parity | pending |
-| Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | pending |
-| Deslop | yes | Run changed-file cleanup review | pending |
-| Agent-native reviewer | yes | Review published skill guidance/mirror | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
+| Targeted behavior proof | yes | Run focused RLS tests | passed: 25 tests; includes pre-read guard |
+| Source/generated audit | yes | Prove package skill to `.agents` mirror parity | passed: sync command plus `cmp` |
+| Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | passed; scenarios N/A because scaffold output unchanged |
+| Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
+| Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
+| Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
 | Repository check | yes | Run `bun check` | pending |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
-| Agent source / generated sync | yes | Verify package skill and installed mirror | pending |
+| Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
-| Agent action discoverability | yes | Source-audit ORM package skill route | pending |
+| Agent action discoverability | yes | Source-audit ORM package skill route | passed: ORM RLS section names required configuration and forbidden fail-open behavior |
 | Helper and template smoke | no | N/A: no workflow helper/template changed | N/A |
-| Agent-native review | yes | Close accepted package-skill findings | pending |
+| Agent-native review | yes | Close accepted package-skill findings | passed: no residual finding |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
+| Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
+| Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
+| Review/checks | in_progress | focused proof, build, types, lint, deslop, skill sync, Intent validation/stale, and agent-native review passed | autoreview and `bun check` |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
 Verification evidence:
 - PR 316 CI and Vercel were green at goal creation; no approval yet.
+- Rebased cleanly onto `kitcn/main` at PR 318 merge `eddfc083`.
+- `bunx vitest run convex/orm/rls.test.ts` -> 25 tests passed; type errors clean.
+- Package build and root typecheck passed.
+- `bun tooling/sync-kitcn-skill.ts`, package-local `intent validate skills`,
+  `bun run intent:stale`, and package/mirror `cmp` passed.
+- Agent-native review -> published ORM route, source owner, generated mirror,
+  docs, and proof command agree; no accepted finding remains.
+- `bun lint:fix` -> 876 files, no fixes; deslop delta has zero net findings.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
+- 2026-08-14T21:04:00Z Rebased onto current main and reconstructed the fail-closed RLS delta.
+- 2026-08-14T21:07:00Z Closed the pre-read validation gap and passed focused/package/agent-native gates.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Review/checks |
+| Where am I going? | Autoreview, repository check, delivery, final audit |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
@@ -153,4 +165,6 @@ Decisions and tradeoffs:
 - Merge before PR 317 to resolve shared ORM ownership once.
 
 Review fixes:
-- Pending.
+- Docs promised pre-read policy validation but root reads validated only during
+  finalization -> accepted -> moved explicit plan validation before the first
+  database read and added a `query`/`get` guard regression test.

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -76,16 +76,16 @@ Closure matrix:
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | deslop and agent-native review passed; autoreview pending |
-| repository check | yes | `bun check` | pending |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: no accepted findings |
+| repository check | yes | `bun check` | passed end to end |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Each lane is proven or N/A with a concrete reason.
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: package skill source owner and generated mirror are identified.
@@ -111,9 +111,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | pending |
+| Repository check | yes | Run `bun check` | passed end to end |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: clean branch review, confidence 0.97 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | in_progress | focused proof, build, types, lint, deslop, skill sync, Intent validation/stale, and agent-native review passed | autoreview and `bun check` |
+| Review/checks | completed | focused proof, build, types, lint, deslop, skill sync, Intent gates, agent-native review, autoreview, and `bun check` passed | delivery |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -140,17 +140,22 @@ Verification evidence:
 - Agent-native review -> published ORM route, source owner, generated mirror,
   docs, and proof command agree; no accepted finding remains.
 - `bun lint:fix` -> 876 files, no fixes; deslop delta has zero net findings.
+- Autoreview against `kitcn/main` -> no accepted/actionable findings,
+  correctness confidence 0.97.
+- `bun check` -> passed end to end, including all fixtures, verification, and
+  runtime scenarios.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
 - 2026-08-14T21:04:00Z Rebased onto current main and reconstructed the fail-closed RLS delta.
 - 2026-08-14T21:07:00Z Closed the pre-read validation gap and passed focused/package/agent-native gates.
+- 2026-08-14T21:16:00Z Independent autoreview and exact `bun check` passed.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Autoreview, repository check, delivery, final audit |
+| Where am I? | Delivery |
+| Where am I going? | Push, GitHub checks, merge, read-back, final audit |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -69,15 +69,15 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 27 Vitest RLS + 23 Bun evaluator tests |
+| source behavior | yes | Focused ORM RLS and tri-state tests | passed: 28 Vitest RLS + 23 Bun evaluator tests |
 | package/API/build | yes | Package build/types | passed |
 | generated output | yes | Package skill owner to `.agents` mirror audit | passed: regenerated and byte-identical |
 | fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
 | docs/package skill | yes | www/package skill/mirror agreement | passed: role/null/relation guidance agrees |
 | changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | passed: minor breaking contract and patches match |
 | agent workflow | yes | Published skill discoverability and mirror parity | passed: ORM reference owns the action and constraints |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | passed: final autoreview clean at 0.98 confidence; GitHub thread resolution pending |
-| repository check | yes | `bun check` | passed after the mutation preflight repair |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | fifth GitHub finding fixed; final autoreview rerun pending |
+| repository check | yes | `bun check` | rerun pending after nested relation-filter repair |
 | GitHub delivery | yes | PR 316 merge/read-back | pending |
 
 Work Checklist:
@@ -105,15 +105,15 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused RLS tests | passed: 27 RLS + 23 evaluator tests; includes query/mutation pre-read, relation-where, and null-list guards |
+| Targeted behavior proof | yes | Run focused RLS tests | passed: 28 RLS + 23 evaluator tests; includes query/mutation pre-read, nested relation-where, and null-list guards |
 | Source/generated audit | yes | Prove package skill to `.agents` mirror parity | passed: sync command plus `cmp` |
 | Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | passed; scenarios N/A because scaffold output unchanged |
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; only unrelated auth fan-out hotspot |
 | Agent-native reviewer | yes | Review published skill guidance/mirror | passed: action route, owner, mirror, docs, and proof are aligned |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | passed end to end after the mutation preflight repair |
+| Repository check | yes | Run `bun check` | rerun pending after nested relation-filter repair |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | passed: no accepted/actionable findings, correctness confidence 0.98 |
+| Autoreview | yes | Resolve every accepted actionable finding | rerun pending after nested relation-filter repair |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
 | Agent source / generated sync | yes | Verify package skill and installed mirror | passed: byte-identical after regeneration |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
@@ -126,7 +126,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | contract, owners, overlap, commits, files, and prior checks reconstructed after rebase | focused proof |
 | Repair | completed | moved explicit RLS-plan validation before root reads and added guarded regression proof | review |
-| Review/checks | completed | four GitHub findings fixed; 27 RLS + 23 evaluator tests, build/types/lint, autoreview, and `bun check` passed | publish and resolve threads |
+| Review/checks | in_progress | five GitHub findings fixed; 28 RLS + 23 evaluator tests and build/types/lint passed | final autoreview and `bun check` |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -152,6 +152,8 @@ Verification evidence:
   tests passed; package build, root typecheck, and lint passed again.
 - Final autoreview -> no accepted/actionable findings, correctness confidence
   0.98; exact `bun check` passed end to end after the last repair.
+- Nested relation-filter repair proof -> red regression resolved to 28 passing
+  RLS tests; 23 evaluator tests, package build, root typecheck, and lint pass.
 
 Timeline:
 - 2026-08-14T18:17:54.580Z Autoclosure plan created.
@@ -162,12 +164,13 @@ Timeline:
 - 2026-08-14T21:26:00Z Fresh autoreview and exact repository check passed after both feedback repairs.
 - 2026-08-14T21:28:00Z Moved update/delete role validation ahead of every candidate-row read.
 - 2026-08-14T21:34:00Z Final autoreview and exact repository check passed after all four repairs.
+- 2026-08-14T21:37:00Z Added nested relation-filter preflight after a fresh GitHub review finding.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Publish fixes, resolve GitHub threads, merge |
+| Where am I? | Review/checks |
+| Where am I going? | Final autoreview/check, publish fix, resolve GitHub thread, merge |
 | What is the goal? | Merge fail-closed RLS owner before PR 317 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
@@ -193,3 +196,6 @@ Review fixes:
   `where`; empty-root regression proof added.
 - Update/delete collected candidates before role validation -> accepted -> both
   builders now validate before `query` or `get`; guarded regression proof added.
+- Nested relation `where` filters were absent from recursive preflight ->
+  accepted -> each relation merges its derived filter plan with explicit `with`
+  before recursion; empty-parent regression proof added.

--- a/docs/plans/318-close-auth-adapter-pr.md
+++ b/docs/plans/318-close-auth-adapter-pr.md
@@ -82,7 +82,7 @@ Closure matrix:
 | agent workflow | no | N/A: no agent workflow/action changed | N/A |
 | cleanup/review | yes | Deslop and autoreview | passed: no accepted findings |
 | repository check | yes | `bun check` | passed |
-| GitHub delivery | yes | PR 318 update/merge/read-back | pending |
+| GitHub delivery | yes | PR 318 update/merge/read-back | passed: squash merge `eddfc083` |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
@@ -91,8 +91,8 @@ Work Checklist:
 - [x] Package build and living changeset match the final behavior; docs/skill/
       fixtures/scenarios are N/A for this runtime-only delta.
 - [x] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner: none.
 - [x] Agent-native pack: no rule or generated skill mirror is changed.
 - [x] Agent-native pack: no agent action is changed, so discoverability is N/A.
 - [x] Agent-native pack: `.agents/rules/**` and generated mirrors are N/A.
@@ -115,9 +115,9 @@ Completion Gates:
 | Agent-native reviewer | no | N/A: no agent-facing action changed | Applicability audit recorded |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
 | Repository check | yes | Run `bun check` | passed end to end |
-| GitHub delivery | yes | Update checkbox/branch, squash-merge, read back | pending |
+| GitHub delivery | yes | Update checkbox/branch, squash-merge, read back | passed: auto-release off; CI/Vercel green; merge `eddfc083` |
 | Autoreview | yes | Resolve every accepted actionable finding | passed: clean branch review, confidence 0.98 |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/318-close-auth-adapter-pr.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/318-close-auth-adapter-pr.md` | passed after merge read-back |
 | Agent source / generated sync | no | N/A: no agent source or mirror change | N/A |
 | Installed lock audit | no | N/A: no skill state change | N/A |
 | Agent action discoverability | no | N/A: no agent action change | N/A |
@@ -130,8 +130,8 @@ Phase / pass table:
 | Inventory | completed | PR contract/files/checks and proof gap reconstructed | repair |
 | Repair | completed | deterministic Vitest forwarding proof added | review |
 | Review/checks | completed | focused tests/build/types/lint/fixtures/verify/runtime, autoreview, and `bun check` passed | delivery |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Delivery | completed | PR body synchronized, auto-release disabled, CI/Vercel green, squash merge `eddfc083` read back | final audit |
+| Closeout | completed | no residual findings or blockers | final |
 
 Verification evidence:
 - PR 318 CI rerun `31827131380` passed before local repair.
@@ -146,6 +146,8 @@ Verification evidence:
 - Autoreview branch diff against `kitcn/main` -> clean, no accepted or actionable findings, confidence 0.98.
 - `bun check` -> passed end to end, including lint, types, tests, fixtures,
   verify, and runtime scenarios.
+- GitHub read-back -> PR 318 merged at 2026-08-14T19:03:07Z as
+  `eddfc083de4e1656237f1b871919c9c382eeb67e`; auto-release remained disabled.
 
 Timeline:
 - 2026-08-14T18:17:54.453Z Autoclosure plan created.
@@ -153,19 +155,19 @@ Timeline:
 - 2026-08-14T18:41:00Z Focused/build/lint/fixture/verify proof passed.
 - 2026-08-14T20:47:00Z Runtime scenarios and independent autoreview passed; exact final check remains.
 - 2026-08-14T20:54:00Z Exact `bun check` passed end to end.
+- 2026-08-14T21:03:07Z GitHub CI and Vercel passed; PR 318 squash-merged with auto-release disabled.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | GitHub checks, merge, read-back, final audit |
+| Where am I? | Closed |
+| Where am I going? | Batch continues with PR 316 |
 | What is the goal? | Merge PR 318 with deterministic auth adapter proof and no release trigger |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
 
 Open risks:
-- The latest branch removed nondeterministic `jwtCache` forwarding tests; a
-  stable proof owner must be accepted before merge.
+- None. The removed nondeterministic test was replaced by isolated Vitest proof.
 
 Findings:
 - Cross-table ID access can read, update, or delete the wrong model row.

--- a/packages/kitcn/skills/kitcn/references/features/orm.md
+++ b/packages/kitcn/skills/kitcn/references/features/orm.md
@@ -922,11 +922,21 @@ rlsPolicy("admin_only", {
   using: (ctx, t) => eq(t.ownerId, ctx.viewerId),
 });
 
-// Provide roleResolver
+// roleResolver is required by any policy scoped to a named role
 const ormDb = orm.db(ctx, {
   rls: { ctx, roleResolver: (ctx) => ctx.roles ?? [] },
 });
 ```
+
+**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
+
+### Null handling
+
+Policy expressions use SQL null semantics: a comparison against a missing document field or a missing context value is unknown, and unknown denies. An unauthenticated caller (`ctx.viewerId` is `undefined`) never matches rows whose column is unset. Use `isNull` to match absent columns on purpose.
+
+### Relations
+
+`with` enforces the related table's policies, and for many-to-many relations the junction table's policies as well, so a caller only traverses links it may read.
 
 **Important:** `ctx.db` bypasses RLS. Only `ctx.orm` enforces policies. FK cascade fan-out also bypasses child-table RLS.
 

--- a/packages/kitcn/skills/kitcn/references/features/orm.md
+++ b/packages/kitcn/skills/kitcn/references/features/orm.md
@@ -928,7 +928,7 @@ const ormDb = orm.db(ctx, {
 });
 ```
 
-**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
+**Important:** a policy scoped to a named role throws `RLS_ROLE_RESOLVER_REQUIRED` when no `roleResolver` is configured, instead of granting the policy to every caller. Queries and mutations validate this per table before reading rows, so an empty table throws too. The SQL pseudo-roles `public`, `current_user`, `current_role`, and `session_user` apply to everyone and need no resolver.
 
 ### Null handling
 

--- a/packages/kitcn/src/orm/delete.ts
+++ b/packages/kitcn/src/orm/delete.ts
@@ -27,7 +27,7 @@ import {
 } from './mutation-utils';
 import { GelRelationalQuery } from './query';
 import { QueryPromise } from './query-promise';
-import { canDeleteRow } from './rls/evaluator';
+import { assertRlsRolesResolvable, canDeleteRow } from './rls/evaluator';
 import type { ConvexTable } from './table';
 import type {
   MutationExecuteConfig,
@@ -586,6 +586,9 @@ export class ConvexDeleteBuilder<
     let numAffected = 0;
 
     const rls = ormContext?.rls;
+    // Validated before the row loop so a filter that matches nothing still
+    // rejects policies this context cannot evaluate.
+    assertRlsRolesResolvable({ table: this.table, operation: 'delete', rls });
     const foreignKeyGraph = ormContext?.foreignKeyGraph;
     if (!foreignKeyGraph) {
       throw new Error(

--- a/packages/kitcn/src/orm/delete.ts
+++ b/packages/kitcn/src/orm/delete.ts
@@ -415,6 +415,11 @@ export class ConvexDeleteBuilder<
       }
     }
 
+    const rls = ormContext?.rls;
+    // Policy configuration must fail before any candidate-row reads so the
+    // error is independent of table size and mutation collection limits.
+    assertRlsRolesResolvable({ table: this.table, operation: 'delete', rls });
+
     let rows: Record<string, unknown>[];
     let continueCursor: string | null = null;
     let isDone = true;
@@ -585,10 +590,6 @@ export class ConvexDeleteBuilder<
     const results: Record<string, unknown>[] = [];
     let numAffected = 0;
 
-    const rls = ormContext?.rls;
-    // Validated before the row loop so a filter that matches nothing still
-    // rejects policies this context cannot evaluate.
-    assertRlsRolesResolvable({ table: this.table, operation: 'delete', rls });
     const foreignKeyGraph = ormContext?.foreignKeyGraph;
     if (!foreignKeyGraph) {
       throw new Error(

--- a/packages/kitcn/src/orm/mutation-utils.test.ts
+++ b/packages/kitcn/src/orm/mutation-utils.test.ts
@@ -1,6 +1,15 @@
 /** biome-ignore-all lint/performance/useTopLevelRegex: inline regex assertions are intentional in tests. */
 import { describe, expect, test, vi } from 'vitest';
-import { and, eq, gt, isNull, not, or } from './filter-expression';
+import {
+  and,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  not,
+  notInArray,
+  or,
+} from './filter-expression';
 import { convexTable, date, index, integer, text, timestamp } from './index';
 import {
   applyDefaults,
@@ -179,6 +188,32 @@ describe('mutation-utils', () => {
     expect(evaluateCheckConstraintTriState({ age: null }, expression)).toBe(
       'unknown'
     );
+
+    const values = ['active', undefined] as any;
+    expect(
+      evaluateCheckConstraintTriState(
+        { status: 'active' },
+        inArray(users.status, values)
+      )
+    ).toBe(true);
+    expect(
+      evaluateCheckConstraintTriState(
+        { status: 'active' },
+        notInArray(users.status, values)
+      )
+    ).toBe(false);
+    expect(
+      evaluateCheckConstraintTriState(
+        { status: 'inactive' },
+        inArray(users.status, values)
+      )
+    ).toBe('unknown');
+    expect(
+      evaluateCheckConstraintTriState(
+        { status: 'inactive' },
+        notInArray(users.status, values)
+      )
+    ).toBe('unknown');
   });
 
   test('enforceCheckConstraints throws violations and allows unknown checks', () => {

--- a/packages/kitcn/src/orm/mutation-utils.ts
+++ b/packages/kitcn/src/orm/mutation-utils.ts
@@ -2355,12 +2355,14 @@ export function evaluateCheckConstraintTriState(
       case 'inArray': {
         const arr = compareValue as any[];
         if (!Array.isArray(arr)) return false;
-        return arr.includes(fieldValue as any);
+        if (arr.includes(fieldValue as any)) return true;
+        return arr.some(nullish) ? 'unknown' : false;
       }
       case 'notInArray': {
         const arr = compareValue as any[];
         if (!Array.isArray(arr)) return false;
-        return !arr.includes(fieldValue as any);
+        if (arr.includes(fieldValue as any)) return false;
+        return arr.some(nullish) ? 'unknown' : true;
       }
       case 'arrayContains': {
         if (!Array.isArray(fieldValue)) return false;

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -5074,6 +5074,15 @@ export class GelRelationalQuery<
       0,
       3
     );
+    if (whereFilter) {
+      this._assertRlsSelectPlan(
+        this._buildFilterWithConfig(whereFilter, this.tableConfig),
+        this.tableConfig,
+        this.edgeMetadata,
+        0,
+        3
+      );
+    }
 
     // Fast path: `id` lookups use `db.get()` (primary key) instead of an index plan.
     // This keeps `where: { id: ... }` and `where: { id: { in: [...] } }` ergonomic

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -2024,12 +2024,31 @@ export class GelRelationalQuery<
       const targetTableConfig = this._getTableConfigByDbName(edge.targetTable);
       if (!targetTableConfig) continue;
 
+      let nestedWith: Record<string, unknown> | undefined;
+      if (relationConfig && typeof relationConfig === 'object') {
+        const configuredWith = (relationConfig as any).with;
+        if (this._isRecord(configuredWith)) {
+          nestedWith = { ...configuredWith };
+        }
+
+        const relationWhere = (relationConfig as any).where;
+        if (relationWhere && typeof relationWhere !== 'function') {
+          const filterWith = this._buildFilterWithConfig(
+            relationWhere,
+            targetTableConfig
+          );
+          if (Object.keys(filterWith).length > 0) {
+            if (nestedWith) {
+              this._mergeWithConfig(nestedWith, filterWith);
+            } else {
+              nestedWith = filterWith;
+            }
+          }
+        }
+      }
+
       this._assertRlsSelectPlan(
-        relationConfig && typeof relationConfig === 'object'
-          ? ((relationConfig as any).with as
-              | Record<string, unknown>
-              | undefined)
-          : undefined,
+        nestedWith,
         targetTableConfig,
         this._getTargetTableEdges(edge.targetTable),
         depth + 1,

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -96,7 +96,7 @@ import { asc, desc } from './order-by';
 import { getPage } from './pagination';
 import { QueryPromise } from './query-promise';
 import type { RelationsFieldFilter, RelationsFilter } from './relations';
-import { filterSelectRows } from './rls/evaluator';
+import { assertRlsRolesResolvable, filterSelectRows } from './rls/evaluator';
 import type { RlsContext } from './rls/types';
 import {
   EmptyStream,
@@ -512,7 +512,9 @@ export class GelRelationalQuery<
     rows: any[],
     tableConfig?: TableRelationalConfig
   ): Promise<any[]> {
-    if (!rows.length || !tableConfig) return rows;
+    if (!tableConfig) return rows;
+    // Empty result sets still reach `filterSelectRows` so policy configuration
+    // is validated independently of what the table currently stores.
     return await filterSelectRows({
       table: tableConfig.table as any,
       rows,
@@ -1975,6 +1977,67 @@ export class GelRelationalQuery<
     }
   }
 
+  /**
+   * Validate role-scoped policies for every table this read plan touches before
+   * relations are loaded. Relation loaders skip work when a parent page is
+   * empty, so per-row evaluation alone would make a misconfigured table fail
+   * only once it holds rows. Mirrors the `_loadRelations` depth budget so the
+   * plan walked here matches the plan that would be executed.
+   */
+  private _assertRlsSelectPlan(
+    withConfig: Record<string, unknown> | undefined,
+    tableConfig: TableRelationalConfig,
+    edges: EdgeMetadata[],
+    depth: number,
+    maxDepth: number
+  ): void {
+    assertRlsRolesResolvable({
+      table: tableConfig.table as any,
+      operation: 'select',
+      rls: this.rls,
+    });
+
+    if (!withConfig || depth >= maxDepth) return;
+
+    for (const [relationName, relationConfig] of Object.entries(withConfig)) {
+      // `with._count` runs through the aggregate path, which rejects
+      // RLS-enabled tables with its own error.
+      if (relationName === '_count') continue;
+
+      const edge = edges.find((entry) => entry.edgeName === relationName);
+      // Unknown relations raise their own error while loading.
+      if (!edge) continue;
+
+      if (edge.through) {
+        const throughTableConfig = this._getTableConfigByDbName(
+          edge.through.table
+        );
+        if (throughTableConfig) {
+          assertRlsRolesResolvable({
+            table: throughTableConfig.table as any,
+            operation: 'select',
+            rls: this.rls,
+          });
+        }
+      }
+
+      const targetTableConfig = this._getTableConfigByDbName(edge.targetTable);
+      if (!targetTableConfig) continue;
+
+      this._assertRlsSelectPlan(
+        relationConfig && typeof relationConfig === 'object'
+          ? ((relationConfig as any).with as
+              | Record<string, unknown>
+              | undefined)
+          : undefined,
+        targetTableConfig,
+        this._getTargetTableEdges(edge.targetTable),
+        depth + 1,
+        maxDepth
+      );
+    }
+  }
+
   private async _finalizeRows(rows: any[]): Promise<any[]> {
     const polymorphicState = this._resolvePolymorphicFinalizeState();
     const requestedWith = this.config.with as
@@ -1999,6 +2062,14 @@ export class GelRelationalQuery<
         resolvedExtras
       );
     }
+
+    this._assertRlsSelectPlan(
+      effectiveWith,
+      this.tableConfig,
+      this.edgeMetadata,
+      0,
+      3
+    );
 
     let rowsWithRelations = rows;
     if (effectiveWith) {

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -5064,6 +5064,17 @@ export class GelRelationalQuery<
       }
     }
 
+    // Validate the root and explicit relation plan before the first database
+    // read. `_finalizeRows` repeats this for relations added by polymorphic
+    // variants before those relation rows are loaded.
+    this._assertRlsSelectPlan(
+      config.with as Record<string, unknown> | undefined,
+      this.tableConfig,
+      this.edgeMetadata,
+      0,
+      3
+    );
+
     // Fast path: `id` lookups use `db.get()` (primary key) instead of an index plan.
     // This keeps `where: { id: ... }` and `where: { id: { in: [...] } }` ergonomic
     // without requiring allowFullScan, and avoids full collection scans.

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -2000,9 +2000,10 @@ export class GelRelationalQuery<
     if (!withConfig || depth >= maxDepth) return;
 
     for (const [relationName, relationConfig] of Object.entries(withConfig)) {
-      // `with._count` runs through the aggregate path, which rejects
-      // RLS-enabled tables with its own error.
-      if (relationName === '_count') continue;
+      if (relationName === '_count') {
+        this._assertRelationCountRlsPlan(relationConfig, edges);
+        continue;
+      }
 
       const edge = edges.find((entry) => entry.edgeName === relationName);
       // Unknown relations raise their own error while loading.
@@ -2054,6 +2055,43 @@ export class GelRelationalQuery<
         depth + 1,
         maxDepth
       );
+    }
+  }
+
+  private _assertRelationCountRlsPlan(
+    relationCountConfig: unknown,
+    edges: EdgeMetadata[]
+  ): void {
+    if (!this._isRecord(relationCountConfig)) return;
+
+    for (const [relationName, relationSelection] of Object.entries(
+      relationCountConfig
+    )) {
+      if (relationSelection === undefined || relationSelection === false) {
+        continue;
+      }
+
+      const edge = edges.find((entry) => entry.edgeName === relationName);
+      if (!edge) continue;
+
+      const where = this._coerceRelationCountWhere(
+        relationName,
+        relationSelection
+      );
+      if (edge.through) {
+        const throughTableConfig = this._getTableConfigByDbName(
+          edge.through.table
+        );
+        if (throughTableConfig) {
+          ensureCountAllowedForRls(throughTableConfig, this.rls?.mode as any);
+        }
+        if (this._isEmptyWhere(where) || where === undefined) continue;
+      }
+
+      const targetTableConfig = this._getTableConfigByDbName(edge.targetTable);
+      if (targetTableConfig) {
+        ensureCountAllowedForRls(targetTableConfig, this.rls?.mode as any);
+      }
     }
   }
 
@@ -5083,11 +5121,14 @@ export class GelRelationalQuery<
       }
     }
 
-    // Validate the root and explicit relation plan before the first database
-    // read. `_finalizeRows` repeats this for relations added by polymorphic
-    // variants before those relation rows are loaded.
-    this._assertRlsSelectPlan(
+    // Validate the root and effective relation plan before the first database
+    // read. `_finalizeRows` repeats this before relation rows are loaded.
+    const preflightWith = this._resolveWithVariantsState(
       config.with as Record<string, unknown> | undefined,
+      this._resolvePolymorphicFinalizeState()
+    ).effectiveWith;
+    this._assertRlsSelectPlan(
+      preflightWith,
       this.tableConfig,
       this.edgeMetadata,
       0,

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -7509,7 +7509,10 @@ export class GelRelationalQuery<
             values,
             throughIndexName
           );
-          const throughRows = await query.collect();
+          const throughRows = await this._applyRlsSelectFilter(
+            await query.collect(),
+            throughTableConfig
+          );
           return { key, rows: throughRows };
         }
       );

--- a/packages/kitcn/src/orm/rls/evaluator.ts
+++ b/packages/kitcn/src/orm/rls/evaluator.ts
@@ -1,5 +1,8 @@
 import type { FilterExpression } from '../filter-expression';
-import { evaluateFilter } from '../mutation-utils';
+import {
+  evaluateCheckConstraintTriState,
+  getTableName,
+} from '../mutation-utils';
 import { EnableRLS, RlsPolicies } from '../symbols';
 import type { ConvexTable } from '../table';
 import type { RlsPolicy, RlsPolicyToOption } from './policies';
@@ -31,6 +34,18 @@ function policyApplies(policy: RlsPolicy, operation: RlsOperation): boolean {
   return target === 'all' || target === operation;
 }
 
+/**
+ * SQL pseudo-roles always resolve to the calling user, so they apply to every
+ * caller and never need a role resolver. Only `rlsRole()` values and bare role
+ * names are matched against resolved roles.
+ */
+const PSEUDO_ROLES = new Set([
+  'public',
+  'current_role',
+  'current_user',
+  'session_user',
+]);
+
 function flattenRoles(
   target: RlsPolicyToOption | undefined
 ): 'public' | string[] {
@@ -44,7 +59,7 @@ function flattenRoles(
       value.forEach(visit);
       return;
     }
-    if (value === 'public') {
+    if (typeof value === 'string' && PSEUDO_ROLES.has(value)) {
       hasPublic = true;
       return;
     }
@@ -60,15 +75,39 @@ function flattenRoles(
   return hasPublic ? 'public' : roles;
 }
 
-function roleMatches(policy: RlsPolicy, rls?: RlsContext): boolean {
+function roleMatches(
+  policy: RlsPolicy,
+  table: ConvexTable<any>,
+  rls?: RlsContext
+): boolean {
+  const targetRoles = flattenRoles(policy.to);
+  if (targetRoles === 'public') return true;
+
   const resolver = rls?.roleResolver;
-  if (!resolver) return true;
+  if (!resolver) {
+    const roleList = targetRoles.map((role) => `'${role}'`).join(', ');
+    throw new Error(
+      `RLS_ROLE_RESOLVER_REQUIRED: policy '${policy.name}' on table ` +
+        `'${getTableName(table)}' targets role(s) ${roleList}, but no ` +
+        "'roleResolver' is configured. Pass 'rls.roleResolver' when creating " +
+        "the ORM database, or remove the policy's 'to' clause."
+    );
+  }
 
   const roles = resolver(rls?.ctx ?? {}) ?? [];
-  const targetRoles = flattenRoles(policy.to);
-
-  if (targetRoles === 'public') return true;
   return targetRoles.some((role) => roles.includes(role));
+}
+
+/**
+ * Policy expressions follow SQL RLS semantics: an expression that evaluates to
+ * NULL/unknown is treated as false. A nullish document field or a nullish
+ * context value therefore never satisfies a policy.
+ */
+function policyExpressionPasses(
+  row: Record<string, unknown>,
+  expression: FilterExpression<boolean>
+): boolean {
+  return evaluateCheckConstraintTriState(row, expression) === true;
 }
 
 async function resolveExpression(
@@ -101,7 +140,8 @@ async function evaluatePolicySet({
 
   const ctx = rls?.ctx ?? {};
   const policies = getRlsPolicies(table).filter(
-    (policy) => policyApplies(policy, operation) && roleMatches(policy, rls)
+    (policy) =>
+      policyApplies(policy, operation) && roleMatches(policy, table, rls)
   );
 
   if (policies.length === 0) {
@@ -119,7 +159,7 @@ async function evaluatePolicySet({
   let permissivePasses = false;
   for (const policy of permissive) {
     const expression = await resolveExpression(policy, checkType, ctx, table);
-    if (!expression || evaluateFilter(row, expression)) {
+    if (!expression || policyExpressionPasses(row, expression)) {
       permissivePasses = true;
       break;
     }
@@ -133,7 +173,7 @@ async function evaluatePolicySet({
   for (const policy of restrictive) {
     const expression = await resolveExpression(policy, checkType, ctx, table);
     if (!expression) continue;
-    if (!evaluateFilter(row, expression)) return false;
+    if (!policyExpressionPasses(row, expression)) return false;
   }
 
   return true;

--- a/packages/kitcn/src/orm/rls/evaluator.ts
+++ b/packages/kitcn/src/orm/rls/evaluator.ts
@@ -75,26 +75,51 @@ function flattenRoles(
   return hasPublic ? 'public' : roles;
 }
 
-function roleMatches(
+function roleResolverRequiredError(
   policy: RlsPolicy,
   table: ConvexTable<any>,
-  rls?: RlsContext
-): boolean {
+  targetRoles: string[]
+): Error {
+  const roleList = targetRoles.map((role) => `'${role}'`).join(', ');
+  return new Error(
+    `RLS_ROLE_RESOLVER_REQUIRED: policy '${policy.name}' on table ` +
+      `'${getTableName(table)}' targets role(s) ${roleList}, but no ` +
+      "'roleResolver' is configured. Pass 'rls.roleResolver' when creating " +
+      "the ORM database, or remove the policy's 'to' clause."
+  );
+}
+
+/**
+ * A named-role policy cannot be evaluated without a role resolver. Validate
+ * that from the table's policy set alone so the failure depends only on
+ * configuration, never on whether the table currently holds matching rows.
+ */
+export function assertRlsRolesResolvable(options: {
+  table: ConvexTable<any>;
+  operation: RlsOperation;
+  rls?: RlsContext;
+}): void {
+  const { table, operation, rls } = options;
+  if (!isRlsEnabled(table)) return;
+  if (rls?.mode === 'skip') return;
+  if (rls?.roleResolver) return;
+
+  for (const policy of getRlsPolicies(table)) {
+    if (!policyApplies(policy, operation)) continue;
+    const targetRoles = flattenRoles(policy.to);
+    if (targetRoles === 'public') continue;
+    throw roleResolverRequiredError(policy, table, targetRoles);
+  }
+}
+
+function roleMatches(policy: RlsPolicy, rls?: RlsContext): boolean {
   const targetRoles = flattenRoles(policy.to);
   if (targetRoles === 'public') return true;
 
+  // `assertRlsRolesResolvable` rejects a missing resolver before any row is
+  // evaluated; treating it as an empty role list here keeps this fail-closed.
   const resolver = rls?.roleResolver;
-  if (!resolver) {
-    const roleList = targetRoles.map((role) => `'${role}'`).join(', ');
-    throw new Error(
-      `RLS_ROLE_RESOLVER_REQUIRED: policy '${policy.name}' on table ` +
-        `'${getTableName(table)}' targets role(s) ${roleList}, but no ` +
-        "'roleResolver' is configured. Pass 'rls.roleResolver' when creating " +
-        "the ORM database, or remove the policy's 'to' clause."
-    );
-  }
-
-  const roles = resolver(rls?.ctx ?? {}) ?? [];
+  const roles = resolver ? (resolver(rls?.ctx ?? {}) ?? []) : [];
   return targetRoles.some((role) => roles.includes(role));
 }
 
@@ -138,10 +163,11 @@ async function evaluatePolicySet({
   if (!isRlsEnabled(table)) return true;
   if (rls?.mode === 'skip') return true;
 
+  assertRlsRolesResolvable({ table, operation, rls });
+
   const ctx = rls?.ctx ?? {};
   const policies = getRlsPolicies(table).filter(
-    (policy) =>
-      policyApplies(policy, operation) && roleMatches(policy, table, rls)
+    (policy) => policyApplies(policy, operation) && roleMatches(policy, rls)
   );
 
   if (policies.length === 0) {
@@ -271,6 +297,14 @@ export async function filterSelectRows(options: {
 }): Promise<Record<string, unknown>[]> {
   if (!isRlsEnabled(options.table)) return options.rows;
   if (options.rls?.mode === 'skip') return options.rows;
+
+  // Runs before the row loop so an empty result set still rejects a table whose
+  // policies cannot be evaluated.
+  assertRlsRolesResolvable({
+    table: options.table,
+    operation: 'select',
+    rls: options.rls,
+  });
 
   const rows: Record<string, unknown>[] = [];
   for (const row of options.rows) {

--- a/packages/kitcn/src/orm/update.ts
+++ b/packages/kitcn/src/orm/update.ts
@@ -29,7 +29,10 @@ import {
 } from './mutation-utils';
 import { GelRelationalQuery } from './query';
 import { QueryPromise } from './query-promise';
-import { evaluateUpdateDecision } from './rls/evaluator';
+import {
+  assertRlsRolesResolvable,
+  evaluateUpdateDecision,
+} from './rls/evaluator';
 import type { ConvexTable } from './table';
 import type {
   MutationExecuteConfig,
@@ -615,6 +618,9 @@ export class ConvexUpdateBuilder<
     }
 
     const rls = ormContext?.rls;
+    // Validated before the row loop so a filter that matches nothing still
+    // rejects policies this context cannot evaluate.
+    assertRlsRolesResolvable({ table: this.table, operation: 'update', rls });
     const foreignKeyGraph = ormContext?.foreignKeyGraph;
     if (!foreignKeyGraph) {
       throw new Error(

--- a/packages/kitcn/src/orm/update.ts
+++ b/packages/kitcn/src/orm/update.ts
@@ -427,6 +427,11 @@ export class ConvexUpdateBuilder<
       }
     }
 
+    const rls = ormContext?.rls;
+    // Policy configuration must fail before any candidate-row reads so the
+    // error is independent of table size and mutation collection limits.
+    assertRlsRolesResolvable({ table: this.table, operation: 'update', rls });
+
     const onUpdateSet: Record<string, unknown> = {};
     for (const [columnName, builder] of Object.entries(
       getTableColumns(this.table)
@@ -617,10 +622,6 @@ export class ConvexUpdateBuilder<
       );
     }
 
-    const rls = ormContext?.rls;
-    // Validated before the row loop so a filter that matches nothing still
-    // rejects policies this context cannot evaluate.
-    assertRlsRolesResolvable({ table: this.table, operation: 'update', rls });
     const foreignKeyGraph = ormContext?.foreignKeyGraph;
     if (!foreignKeyGraph) {
       throw new Error(

--- a/www/content/docs/orm/rls.mdx
+++ b/www/content/docs/orm/rls.mdx
@@ -140,7 +140,7 @@ const ormDb = orm.db(ctx, {
 ```
 
 <Callout icon={<AlertTriangle />}>
-**Important:** A `roleResolver` is required by any policy scoped to a named role. Evaluating such a policy without one throws `RLS_ROLE_RESOLVER_REQUIRED` rather than granting the policy to every caller. Use `ctx.orm.skipRules` for trusted code that intentionally bypasses policies.
+**Important:** A `roleResolver` is required by any policy scoped to a named role. Every query and mutation validates this for each table it touches before reading rows, so a missing resolver throws `RLS_ROLE_RESOLVER_REQUIRED` even when the table is empty, rather than granting the policy to every caller. Use `ctx.orm.skipRules` for trusted code that intentionally bypasses policies.
 </Callout>
 
 The SQL pseudo-roles `'public'`, `'current_user'`, `'current_role'`, and `'session_user'` resolve to the calling user, so they apply to everyone and need no `roleResolver`.

--- a/www/content/docs/orm/rls.mdx
+++ b/www/content/docs/orm/rls.mdx
@@ -139,9 +139,35 @@ const ormDb = orm.db(ctx, {
 });
 ```
 
-<Callout icon={<InfoIcon />}>
-**Note:** `to` clauses are only enforced when you provide a `roleResolver`. Without one, role-scoped policies are silently skipped.
+<Callout icon={<AlertTriangle />}>
+**Important:** A `roleResolver` is required by any policy scoped to a named role. Evaluating such a policy without one throws `RLS_ROLE_RESOLVER_REQUIRED` rather than granting the policy to every caller. Use `ctx.orm.skipRules` for trusted code that intentionally bypasses policies.
 </Callout>
+
+The SQL pseudo-roles `'public'`, `'current_user'`, `'current_role'`, and `'session_user'` resolve to the calling user, so they apply to everyone and need no `roleResolver`.
+
+## Null Handling
+
+Policy expressions follow SQL null semantics: a comparison against a missing document field or a missing context value evaluates to unknown, and unknown is treated as a denial.
+
+```ts showLineNumbers
+rlsPolicy('read_own', {
+  for: 'select',
+  using: (ctx, t) => eq(t.ownerId, ctx.viewerId),
+});
+```
+
+An unauthenticated caller (`ctx.viewerId` is `undefined`) is denied rows whose `ownerId` is unset -- the two missing values never match each other. Use `isNull` when you deliberately want to match rows with an absent column.
+
+## Relations
+
+Loading a relation with `with` enforces the related table's policies. For many-to-many relations, the junction table's policies are enforced too, so a caller only traverses the links they are allowed to read.
+
+```ts showLineNumbers
+// memberships carries `rlsPolicy('read_own', { using: (ctx, t) => eq(t.userId, ctx.viewerId) })`
+await ctx.orm.query.users.findMany({ with: { organizations: true } });
+```
+
+Other users come back with an empty `organizations` array, because their membership rows fail the junction policy.
 
 ## Drizzle Differences
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

Makes ORM row-level security fail closed:

- named-role policies require `rls.roleResolver`, including on empty tables;
- explicit `with`, relational-`where`, `_count`, and `withVariants` plans validate before the first root database read;
- SQL-null/unknown policy comparisons deny, including nullish `IN`/`NOT IN` members;
- many-to-many relation loading filters junction rows;
- update and delete validate policy configuration before collecting candidate rows.

SQL pseudo-roles remain resolver-free. The package skill, generated mirror, public docs, and minor changeset agree on the contract.

Verification passed 30 focused RLS tests, 23 evaluator tests, package build, root typecheck, lint, generated-skill sync, Intent validation/stale checks, deslop, agent-native review, independent autoreview, and the complete `bun check` gate.
