### PR TITLE
fix(auth): adapter no longer reads, patches or deletes the wrong rows

### DIFF
--- a/.changeset/auth-adapter-wrong-rows.md
+++ b/.changeset/auth-adapter-wrong-rows.md
@@ -1,0 +1,22 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix auth queries that filter by `id` resolving records from the wrong model,
+  which let a lookup, update, or delete for one model read, patch, or destroy a
+  record belonging to another. IDs are now checked against the model being
+  queried, and IDs that belong elsewhere or are malformed resolve to "not
+  found" instead of a foreign record or an error.
+- Fix `findMany` and `count` returning duplicated records past the first page,
+  which also inflated counts used for membership, role, and API key limits.
+- Fix mixed `AND`/`OR` filters in `findMany` and `count` returning records the
+  filter excluded, such as rows outside the requested organization. Mixed
+  filters are now rejected, matching `updateMany` and `deleteMany`.
+- Fix `not_in` filters returning no match when the matching record was not
+  among the first records scanned, which made those updates fail and those
+  deletes silently do nothing.
+- Fix `auth.jwtCache: false` in the Next.js integration disabling
+  authentication instead of just the JWT cookie cache, which made every server
+  request anonymous.

--- a/docs/plans/2026-08-14-close-pr-316-322-batch.md
+++ b/docs/plans/2026-08-14-close-pr-316-322-batch.md
@@ -1,0 +1,181 @@
+# Close PR 316 through 322 batch
+
+Objective:
+Close PRs 318, 316, 317, 322, 320, 319, and 321 through focused proof,
+deslop, agent-native review where applicable, autoreview, repository checks,
+GitHub merge, and one final release triggered by PR 321.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-08-14-close-pr-316-322-batch.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- [PR 318 auth adapter closeout](docs/plans/318-close-auth-adapter-pr.md)
+- [PR 316 ORM RLS closeout](docs/plans/316-close-orm-rls-pr.md)
+- [PR 317 ORM planner closeout](docs/plans/317-close-orm-planner-pr.md)
+- [PR 322 CLI safety closeout](docs/plans/322-close-cli-safety-pr.md)
+- [PR 320 cRPC correctness closeout](docs/plans/320-close-crpc-correctness-pr.md)
+- [PR 319 ratelimit accounting closeout](docs/plans/319-close-ratelimit-accounting-pr.md)
+- [PR 321 React auth closeout](docs/plans/321-close-react-auth-pr.md)
+
+Completion threshold:
+- All seven linked PR plans pass their goal checker and their PRs are merged.
+- Every accepted review finding is fixed with fresh focused proof.
+- PR 317 is rebased after PR 316 and receives a fresh `bun check` result.
+- PR 318 does not trigger an intermediate release; PR 321 triggers one final
+  Version Packages merge and the resulting publish workflow succeeds.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Each linked plan records focused tests, package build, required generation or
+  fixture proof, deslop, agent-native review applicability, autoreview, and
+  `bun check`.
+- GitHub PR/check/review/merge read-back for PRs 318, 316, 317, 322, 320, 319,
+  and 321 plus the final Version Packages PR and publish workflow.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: the behavior already described by the seven PRs
+- allowed repairs: accepted findings within each PR's existing owner boundary
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new features, unrelated cleanup, compatibility shims, or API work
+  outside the seven PR contracts
+
+Output budget strategy:
+- Use exact PR/file lists, focused tests, capped review output, and GitHub JSON
+  summaries. Exclude `node_modules`, build artifacts, coverage, and broad logs.
+
+Blocked condition:
+- Stop only for a repeated external GitHub/release failure, missing authority,
+  or a reproducible environment blocker after distinct repair attempts.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | Seven open PR bodies, changed-file lists, checks, and linked plans read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries above |
+| Closure matrix classified | yes | Parent matrix below; child matrices own PR-specific rows |
+| GitHub delivery expectation recorded | yes | Merge all seven; PR 321 owns the single final release trigger |
+| Active goal checked or created | yes | Goal created for this exact plan |
+| Agent-native pack selected | yes | Materialized `agent-native` pack |
+| Agent-facing action surface identified | yes | Autoclosure workflow and package skill/CLI surfaces in PRs 316, 319, and 322 |
+| Source rule versus generated mirror boundary identified | yes | Child plans identify package skill owners and `.agents` mirrors where touched |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no installed skill membership change is intended |
+| `agent-native-reviewer` loaded or waiver recorded | yes | `.agents/skills/agent-native-reviewer/SKILL.md` loaded fully |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Linked child focused proofs | pending |
+| package/API/build | yes | Linked child package builds and types | pending |
+| generated output | yes | PRs 316 and 322 source/mirror proof | pending |
+| fixtures/scenarios | yes | PR 322 fixture sync/check; child N/A rows elsewhere | pending |
+| docs/package skill | yes | PRs 316, 319, and 322 paired owner audit | pending |
+| changeset | yes | Seven living changesets audited in child plans | pending |
+| agent workflow | yes | Agent-native review for affected package skill/CLI actions | pending |
+| cleanup/review | yes | Deslop plus autoreview per child | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | Seven merges plus final release read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: source owner boundaries are recorded; no generated
+      skill mirror will be edited directly.
+- [ ] Agent-native pack: affected package skill and CLI actions remain discoverable.
+- [x] Agent-native pack: `.agents/rules/**` is outside scope; mirror sync is
+      owned only by package skill changes in the relevant child plans.
+- [x] Agent-native pack: installed skill membership is unchanged, so Skills CLI
+      lock mutation is N/A.
+- [ ] Agent-native pack: affected routing, receipts, failure representation,
+      and forbidden behavior are proved in child plans.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run smallest missing owning proof | Linked child plans pending |
+| Source/generated audit | yes | Prove correct source and regenerated mirrors | PR 316/322 child plans pending |
+| Package/docs/scenario closure | yes | Run every applicable local contract | Linked child plans pending |
+| Deslop | yes | Run bounded cleanup or N/A | Linked child plans pending |
+| Agent-native reviewer | yes | Run for affected agent/package skill/CLI surfaces | Linked child plans pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update/merge seven PRs and read back final release | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-14-close-pr-316-322-batch.md` | pending |
+| Agent source / generated sync | yes | Verify package skill mirrors where touched; `.agents/rules/**` N/A | Child plans pending |
+| Installed lock audit | no | N/A: no skill installation/removal/update | No lock membership change intended |
+| Agent action discoverability | yes | Source-audit affected package skill and CLI routes | Child plans pending |
+| Helper and template smoke | no | N/A: no workflow helper/template behavior is being changed | Plans only record execution |
+| Agent-native review | yes | Close accepted findings for affected agent-facing actions | Child plans pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- GitHub inventory: seven open PRs, CI/Vercel green at goal creation, all review-required.
+- Source audit: PR 316 must precede PR 317; PR 318 and PR 321 have auto-release checked.
+
+Timeline:
+- 2026-08-14T18:17:43.119Z Autoclosure plan created.
+- 2026-08-14T18:18:00Z Goal created and seven linked child plans materialized.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge seven verified PRs and publish one coherent release |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- PR 318 regained green CI by removing nondeterministic forwarding tests; its
+  deterministic behavior proof must be reviewed before merge.
+- PR 317 must be rebased and fully rechecked after PR 316.
+- Auto-release must remain disabled until the final PR 321 merge.
+
+Findings:
+- The seven PRs share one internal ordering constraint: PR 316 before PR 317.
+- PR 318 and PR 321 default to auto-release; only PR 321 should retain it.
+
+Decisions and tradeoffs:
+- Use linked child plans -> each PR owns proof while the root prevents partial completion.
+- Keep PR 321 last -> one release contains the complete compatibility/correctness batch.
+
+Review fixes:
+- Pending child reviews.

--- a/docs/plans/316-close-orm-rls-pr.md
+++ b/docs/plans/316-close-orm-rls-pr.md
@@ -1,0 +1,156 @@
+# Close ORM RLS PR
+
+Objective:
+Close PR 316 as the fail-closed ORM RLS owner and merge it before PR 317 after
+focused proof, source/mirror/docs sync, review closure, and `bun check`.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/316-close-orm-rls-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Role, nullish, and junction RLS regressions have focused proof; package skill,
+  installed mirror, docs, and changeset agree; zero accepted findings remain;
+  full checks pass; PR 316 is squash-merged before PR 317.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused ORM RLS tests, package build/types, package-skill/mirror/docs audit,
+  deslop, agent-native review, autoreview, lint, `bun check`, GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: fail-closed role/nullish/junction RLS behavior in PR 316
+- allowed repairs: touched ORM RLS owner/tests/docs/package skill/changeset
+- unrelated files: preserve; do not treat as blockers
+- non-goals: query-planner fixes owned by PR 317 or broader ORM redesign
+
+Output budget strategy:
+- Exact changed files, focused ORM tests, capped review/check failures; exclude
+  build outputs, fixtures, coverage, and broad generated trees.
+
+Blocked condition:
+- Repeated external/environment failure or a finding requiring a new public ORM contract.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 316 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Merge before PR 317; no auto-release |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | yes | Published ORM package skill guidance |
+| Source rule versus generated mirror boundary identified | yes | `packages/kitcn/skills/kitcn/**` owns `.agents/skills/kitcn/**` mirror |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no installed skill membership change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded fully |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused ORM RLS tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | yes | Package skill owner to `.agents` mirror audit | pending |
+| fixtures/scenarios | no | N/A: no scaffold output changes | N/A |
+| docs/package skill | yes | www/package skill/mirror agreement | pending |
+| changeset | yes | `.changeset/orm-rls-fail-closed.md` audit | pending |
+| agent workflow | yes | Published skill discoverability and mirror parity | pending |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 316 merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: package skill source owner and generated mirror are identified.
+- [ ] Agent-native pack: ORM RLS action/constraints remain discoverable.
+- [ ] Agent-native pack: package skill mirror parity is proved; `.agents/rules/**` is N/A.
+- [x] Agent-native pack: installed skill membership is unchanged.
+- [ ] Agent-native pack: package skill guidance represents required behavior and forbidden fail-open behavior.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused RLS tests | pending |
+| Source/generated audit | yes | Prove package skill to `.agents` mirror parity | pending |
+| Package/docs/scenario closure | yes | Build package; audit docs/skill/changeset | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | yes | Review published skill guidance/mirror | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/316-close-orm-rls-pr.md` | pending |
+| Agent source / generated sync | yes | Verify package skill and installed mirror | pending |
+| Installed lock audit | no | N/A: no skill membership change | N/A |
+| Agent action discoverability | yes | Source-audit ORM package skill route | pending |
+| Helper and template smoke | no | N/A: no workflow helper/template changed | N/A |
+| Agent-native review | yes | Close accepted package-skill findings | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 316 CI and Vercel were green at goal creation; no approval yet.
+
+Timeline:
+- 2026-08-14T18:17:54.580Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge fail-closed RLS owner before PR 317 |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- PR 317 overlaps `packages/kitcn/src/orm/query.ts` and `convex/orm/rls.test.ts`.
+
+Findings:
+- PR 316 is the dependency root for the two-PR ORM sequence.
+
+Decisions and tradeoffs:
+- Merge before PR 317 to resolve shared ORM ownership once.
+
+Review fixes:
+- Pending.

--- a/docs/plans/317-close-orm-planner-pr.md
+++ b/docs/plans/317-close-orm-planner-pr.md
@@ -1,0 +1,154 @@
+# Close ORM planner PR
+
+Objective:
+Close PR 317 after PR 316 by rebasing onto the merged RLS owner, proving the
+query-planner bug class, closing review, passing `bun check`, and merging.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/317-close-orm-planner-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- PR 317 is rebased after PR 316; focused ORM tests and full checks pass on the
+  rebased head; zero accepted findings remain; the changeset matches; PR is merged.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused ORM planner/relations/filter tests, package build/types, deslop,
+  agent-native applicability audit, autoreview, lint, `bun check`, GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: PR 317 limit/index/LIKE/relation correctness
+- allowed repairs: touched ORM source/tests and living changeset, plus rebase conflicts
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new ORM APIs or RLS policy work outside PR 316 integration
+
+Output budget strategy:
+- Exact changed ORM files and focused failures; cap review/check output and exclude artifacts.
+
+Blocked condition:
+- A non-mechanical PR 316 conflict requiring a new contract, or repeated external/environment failure.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 317 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Rebase after PR 316, fresh check, merge |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | no | N/A: ORM runtime behavior only |
+| Source rule versus generated mirror boundary identified | no | N/A: no rule/mirror change |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded; applicability N/A |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused ORM tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | no | N/A: no generated output | N/A |
+| fixtures/scenarios | no | N/A: no scaffold behavior | N/A |
+| docs/package skill | no | N/A: no docs/skill delta | N/A |
+| changeset | yes | `.changeset/orm-query-planner-limit-index.md` audit | pending |
+| agent workflow | no | N/A: no agent workflow/action | N/A |
+| cleanup/review | yes | Deslop and autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | Rebase/push/merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: no rule/generated mirror changed.
+- [x] Agent-native pack: no agent action changed; discoverability N/A.
+- [x] Agent-native pack: mirror sync N/A.
+- [x] Agent-native pack: installed skill state unchanged.
+- [x] Agent-native pack: agent routing/eval rows N/A.
+- [x] Agent-native pack: agent-native review N/A after applicability audit.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused ORM tests after rebase | pending |
+| Source/generated audit | no | N/A: source-only runtime change | N/A |
+| Package/docs/scenario closure | yes | Build package and audit changeset | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Rebase/push/squash-merge/read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/317-close-orm-planner-pr.md` | pending |
+| Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
+| Installed lock audit | no | N/A: no skill state change | N/A |
+| Agent action discoverability | no | N/A: no agent action | N/A |
+| Helper and template smoke | no | N/A: no workflow helper/template | N/A |
+| Agent-native review | no | N/A after applicability audit | No agent surface |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- Pre-rebase PR 317 CI/Vercel green; evidence becomes stale after PR 316 and must rerun.
+
+Timeline:
+- 2026-08-14T18:17:54.701Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Rebase, prove, and merge PR 317 after PR 316 |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- Shared ORM files require source-backed conflict resolution and fresh full proof.
+
+Findings:
+- PR 317 is the only dependent branch in the batch.
+
+Decisions and tradeoffs:
+- Treat all pre-rebase checks as stale after PR 316 lands.
+
+Review fixes:
+- Pending.

--- a/docs/plans/318-close-auth-adapter-pr.md
+++ b/docs/plans/318-close-auth-adapter-pr.md
@@ -1,0 +1,174 @@
+# Close auth adapter PR
+
+Objective:
+Close PR 318 without expanding its Better Auth adapter contract; merge only
+after deterministic regression proof, review closure, `bun check`, and GitHub
+read-back.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/318-close-auth-adapter-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- PR 318 has deterministic proof for model-scoped IDs, pagination/filtering,
+  and `jwtCache: false`; zero accepted review findings; full checks pass; the
+  auto-release checkbox is off; and the PR is squash-merged.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused auth and auth-nextjs tests, package build/types, deslop,
+  `agent-native-reviewer` N/A audit, autoreview, `bun lint:fix`, `bun check`,
+  PR/check/merge read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: Better Auth adapter row ownership, pagination/filtering, and
+  Next.js JWT-cache forwarding described by PR 318
+- allowed repairs: auth/auth-nextjs source and tests plus the living changeset
+- unrelated files: preserve; do not treat as blockers
+- non-goals: broader Better Auth API redesign, Solid auth work, release policy
+
+Output budget strategy:
+- Read exact changed auth files and focused test output; cap review/check logs
+  to failing sections; exclude generated/build directories.
+
+Blocked condition:
+- Repeated GitHub or environment failure after distinct repair attempts, or a
+  finding that requires a new public auth contract.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 318 body, commits, changed files, and CI read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries above |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Disable auto-release, squash-merge, read back |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by governing autoclosure skill |
+| Agent-facing action surface identified | no | N/A: runtime adapter behavior, no agent action changed |
+| Source rule versus generated mirror boundary identified | no | N/A: no rule or generated skill mirror changed |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill membership change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded; child applicability is N/A |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused auth/auth-nextjs tests | passed: 12 Vitest + 93 Bun |
+| package/API/build | yes | `bun --cwd packages/kitcn build` and typecheck | passed |
+| generated output | no | N/A: no generated owner touched | N/A |
+| fixtures/scenarios | no | N/A: adapter source does not change scaffold output | N/A |
+| docs/package skill | no | N/A: no public docs or package skill changed | N/A |
+| changeset | yes | `.changeset/auth-adapter-wrong-rows.md` audit | passed: patch sections match final behavior |
+| agent workflow | no | N/A: no agent workflow/action changed | N/A |
+| cleanup/review | yes | Deslop and autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 318 update/merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output is N/A: no generated owner is touched.
+- [ ] Package build and living changeset match the final behavior; docs/skill/
+      fixtures/scenarios are N/A for this runtime-only delta.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: no rule or generated skill mirror is changed.
+- [x] Agent-native pack: no agent action is changed, so discoverability is N/A.
+- [x] Agent-native pack: `.agents/rules/**` and generated mirrors are N/A.
+- [x] Agent-native pack: installed skill state is unchanged.
+- [x] Agent-native pack: routing/receipt/eval rows are N/A for runtime adapter behavior.
+- [x] Agent-native pack: agent-native review is N/A after applicability audit.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| `bun check` fixture lane stalled in a zero-CPU Start template network fetch | 1 | Interrupt only the inert run; rerun exact fixture gate without TTY | `bun run fixtures:check` passed all 8 fixtures |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused auth/auth-nextjs tests | passed: 12 Vitest + 93 Bun |
+| Source/generated audit | no | N/A: source-only runtime change | No generated mirror |
+| Package/docs/scenario closure | yes | Build package and audit changeset; other lanes N/A | package build/typecheck/changeset passed; fixtures and verify passed |
+| Deslop | yes | Run changed-file cleanup review | passed: zero net findings; no worthwhile cleanup |
+| Agent-native reviewer | no | N/A: no agent-facing action changed | Applicability audit recorded |
+| Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update checkbox/branch, squash-merge, read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/318-close-auth-adapter-pr.md` | pending |
+| Agent source / generated sync | no | N/A: no agent source or mirror change | N/A |
+| Installed lock audit | no | N/A: no skill state change | N/A |
+| Agent action discoverability | no | N/A: no agent action change | N/A |
+| Helper and template smoke | no | N/A: no workflow helper/template change | N/A |
+| Agent-native review | no | N/A after loaded-skill applicability audit | No agent surface |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | completed | PR contract/files/checks and proof gap reconstructed | repair |
+| Repair | completed | deterministic Vitest forwarding proof added | review |
+| Review/checks | in_progress | focused tests/build/types/lint/fixtures/verify passed | autoreview and final `bun check` |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 318 CI rerun `31827131380` passed before local repair.
+- `bunx vitest run --project integration packages/kitcn/src/auth-nextjs/index.vitest.ts packages/kitcn/src/auth/adapter-utils.vitest.ts packages/kitcn/src/auth/adapter.vitest.ts` -> 3 files, 12 tests, type errors clean.
+- Focused Bun auth/CLI command -> 93 pass, 0 fail.
+- `bun --cwd packages/kitcn build` and `bun typecheck` -> passed.
+- `bun lint:fix` -> 876 files, no fixes.
+- `bun run lint:slop:delta` -> finding count unchanged, score +0.12; only existing auth directory fan-out hotspot.
+- `bun run fixtures:check` -> all 8 fixtures match fresh output after one transient network-stall retry.
+- `bun run test:verify` -> passed.
+- `bun run test:runtime` -> running.
+
+Timeline:
+- 2026-08-14T18:17:54.453Z Autoclosure plan created.
+- 2026-08-14T18:25:00Z Restored deterministic JWT-cache forwarding proof in Vitest.
+- 2026-08-14T18:41:00Z Focused/build/lint/fixture/verify proof passed; runtime and review remain.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge PR 318 with deterministic auth adapter proof and no release trigger |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- The latest branch removed nondeterministic `jwtCache` forwarding tests; a
+  stable proof owner must be accepted before merge.
+
+Findings:
+- Cross-table ID access can read, update, or delete the wrong model row.
+- Current CI is green, but the forwarding regression test was removed.
+
+Decisions and tradeoffs:
+- Disable auto-release on this PR so PR 321 can publish the complete batch.
+
+Review fixes:
+- Missing deterministic `jwtCache: false` forwarding proof -> accepted -> added
+  isolated Vitest assertion and replaced the Bun no-test comment.

--- a/docs/plans/318-close-auth-adapter-pr.md
+++ b/docs/plans/318-close-auth-adapter-pr.md
@@ -80,17 +80,17 @@ Closure matrix:
 | docs/package skill | no | N/A: no public docs or package skill changed | N/A |
 | changeset | yes | `.changeset/auth-adapter-wrong-rows.md` audit | passed: patch sections match final behavior |
 | agent workflow | no | N/A: no agent workflow/action changed | N/A |
-| cleanup/review | yes | Deslop and autoreview | pending |
-| repository check | yes | `bun check` | pending |
+| cleanup/review | yes | Deslop and autoreview | passed: no accepted findings |
+| repository check | yes | `bun check` | passed |
 | GitHub delivery | yes | PR 318 update/merge/read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Each lane is proven or N/A with a concrete reason.
 - [x] Generated output is N/A: no generated owner is touched.
-- [ ] Package build and living changeset match the final behavior; docs/skill/
+- [x] Package build and living changeset match the final behavior; docs/skill/
       fixtures/scenarios are N/A for this runtime-only delta.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: no rule or generated skill mirror is changed.
@@ -114,9 +114,9 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: zero net findings; no worthwhile cleanup |
 | Agent-native reviewer | no | N/A: no agent-facing action changed | Applicability audit recorded |
 | Final lint | yes | Run `bun lint:fix` | passed: 876 files, no fixes |
-| Repository check | yes | Run `bun check` | pending |
+| Repository check | yes | Run `bun check` | passed end to end |
 | GitHub delivery | yes | Update checkbox/branch, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: clean branch review, confidence 0.98 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/318-close-auth-adapter-pr.md` | pending |
 | Agent source / generated sync | no | N/A: no agent source or mirror change | N/A |
 | Installed lock audit | no | N/A: no skill state change | N/A |
@@ -129,7 +129,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | completed | PR contract/files/checks and proof gap reconstructed | repair |
 | Repair | completed | deterministic Vitest forwarding proof added | review |
-| Review/checks | in_progress | focused tests/build/types/lint/fixtures/verify passed | autoreview and final `bun check` |
+| Review/checks | completed | focused tests/build/types/lint/fixtures/verify/runtime, autoreview, and `bun check` passed | delivery |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -142,18 +142,23 @@ Verification evidence:
 - `bun run lint:slop:delta` -> finding count unchanged, score +0.12; only existing auth directory fan-out hotspot.
 - `bun run fixtures:check` -> all 8 fixtures match fresh output after one transient network-stall retry.
 - `bun run test:verify` -> passed.
-- `bun run test:runtime` -> running.
+- `bun run test:runtime` -> passed; supported scenarios started and auth smoke checks passed.
+- Autoreview branch diff against `kitcn/main` -> clean, no accepted or actionable findings, confidence 0.98.
+- `bun check` -> passed end to end, including lint, types, tests, fixtures,
+  verify, and runtime scenarios.
 
 Timeline:
 - 2026-08-14T18:17:54.453Z Autoclosure plan created.
 - 2026-08-14T18:25:00Z Restored deterministic JWT-cache forwarding proof in Vitest.
-- 2026-08-14T18:41:00Z Focused/build/lint/fixture/verify proof passed; runtime and review remain.
+- 2026-08-14T18:41:00Z Focused/build/lint/fixture/verify proof passed.
+- 2026-08-14T20:47:00Z Runtime scenarios and independent autoreview passed; exact final check remains.
+- 2026-08-14T20:54:00Z Exact `bun check` passed end to end.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Delivery |
+| Where am I going? | GitHub checks, merge, read-back, final audit |
 | What is the goal? | Merge PR 318 with deterministic auth adapter proof and no release trigger |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |

--- a/docs/plans/319-close-ratelimit-accounting-pr.md
+++ b/docs/plans/319-close-ratelimit-accounting-pr.md
@@ -1,0 +1,155 @@
+# Close ratelimit accounting PR
+
+Objective:
+Close PR 319 with rate-limit accounting regressions proved, docs and published
+package skill synchronized, reviews clean, checks passing, and PR merged.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/319-close-ratelimit-accounting-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Focused ratelimit tests prove count/sharding/remaining/reset behavior; docs,
+  package skill, installed mirror, and changeset agree; zero findings; `bun check`
+  passes; PR 319 is squash-merged without auto-release.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused ratelimit tests, package build/types, docs/skill/mirror audit, deslop,
+  agent-native review, autoreview, lint, check, GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: PR 319 rate-limit accounting and sharding contract
+- allowed repairs: touched ratelimit source/tests/docs/package skill/mirror/changeset
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new algorithms or unrelated plugin APIs
+
+Output budget strategy:
+- Exact ratelimit files and focused failures; cap review/check output; exclude artifacts.
+
+Blocked condition:
+- Repeated external/environment failure or a finding requiring a new limiter API.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 319 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Squash-merge; no release trigger |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | yes | Published ratelimit package skill guidance |
+| Source rule versus generated mirror boundary identified | yes | Package skill owns installed `.agents` mirror |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill membership change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded fully |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused ratelimit tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | yes | Package skill to `.agents` mirror | pending |
+| fixtures/scenarios | no | N/A: no scaffold output | N/A |
+| docs/package skill | yes | www/package skill/mirror agreement | pending |
+| changeset | yes | `.changeset/ratelimit-accounting.md` audit | pending |
+| agent workflow | yes | Published behavior/guard discoverability | pending |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 319 update/merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: package skill owner/mirror boundary recorded.
+- [ ] Agent-native pack: ratelimit semantics and invalid shard guard are discoverable.
+- [ ] Agent-native pack: package skill/mirror parity proved; `.agents/rules` N/A.
+- [x] Agent-native pack: installed skill membership unchanged.
+- [ ] Agent-native pack: published guidance represents exact budget/guard behavior.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused ratelimit tests | pending |
+| Source/generated audit | yes | Prove package skill/mirror parity | pending |
+| Package/docs/scenario closure | yes | Build and audit docs/skill/changeset | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | yes | Review published ratelimit guidance | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/319-close-ratelimit-accounting-pr.md` | pending |
+| Agent source / generated sync | yes | Verify package skill/mirror | pending |
+| Installed lock audit | no | N/A: no skill membership change | N/A |
+| Agent action discoverability | yes | Audit published ratelimit skill route | pending |
+| Helper and template smoke | no | N/A: no workflow helper/template | N/A |
+| Agent-native review | yes | Close accepted guidance findings | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 319 CI/Vercel green at goal creation; no approval yet.
+
+Timeline:
+- 2026-08-14T18:17:55.073Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge correct limiter accounting with synchronized guidance |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- PR currently changes www docs without the matching published package skill; closeout must repair that owner drift.
+
+Findings:
+- Repo policy requires www docs and package skill synchronization.
+
+Decisions and tradeoffs:
+- Add/update package skill owner, regenerate mirror, and keep runtime scope unchanged.
+
+Review fixes:
+- Pending.

--- a/docs/plans/320-close-crpc-correctness-pr.md
+++ b/docs/plans/320-close-crpc-correctness-pr.md
@@ -1,0 +1,155 @@
+# Close cRPC correctness PR
+
+Objective:
+Close PR 320 within its cRPC validation/middleware/HTTP error contract after
+focused proof, cleanup, review closure, full checks, and squash merge.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/320-close-crpc-correctness-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Focused server tests prove validation, middleware chaining, error identity,
+  status mapping, and malformed JSON behavior; zero findings; package build and
+  `bun check` pass; changeset agrees; PR 320 is merged without auto-release.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused server tests, package build/types, changeset audit, deslop,
+  agent-native applicability audit, autoreview, lint, check, GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: PR 320 cRPC input/middleware/error/HTTP correctness
+- allowed repairs: touched server source/tests and living changeset
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new procedure APIs or unrelated transport redesign
+
+Output budget strategy:
+- Exact server files and focused failures; cap review/check output; exclude artifacts.
+
+Blocked condition:
+- Repeated external/environment failure or a finding requiring a new public server contract.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 320 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Squash-merge; no release trigger |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | no | N/A: runtime server behavior only |
+| Source rule versus generated mirror boundary identified | no | N/A: no rule/mirror change |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill state change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded; applicability N/A |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused server tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | no | N/A: no generated output | N/A |
+| fixtures/scenarios | no | N/A: no scaffold output | N/A |
+| docs/package skill | no | N/A: no docs/skill delta | N/A |
+| changeset | yes | `.changeset/crpc-procedure-contracts.md` audit | pending |
+| agent workflow | no | N/A: no agent action | N/A |
+| cleanup/review | yes | Deslop and autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 320 update/merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output is N/A: no generated owner is touched.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: no rule/generated mirror changed.
+- [x] Agent-native pack: no agent action changed; discoverability N/A.
+- [x] Agent-native pack: mirror sync N/A.
+- [x] Agent-native pack: installed skill state unchanged.
+- [x] Agent-native pack: agent routing/eval rows N/A.
+- [x] Agent-native pack: agent-native review N/A after applicability audit.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused server tests | pending |
+| Source/generated audit | no | N/A: source-only runtime change | N/A |
+| Package/docs/scenario closure | yes | Build package and audit changeset | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/320-close-crpc-correctness-pr.md` | pending |
+| Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
+| Installed lock audit | no | N/A: no skill state change | N/A |
+| Agent action discoverability | no | N/A: no agent action | N/A |
+| Helper and template smoke | no | N/A: no workflow helper/template | N/A |
+| Agent-native review | no | N/A after applicability audit | No agent surface |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 320 CI/Vercel green at goal creation; no approval yet.
+
+Timeline:
+- 2026-08-14T18:17:54.952Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge proven cRPC validation, middleware, and HTTP correctness |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- Middleware terminal-chain changes can double-run or skip handlers if review misses propagation paths.
+
+Findings:
+- cRPC error identity crosses a Convex syscall boundary and needs behavior-level tests.
+
+Decisions and tradeoffs:
+- Keep the resolver as terminal middleware owner; reject adjacent API redesign.
+
+Review fixes:
+- Pending.

--- a/docs/plans/321-close-react-auth-pr.md
+++ b/docs/plans/321-close-react-auth-pr.md
@@ -1,0 +1,156 @@
+# Close React auth PR
+
+Objective:
+Close PR 321 as the final batch merge and sole auto-release trigger after React,
+RSC, auth-cache, and caller retry behavior is proved and all checks/reviews pass.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/321-close-react-auth-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Focused React/RSC/server tests pass; zero findings; package build and `bun check`
+  pass; changeset agrees; all six earlier PRs are merged; PR 321 merges with
+  auto-release checked; Version Packages merge and publish workflow succeed.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Focused React/RSC/server tests, package build/types, changeset audit, deslop,
+  agent-native applicability audit, autoreview, lint, check, PR/release read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: PR 321 JWT/auth cache/query metadata/RSC/caller retry behavior
+- allowed repairs: touched React/RSC/server/internal source/tests and changeset
+- unrelated files: preserve; do not treat as blockers
+- non-goals: Solid client repair, unrelated query APIs, release-policy changes
+
+Output budget strategy:
+- Exact changed files and focused failures; compact GitHub release checks; exclude artifacts.
+
+Blocked condition:
+- Repeated publish/external failure or a finding requiring a new public client contract.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 321 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Merge last with auto-release checked; verify publish |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | no | N/A: runtime client behavior only |
+| Source rule versus generated mirror boundary identified | no | N/A: no rule/mirror change |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill state change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded; applicability N/A |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused React/RSC/server tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | no | N/A: no generated output | N/A |
+| fixtures/scenarios | no | N/A: no scaffold output | N/A |
+| docs/package skill | no | N/A: no docs/skill delta | N/A |
+| changeset | yes | `.changeset/react-rsc-auth-cache.md` audit | pending |
+| agent workflow | no | N/A: no agent action | N/A |
+| cleanup/review | yes | Deslop and autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 321 merge plus Version Packages/publish read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output is N/A: no generated owner is touched.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: no rule/generated mirror changed.
+- [x] Agent-native pack: no agent action changed; discoverability N/A.
+- [x] Agent-native pack: mirror sync N/A.
+- [x] Agent-native pack: installed skill state unchanged.
+- [x] Agent-native pack: agent routing/eval rows N/A.
+- [x] Agent-native pack: agent-native review N/A after applicability audit.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused React/RSC/server tests | pending |
+| Source/generated audit | no | N/A: source-only runtime change | N/A |
+| Package/docs/scenario closure | yes | Build package and audit changeset | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Merge last and verify release/publish | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/321-close-react-auth-pr.md` | pending |
+| Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
+| Installed lock audit | no | N/A: no skill state change | N/A |
+| Agent action discoverability | no | N/A: no agent action | N/A |
+| Helper and template smoke | no | N/A: no workflow helper/template | N/A |
+| Agent-native review | no | N/A after applicability audit | No agent surface |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 321 CI/Vercel green at goal creation; auto-release checked; no approval yet.
+
+Timeline:
+- 2026-08-14T18:17:55.196Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge final client/auth fix and publish the complete batch once |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- Auth-cache scoping and failed-action retry can leak data or duplicate effects if review misses a path.
+- Release proof is external and must be read back after merge.
+
+Findings:
+- PR 321 is intentionally last solely because it owns the single release trigger.
+
+Decisions and tradeoffs:
+- Keep Solid's matching decoder bug out of scope as the PR explicitly states.
+
+Review fixes:
+- Pending.

--- a/docs/plans/322-close-cli-safety-pr.md
+++ b/docs/plans/322-close-cli-safety-pr.md
@@ -1,0 +1,157 @@
+# Close CLI safety PR
+
+Objective:
+Close PR 322 with destructive-overwrite and schema-edit regressions proved,
+generated/docs/skill/fixture owners synchronized, review clean, checks passing,
+and the PR merged without triggering release.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/322-close-cli-safety-pr.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- Focused CLI tests and fixture sync/check pass; source-owned package skill,
+  `.agents` mirror, and docs agree; zero accepted findings; `bun check` passes;
+  PR 322 is squash-merged with auto-release off.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- CLI tests, `fixtures:sync`, `fixtures:check`, package build/types, source/mirror
+  audit, deslop, agent-native review, autoreview, lint, check, GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: PR 322 safe file ownership/refusal and AST schema editing
+- allowed repairs: touched CLI owners/tests/docs/package skill/mirror/changeset/fixtures
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new CLI commands, unrelated scaffold redesign, compatibility shims
+
+Output budget strategy:
+- Exact CLI changed files and focused test/fix logs; summarize fixture diffs;
+  exclude materialized scenarios, build artifacts, and broad generated output.
+
+Blocked condition:
+- Repeated fixture/bootstrap environment failure or a finding requiring a new CLI contract.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR 322 body/files/checks read |
+| Intended delta and exclusions recorded | yes | Objective and Boundaries |
+| Closure matrix classified | yes | Matrix below |
+| GitHub delivery expectation recorded | yes | Squash-merge; no release trigger |
+| Active goal checked or created | yes | Linked from active batch goal |
+| Agent-native pack selected | yes | Materialized by autoclosure |
+| Agent-facing action surface identified | yes | `kitcn add/init --yes/--overwrite/--json` |
+| Source rule versus generated mirror boundary identified | yes | Package skill owns `.agents/skills/kitcn` mirror |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill membership change |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded fully |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused CLI tests | pending |
+| package/API/build | yes | Package build/types | pending |
+| generated output | yes | Package skill to `.agents` mirror plus fixtures | pending |
+| fixtures/scenarios | yes | `fixtures:sync` and `fixtures:check` | pending |
+| docs/package skill | yes | www/package skill/mirror audit | pending |
+| changeset | yes | `.changeset/cli-safe-file-edits.md` audit | pending |
+| agent workflow | yes | Deterministic non-interactive refusal/output contract | pending |
+| cleanup/review | yes | Deslop, agent-native review, autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | PR 322 update/merge/read-back | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] Agent-native pack: package skill source owner/mirror boundary recorded.
+- [ ] Agent-native pack: safe CLI refusal and overwrite routes are discoverable.
+- [ ] Agent-native pack: package skill mirror and fixtures are regenerated/proved.
+- [x] Agent-native pack: installed skill membership unchanged.
+- [ ] Agent-native pack: JSON refused receipt, exit status, and forbidden overwrite behavior have tests.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run focused CLI tests | pending |
+| Source/generated audit | yes | Regenerate/prove skill mirror and fixtures | pending |
+| Package/docs/scenario closure | yes | Build, docs/skill/changeset, fixtures | pending |
+| Deslop | yes | Run changed-file cleanup review | pending |
+| Agent-native reviewer | yes | Review CLI agent route and receipts | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/322-close-cli-safety-pr.md` | pending |
+| Agent source / generated sync | yes | Prove package skill mirror; `.agents/rules` N/A | pending |
+| Installed lock audit | no | N/A: no skill membership change | N/A |
+| Agent action discoverability | yes | Audit package skill CLI guidance | pending |
+| Helper and template smoke | yes | Focused CLI planner/codegen/refusal tests | pending |
+| Agent-native review | yes | Close accepted CLI agent-route findings | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- PR 322 CI/Vercel green at goal creation; no approval yet.
+
+Timeline:
+- 2026-08-14T18:17:54.831Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge safe CLI ownership and schema editing with full generated proof |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- Fail-closed file ownership can half-install a plugin unless refusal and lockfile receipts agree.
+
+Findings:
+- This is the batch's widest generated/fixture/agent-facing closeout surface.
+
+Decisions and tradeoffs:
+- Require fixture sync/check and structured refusal proof before merge.
+
+Review fixes:
+- Pending.

--- a/packages/kitcn/src/auth-nextjs/index.test.ts
+++ b/packages/kitcn/src/auth-nextjs/index.test.ts
@@ -1,6 +1,11 @@
-import * as tokenModule from '../auth/internal/token';
 import { convexBetterAuth } from './index';
 
+// `auth.jwtCache` forwarding is deliberately not unit-tested here. The only
+// observable seam is the shared `../auth/internal/token` module namespace, and
+// a spy on it in Bun's single-process runner records calls other test files
+// make, so no assertion through it is deterministic. The cached vs uncached
+// behaviour it selects is covered by `auth/internal/token.ts`. Please do not
+// re-add a spy-based test for it.
 describe('convexBetterAuth', () => {
   // Bun shares one process across test files, so a fetch stub installed by an
   // earlier file can still be live here. Pin the global around every test so
@@ -110,67 +115,5 @@ describe('convexBetterAuth', () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
-  });
-
-  // These two assert how `auth.jwtCache` is forwarded to the token layer.
-  // They spy on the token module rather than stubbing `globalThis.fetch`, so
-  // no ambient fetch state can shadow the call being measured. How many times
-  // the token layer is called is not part of the contract — retries and
-  // ambient state can change it — so assert only on the values forwarded.
-  describe('jwtCache forwarding', () => {
-    let getTokenSpy: ReturnType<typeof spyOn>;
-
-    // Distinct `jwtCache.enabled` values across every recorded call. `[false]`
-    // means "called at least once, and every call disabled the cache".
-    const forwardedCacheFlags = () =>
-      Array.from(
-        new Set(
-          getTokenSpy.mock.calls.map(
-            (call) =>
-              (call?.[2] as { jwtCache?: { enabled?: boolean } } | undefined)
-                ?.jwtCache?.enabled
-          )
-        )
-      );
-
-    beforeEach(() => {
-      getTokenSpy = spyOn(tokenModule, 'getToken').mockImplementation(
-        async () => ({ isFresh: true, token: 'server-token' })
-      );
-    });
-
-    afterEach(() => {
-      getTokenSpy.mockRestore();
-    });
-
-    test('jwtCache false disables the cache without disabling auth', async () => {
-      const { createContext } = convexBetterAuth({
-        api: {},
-        auth: { jwtCache: false },
-        convexSiteUrl: 'https://my-app.convex.site',
-      });
-
-      const ctx = await createContext({ headers: new Headers() });
-
-      // With auth wired off entirely the token layer is never reached at all
-      // and the request runs anonymously.
-      expect(getTokenSpy).toHaveBeenCalled();
-      expect(forwardedCacheFlags()).toEqual([false]);
-      expect(ctx.token).toBe('server-token');
-      expect(ctx.isAuthenticated).toBe(true);
-    });
-
-    test('jwtCache defaults to enabled', async () => {
-      const { createContext } = convexBetterAuth({
-        api: {},
-        convexSiteUrl: 'https://my-app.convex.site',
-      });
-
-      const ctx = await createContext({ headers: new Headers() });
-
-      expect(getTokenSpy).toHaveBeenCalled();
-      expect(forwardedCacheFlags()).toEqual([true]);
-      expect(ctx.token).toBe('server-token');
-    });
   });
 });

--- a/packages/kitcn/src/auth-nextjs/index.test.ts
+++ b/packages/kitcn/src/auth-nextjs/index.test.ts
@@ -1,6 +1,20 @@
+import * as tokenModule from '../auth/internal/token';
 import { convexBetterAuth } from './index';
 
 describe('convexBetterAuth', () => {
+  // Bun shares one process across test files, so a fetch stub installed by an
+  // earlier file can still be live here. Pin the global around every test so
+  // this file neither inherits nor leaks one.
+  let ambientFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    ambientFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ambientFetch;
+  });
+
   test('creates GET/POST/OPTIONS handlers that rewrite request URL to convex site', async () => {
     const originalFetch = globalThis.fetch;
     const calls: Array<{
@@ -98,74 +112,52 @@ describe('convexBetterAuth', () => {
     }
   });
 
-  test('jwtCache false still authenticates, skipping only the cookie cache', async () => {
-    const originalFetch = globalThis.fetch;
-    const requests: string[] = [];
+  // These two assert how `auth.jwtCache` is forwarded to the token layer.
+  // They spy on the token module rather than stubbing `globalThis.fetch`, so
+  // no ambient fetch state can shadow the call being measured.
+  describe('jwtCache forwarding', () => {
+    let getTokenSpy: ReturnType<typeof spyOn>;
+    const jwtCacheOf = (call: unknown[]) =>
+      (call?.[2] as { jwtCache?: { enabled?: boolean } } | undefined)?.jwtCache;
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      requests.push(String(input));
-      return new Response(JSON.stringify({ token: 'fresh-token' }), {
-        headers: { 'content-type': 'application/json' },
-      });
-    }) as typeof fetch;
+    beforeEach(() => {
+      getTokenSpy = spyOn(tokenModule, 'getToken').mockImplementation(
+        async () => ({ isFresh: true, token: 'server-token' })
+      );
+    });
 
-    try {
+    afterEach(() => {
+      getTokenSpy.mockRestore();
+    });
+
+    test('jwtCache false disables the cache without disabling auth', async () => {
       const { createContext } = convexBetterAuth({
         api: {},
         auth: { jwtCache: false },
         convexSiteUrl: 'https://my-app.convex.site',
       });
 
-      const ctx = await createContext({
-        headers: new Headers({
-          cookie: 'better-auth.convex_jwt=cached.jwt.value',
-        }),
-      });
+      const ctx = await createContext({ headers: new Headers() });
 
-      expect(ctx.token).toBe('fresh-token');
+      // With auth wired off entirely, getToken is never reached and the
+      // request runs anonymously.
+      expect(getTokenSpy).toHaveBeenCalledTimes(1);
+      expect(jwtCacheOf(getTokenSpy.mock.calls[0] ?? [])?.enabled).toBe(false);
+      expect(ctx.token).toBe('server-token');
       expect(ctx.isAuthenticated).toBe(true);
-      expect(requests).toHaveLength(1);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
+    });
 
-  test('jwtCache default reuses an unexpired token from the cookie', async () => {
-    const originalFetch = globalThis.fetch;
-    const requests: string[] = [];
-
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      requests.push(String(input));
-      return new Response(JSON.stringify({ token: 'fresh-token' }), {
-        headers: { 'content-type': 'application/json' },
-      });
-    }) as typeof fetch;
-
-    const encode = (value: object) =>
-      btoa(JSON.stringify(value))
-        .replaceAll('+', '-')
-        .replaceAll('/', '_')
-        .replaceAll('=', '');
-    const cachedToken = `${encode({ alg: 'RS256' })}.${encode({
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    })}.sig`;
-
-    try {
+    test('jwtCache defaults to enabled', async () => {
       const { createContext } = convexBetterAuth({
         api: {},
         convexSiteUrl: 'https://my-app.convex.site',
       });
 
-      const ctx = await createContext({
-        headers: new Headers({
-          cookie: `better-auth.convex_jwt=${cachedToken}`,
-        }),
-      });
+      const ctx = await createContext({ headers: new Headers() });
 
-      expect(ctx.token).toBe(cachedToken);
-      expect(requests).toHaveLength(0);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+      expect(getTokenSpy).toHaveBeenCalledTimes(1);
+      expect(jwtCacheOf(getTokenSpy.mock.calls[0] ?? [])?.enabled).toBe(true);
+      expect(ctx.token).toBe('server-token');
+    });
   });
 });

--- a/packages/kitcn/src/auth-nextjs/index.test.ts
+++ b/packages/kitcn/src/auth-nextjs/index.test.ts
@@ -1,11 +1,7 @@
 import { convexBetterAuth } from './index';
 
-// `auth.jwtCache` forwarding is deliberately not unit-tested here. The only
-// observable seam is the shared `../auth/internal/token` module namespace, and
-// a spy on it in Bun's single-process runner records calls other test files
-// make, so no assertion through it is deterministic. The cached vs uncached
-// behaviour it selects is covered by `auth/internal/token.ts`. Please do not
-// re-add a spy-based test for it.
+// `auth.jwtCache` forwarding is covered by the isolated Vitest lane because
+// Bun shares module spies across test files in one process.
 describe('convexBetterAuth', () => {
   // Bun shares one process across test files, so a fetch stub installed by an
   // earlier file can still be live here. Pin the global around every test so

--- a/packages/kitcn/src/auth-nextjs/index.test.ts
+++ b/packages/kitcn/src/auth-nextjs/index.test.ts
@@ -114,11 +114,24 @@ describe('convexBetterAuth', () => {
 
   // These two assert how `auth.jwtCache` is forwarded to the token layer.
   // They spy on the token module rather than stubbing `globalThis.fetch`, so
-  // no ambient fetch state can shadow the call being measured.
+  // no ambient fetch state can shadow the call being measured. How many times
+  // the token layer is called is not part of the contract — retries and
+  // ambient state can change it — so assert only on the values forwarded.
   describe('jwtCache forwarding', () => {
     let getTokenSpy: ReturnType<typeof spyOn>;
-    const jwtCacheOf = (call: unknown[]) =>
-      (call?.[2] as { jwtCache?: { enabled?: boolean } } | undefined)?.jwtCache;
+
+    // Distinct `jwtCache.enabled` values across every recorded call. `[false]`
+    // means "called at least once, and every call disabled the cache".
+    const forwardedCacheFlags = () =>
+      Array.from(
+        new Set(
+          getTokenSpy.mock.calls.map(
+            (call) =>
+              (call?.[2] as { jwtCache?: { enabled?: boolean } } | undefined)
+                ?.jwtCache?.enabled
+          )
+        )
+      );
 
     beforeEach(() => {
       getTokenSpy = spyOn(tokenModule, 'getToken').mockImplementation(
@@ -139,10 +152,10 @@ describe('convexBetterAuth', () => {
 
       const ctx = await createContext({ headers: new Headers() });
 
-      // With auth wired off entirely, getToken is never reached and the
-      // request runs anonymously.
-      expect(getTokenSpy).toHaveBeenCalledTimes(1);
-      expect(jwtCacheOf(getTokenSpy.mock.calls[0] ?? [])?.enabled).toBe(false);
+      // With auth wired off entirely the token layer is never reached at all
+      // and the request runs anonymously.
+      expect(getTokenSpy).toHaveBeenCalled();
+      expect(forwardedCacheFlags()).toEqual([false]);
       expect(ctx.token).toBe('server-token');
       expect(ctx.isAuthenticated).toBe(true);
     });
@@ -155,8 +168,8 @@ describe('convexBetterAuth', () => {
 
       const ctx = await createContext({ headers: new Headers() });
 
-      expect(getTokenSpy).toHaveBeenCalledTimes(1);
-      expect(jwtCacheOf(getTokenSpy.mock.calls[0] ?? [])?.enabled).toBe(true);
+      expect(getTokenSpy).toHaveBeenCalled();
+      expect(forwardedCacheFlags()).toEqual([true]);
       expect(ctx.token).toBe('server-token');
     });
   });

--- a/packages/kitcn/src/auth-nextjs/index.test.ts
+++ b/packages/kitcn/src/auth-nextjs/index.test.ts
@@ -97,4 +97,75 @@ describe('convexBetterAuth', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('jwtCache false still authenticates, skipping only the cookie cache', async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({ token: 'fresh-token' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    try {
+      const { createContext } = convexBetterAuth({
+        api: {},
+        auth: { jwtCache: false },
+        convexSiteUrl: 'https://my-app.convex.site',
+      });
+
+      const ctx = await createContext({
+        headers: new Headers({
+          cookie: 'better-auth.convex_jwt=cached.jwt.value',
+        }),
+      });
+
+      expect(ctx.token).toBe('fresh-token');
+      expect(ctx.isAuthenticated).toBe(true);
+      expect(requests).toHaveLength(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('jwtCache default reuses an unexpired token from the cookie', async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: string[] = [];
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({ token: 'fresh-token' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const encode = (value: object) =>
+      btoa(JSON.stringify(value))
+        .replaceAll('+', '-')
+        .replaceAll('/', '_')
+        .replaceAll('=', '');
+    const cachedToken = `${encode({ alg: 'RS256' })}.${encode({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })}.sig`;
+
+    try {
+      const { createContext } = convexBetterAuth({
+        api: {},
+        convexSiteUrl: 'https://my-app.convex.site',
+      });
+
+      const ctx = await createContext({
+        headers: new Headers({
+          cookie: `better-auth.convex_jwt=${cachedToken}`,
+        }),
+      });
+
+      expect(ctx.token).toBe(cachedToken);
+      expect(requests).toHaveLength(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/packages/kitcn/src/auth-nextjs/index.ts
+++ b/packages/kitcn/src/auth-nextjs/index.ts
@@ -109,25 +109,23 @@ export function convexBetterAuth<TApi extends Record<string, unknown>>(
 
   const { createContext, createCaller } = createCallerFactory({
     api: opts.api,
-    auth: jwtCacheEnabled
-      ? {
-          getToken: (siteUrl, headers, getTokenOpts) => {
-            const mutableHeaders = new Headers(headers);
-            stripHopByHopHeaders(mutableHeaders);
-            mutableHeaders.set('accept-encoding', 'identity');
-            return getToken(siteUrl, mutableHeaders, {
-              basePath: auth.basePath,
-              ...(getTokenOpts as GetTokenOptions),
-              jwtCache: {
-                enabled: true,
-                expirationToleranceSeconds: auth.expirationToleranceSeconds,
-                isAuthError: auth.isUnauthorized ?? defaultIsUnauthorized,
-              },
-            });
+    auth: {
+      getToken: (siteUrl, headers, getTokenOpts) => {
+        const mutableHeaders = new Headers(headers);
+        stripHopByHopHeaders(mutableHeaders);
+        mutableHeaders.set('accept-encoding', 'identity');
+        return getToken(siteUrl, mutableHeaders, {
+          basePath: auth.basePath,
+          ...(getTokenOpts as GetTokenOptions),
+          jwtCache: {
+            enabled: jwtCacheEnabled,
+            expirationToleranceSeconds: auth.expirationToleranceSeconds,
+            isAuthError: auth.isUnauthorized ?? defaultIsUnauthorized,
           },
-          isUnauthorized: auth.isUnauthorized ?? defaultIsUnauthorized,
-        }
-      : undefined,
+        });
+      },
+      isUnauthorized: auth.isUnauthorized ?? defaultIsUnauthorized,
+    },
     convexSiteUrl: opts.convexSiteUrl,
     convexUrl: opts.convexUrl,
   });

--- a/packages/kitcn/src/auth-nextjs/index.vitest.ts
+++ b/packages/kitcn/src/auth-nextjs/index.vitest.ts
@@ -1,10 +1,48 @@
 import { createServer } from 'node:http';
 
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
+import * as tokenModule from '../auth/internal/token';
 import { convexBetterAuth } from './index';
 
 describe('convexBetterAuth (Node)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('jwtCache false disables caching without disabling auth', async () => {
+    const getToken = vi
+      .spyOn(tokenModule, 'getToken')
+      .mockResolvedValue({ isFresh: true, token: 'token' });
+    const isUnauthorized = () => false;
+    const { createContext } = convexBetterAuth({
+      api: {},
+      auth: {
+        expirationToleranceSeconds: 15,
+        isUnauthorized,
+        jwtCache: false,
+      },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    await createContext({
+      headers: new Headers({ connection: 'keep-alive' }),
+    });
+
+    expect(getToken).toHaveBeenCalledOnce();
+    const [siteUrl, headers, options] = getToken.mock.calls[0] ?? [];
+    expect(siteUrl).toBe('https://example.convex.site');
+    expect(headers?.get('connection')).toBeNull();
+    expect(headers?.get('accept-encoding')).toBe('identity');
+    expect(options).toMatchObject({
+      jwtCache: {
+        enabled: false,
+        expirationToleranceSeconds: 15,
+        isAuthError: isUnauthorized,
+      },
+    });
+  });
+
   test('POST handler forwards non-2xx upstream responses', async () => {
     let requestBody = '';
     const server = createServer((req, res) => {

--- a/packages/kitcn/src/auth/adapter-utils.ts
+++ b/packages/kitcn/src/auth/adapter-utils.ts
@@ -9,7 +9,7 @@ import type {
   SchemaDefinition,
   TableNamesInDataModel,
 } from 'convex/server';
-import { type GenericId, type Infer, v } from 'convex/values';
+import { type Infer, v } from 'convex/values';
 import { asyncMap } from '../internal/upstream';
 import {
   mergedStream,
@@ -475,6 +475,24 @@ const filterByWhere = <
   return true;
 };
 
+// Convex's single-argument `db.get` is table-unchecked: it resolves an id from
+// any table. Auth models must never read, patch or delete another model's rows,
+// so every id lookup is normalized against the queried table first. Ids that
+// belong elsewhere, or that are not ids at all, resolve to "not found".
+const getByIdInTable = async (
+  ctx: GenericQueryCtx<GenericDataModel>,
+  model: string,
+  value: unknown
+) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalizedId = ctx.db.normalizeId(model as any, value);
+
+  return normalizedId === null ? null : await ctx.db.get(normalizedId);
+};
+
 const generateQuery = (
   ctx: GenericQueryCtx<GenericDataModel>,
   schema: SchemaDefinition<any, any>,
@@ -609,7 +627,7 @@ export const paginate = async <
       }) || {};
     const doc =
       uniqueWhere.field === '_id'
-        ? await ctx.db.get(uniqueWhere.value as GenericId<T>)
+        ? await getByIdInTable(ctx, args.model, uniqueWhere.value)
         : await ctx.db
             .query(args.model as any)
             .withIndex(index?.indexDescriptor as any, (q) =>
@@ -661,7 +679,7 @@ export const paginate = async <
     // For ids, just use asyncMap + .get()
     if (inWhere.field === '_id') {
       const docs = await asyncMap(inWhere.value as any[], async (value) =>
-        ctx.db.get(value as GenericId<T>)
+        getByIdInTable(ctx, args.model, value)
       );
       const filteredDocs = docs
         .flatMap((doc) => (doc ? [doc] : []))
@@ -727,28 +745,12 @@ export const paginate = async <
     };
   }
 
-  // Handle not_in operator separately as it requires filtering out documents
+  // `not_in` is applied inside the stream by `generateQuery`, like `ne` and
+  // `contains`, so the page limit counts only rows that satisfy the clause.
   const notInWhere = args.where?.find((w) => w.operator === 'not_in');
 
-  if (notInWhere) {
-    if (!Array.isArray(notInWhere.value)) {
-      throw new TypeError('not_in clause value must be an array');
-    }
-
-    // For not_in with IDs, we need to query all and filter out the excluded ones
-    const query = generateQuery(ctx, schema, {
-      ...args,
-      where: args.where?.filter((w) => w !== notInWhere),
-    });
-    const result = await query.paginate(paginationOpts);
-    const filteredPage = result.page.filter((doc) =>
-      filterByWhere(doc, [notInWhere])
-    );
-
-    return {
-      ...result,
-      page: filteredPage.map((doc) => selectFields(doc, args.select)),
-    };
+  if (notInWhere && !Array.isArray(notInWhere.value)) {
+    throw new TypeError('not_in clause value must be an array');
   }
 
   const query = generateQuery(ctx, schema, args);

--- a/packages/kitcn/src/auth/adapter-utils.vitest.ts
+++ b/packages/kitcn/src/auth/adapter-utils.vitest.ts
@@ -1,0 +1,206 @@
+import { defineSchema, defineTable } from 'convex/server';
+import { v } from 'convex/values';
+import { describe, expect, test } from 'vitest';
+import { convexTest } from '../../../../convex/setup.testing';
+import { listOne, paginate } from './adapter-utils';
+import { deleteOneHandler, updateOneHandler } from './create-api';
+
+const schema = defineSchema({
+  user: defineTable({
+    email: v.string(),
+    role: v.string(),
+  }).index('email', ['email']),
+  member: defineTable({
+    organizationId: v.string(),
+    role: v.string(),
+    userId: v.string(),
+  }).index('organizationId', ['organizationId']),
+  invitation: defineTable({
+    organizationId: v.string(),
+    status: v.string(),
+  }).index('organizationId', ['organizationId']),
+});
+
+const betterAuthSchema = {
+  invitation: {
+    fields: { organizationId: {}, status: {} },
+    modelName: 'invitation',
+  },
+  member: {
+    fields: { organizationId: {}, role: {}, userId: {} },
+    modelName: 'member',
+  },
+  user: {
+    fields: { email: { unique: true }, role: {} },
+    modelName: 'user',
+  },
+} as any;
+
+const insertUser = (ctx: any) =>
+  ctx.db.insert('user', { email: 'victim@example.com', role: 'user' });
+
+describe('id where clauses are scoped to the queried table', () => {
+  test('findOne for one model does not return a row from another table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const userId = await insertUser(ctx);
+
+      const doc = await listOne(ctx as any, schema, betterAuthSchema, {
+        model: 'member',
+        where: [{ field: '_id', operator: 'eq', value: userId }],
+      });
+
+      expect(doc ?? null).toBeNull();
+    });
+  });
+
+  test('update for one model does not patch a row from another table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const userId = await insertUser(ctx);
+
+      await expect(
+        updateOneHandler(
+          ctx as any,
+          {
+            input: {
+              model: 'member',
+              update: { role: 'owner' },
+              where: [{ field: '_id', operator: 'eq', value: userId }],
+            },
+          },
+          schema as any,
+          betterAuthSchema
+        )
+      ).rejects.toThrow('Failed to update member');
+
+      expect(await ctx.db.get(userId)).toMatchObject({ role: 'user' });
+    });
+  });
+
+  test('delete for one model does not delete a row from another table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const userId = await insertUser(ctx);
+
+      await deleteOneHandler(
+        ctx as any,
+        {
+          input: {
+            model: 'member',
+            where: [{ field: '_id', operator: 'eq', value: userId }],
+          },
+        },
+        schema as any,
+        betterAuthSchema
+      );
+
+      expect(await ctx.db.get(userId)).toMatchObject({
+        email: 'victim@example.com',
+      });
+    });
+  });
+
+  test('in clauses on id drop ids that belong to another table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const userId = await insertUser(ctx);
+      const memberId = await ctx.db.insert('member', {
+        organizationId: 'org1',
+        role: 'member',
+        userId: 'u1',
+      });
+
+      const result = await paginate(ctx as any, schema, betterAuthSchema, {
+        model: 'member',
+        paginationOpts: { cursor: null, numItems: 10 },
+        where: [{ field: '_id', operator: 'in', value: [userId, memberId] }],
+      });
+
+      expect(result.page.map((doc: any) => doc._id)).toEqual([memberId]);
+    });
+  });
+
+  test('malformed ids resolve to not found instead of throwing', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const doc = await listOne(ctx as any, schema, betterAuthSchema, {
+        model: 'member',
+        where: [{ field: '_id', operator: 'eq', value: 'not-an-id' }],
+      });
+
+      expect(doc ?? null).toBeNull();
+    });
+  });
+
+  test('id where clauses still resolve rows in the queried table', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      const memberId = await ctx.db.insert('member', {
+        organizationId: 'org1',
+        role: 'member',
+        userId: 'u1',
+      });
+
+      const doc: any = await listOne(ctx as any, schema, betterAuthSchema, {
+        model: 'member',
+        where: [{ field: '_id', operator: 'eq', value: memberId }],
+      });
+
+      expect(doc?._id).toBe(memberId);
+    });
+  });
+});
+
+describe('not_in clauses are applied before the page limit', () => {
+  test('findOne returns a match that is not in the first scanned row', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('invitation', {
+        organizationId: 'org1',
+        status: 'cancelled',
+      });
+      await ctx.db.insert('invitation', {
+        organizationId: 'org1',
+        status: 'pending',
+      });
+
+      const doc: any = await listOne(ctx as any, schema, betterAuthSchema, {
+        model: 'invitation',
+        where: [
+          { field: 'organizationId', operator: 'eq', value: 'org1' },
+          { field: 'status', operator: 'not_in', value: ['cancelled'] },
+        ],
+      });
+
+      expect(doc?.status).toBe('pending');
+    });
+  });
+
+  test('paginated not_in queries fill the page with matching rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 6; index++) {
+        await ctx.db.insert('invitation', {
+          organizationId: 'org1',
+          status: index % 2 === 0 ? 'cancelled' : 'pending',
+        });
+      }
+
+      const result = await paginate(ctx as any, schema, betterAuthSchema, {
+        model: 'invitation',
+        paginationOpts: { cursor: null, numItems: 3 },
+        where: [
+          { field: 'organizationId', operator: 'eq', value: 'org1' },
+          { field: 'status', operator: 'not_in', value: ['cancelled'] },
+        ],
+      });
+
+      expect(result.page.map((doc: any) => doc.status)).toEqual([
+        'pending',
+        'pending',
+        'pending',
+      ]);
+    });
+  });
+});

--- a/packages/kitcn/src/auth/adapter.test.ts
+++ b/packages/kitcn/src/auth/adapter.test.ts
@@ -7,23 +7,11 @@ import {
 } from './adapter';
 
 describe('handlePagination', () => {
-  test('collects pages and follows split cursor for split-recommended pages', async () => {
+  test('resumes split-recommended pages after the rows they already returned', async () => {
+    // A page covers [cursor, continueCursor]; splitCursor points into the middle
+    // of that same page, so resuming there would replay rows.
+    const rows = Array.from({ length: 5 }, (_, index) => ({ id: index + 1 }));
     const calls: Array<{ cursor: string | null; numItems: number }> = [];
-    const results = [
-      {
-        continueCursor: 'cursor-1',
-        isDone: false,
-        page: [{ id: 1 }],
-        pageStatus: 'SplitRecommended' as const,
-        splitCursor: 'split-1',
-      },
-      {
-        continueCursor: 'cursor-2',
-        isDone: true,
-        page: [{ id: 2 }],
-        pageStatus: 'Done' as const,
-      },
-    ];
 
     const state = await handlePagination(
       async ({ paginationOpts }) => {
@@ -31,16 +19,29 @@ describe('handlePagination', () => {
           cursor: paginationOpts.cursor,
           numItems: paginationOpts.numItems,
         });
-        return results[calls.length - 1] as any;
+        const start = paginationOpts.cursor ? Number(paginationOpts.cursor) : 0;
+        const end = Math.min(start + paginationOpts.numItems, rows.length);
+        const page = rows.slice(start, end);
+        const isDone = end >= rows.length;
+
+        return {
+          continueCursor: String(end),
+          isDone,
+          page,
+          pageStatus: isDone
+            ? ('Done' as const)
+            : ('SplitRecommended' as const),
+          splitCursor: String(start + Math.floor(page.length / 2)),
+        } as any;
       },
       { limit: 10, numItems: 3 }
     );
 
     expect(calls).toEqual([
       { cursor: null, numItems: 3 },
-      { cursor: 'split-1', numItems: 3 },
+      { cursor: '3', numItems: 3 },
     ]);
-    expect(state.docs).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(state.docs).toEqual(rows);
     expect(state.isDone).toBe(true);
   });
 
@@ -646,6 +647,31 @@ describe('httpAdapter', () => {
     expect(runQuery).not.toHaveBeenCalled();
     expect(runMutation).not.toHaveBeenCalled();
   });
+
+  test('findMany and count reject mixed OR and AND where clauses', async () => {
+    const runQuery = mock(async () => ({
+      continueCursor: null,
+      isDone: true,
+      page: [{ _id: 'user-1', email: 'a@b.com' }],
+      pageStatus: 'Done' as const,
+    }));
+    const adapterFactory = httpAdapter({ runQuery } as any, {
+      authFunctions: { findMany: 'findMany' } as any,
+    });
+    const adapter = adapterFactory({} as any);
+    const where = [
+      { connector: 'AND', field: 'email', operator: 'eq', value: 'a@b.com' },
+      { connector: 'OR', field: 'name', operator: 'eq', value: 'admin' },
+    ] as any;
+
+    await expect(adapter.findMany({ model: 'user', where })).rejects.toThrow(
+      'Mixed OR/AND where clauses are not supported for findMany'
+    );
+    await expect(adapter.count({ model: 'user', where })).rejects.toThrow(
+      'Mixed OR/AND where clauses are not supported for count'
+    );
+    expect(runQuery).not.toHaveBeenCalled();
+  });
 });
 
 describe('dbAdapter', () => {
@@ -663,6 +689,8 @@ describe('dbAdapter', () => {
         store.set(id, { _id: id, ...data });
         return id;
       },
+      // Single-table fake: an id normalizes only when it names a stored row.
+      normalizeId: (_table: string, id: string) => (store.has(id) ? id : null),
       patch: async (id: string, update: Record<string, unknown>) => {
         const existing = store.get(id);
         if (!existing) return;
@@ -713,6 +741,30 @@ describe('dbAdapter', () => {
     );
     expect(ctx.runMutation).not.toHaveBeenCalled();
     expect(Array.from(store.keys())).toEqual(['user-1', 'user-2']);
+  });
+
+  test('findMany and count reject mixed OR and AND where clauses', async () => {
+    const { ctx } = createMemoryCtx({
+      'user-1': { _id: 'user-1', email: 'a@b.com', name: 'user' },
+      'user-2': { _id: 'user-2', email: 'z@z.com', name: 'admin' },
+    });
+
+    const adapterFactory = dbAdapter(ctx, () => ({}) as any, {
+      authFunctions: {} as any,
+      schema,
+    });
+    const adapter = adapterFactory({} as any);
+    const where = [
+      { connector: 'AND', field: 'email', operator: 'eq', value: 'a@b.com' },
+      { connector: 'OR', field: 'name', operator: 'eq', value: 'admin' },
+    ] as any;
+
+    await expect(adapter.findMany({ model: 'user', where })).rejects.toThrow(
+      'Mixed OR/AND where clauses are not supported for findMany'
+    );
+    await expect(adapter.count({ model: 'user', where })).rejects.toThrow(
+      'Mixed OR/AND where clauses are not supported for count'
+    );
   });
 
   test('findOne OR tries each clause until a doc is found', async () => {

--- a/packages/kitcn/src/auth/adapter.ts
+++ b/packages/kitcn/src/auth/adapter.ts
@@ -46,11 +46,10 @@ export const handlePagination = async (
   const onResult = (
     result: SetOptional<PaginationResult<any>, 'page'> & { count?: number }
   ) => {
-    state.cursor =
-      result.pageStatus === 'SplitRecommended' ||
-      result.pageStatus === 'SplitRequired'
-        ? (result.splitCursor ?? result.continueCursor)
-        : result.continueCursor;
+    // A page always covers [cursor, continueCursor], including when Convex
+    // recommends or requires a split. `splitCursor` points into the middle of
+    // the page we just consumed, so resuming there would replay rows.
+    state.cursor = result.continueCursor;
 
     if (result.page) {
       state.docs.push(...result.page);
@@ -104,9 +103,12 @@ type AdapterWhere = Where & { join?: undefined };
 const hasOrWhere = (where?: AdapterWhere[]): where is AdapterWhere[] =>
   where?.some((clause) => clause.connector === 'OR') ?? false;
 
-const assertSupportedBulkOrWhere = (
+// OR where clauses are executed as one query per clause and unioned, which
+// discards the AND semantics of the remaining clauses. Refusing the mixed case
+// keeps authorization-scoped reads from silently widening.
+const assertSupportedOrWhere = (
   where: AdapterWhere[] | undefined,
-  operation: 'deleteMany' | 'updateMany'
+  operation: 'count' | 'deleteMany' | 'findMany' | 'updateMany'
 ) => {
   if (
     hasOrWhere(where) &&
@@ -306,6 +308,7 @@ export const httpAdapter = <
         },
         count: async (data) => {
           // Yes, count is just findMany returning a number.
+          assertSupportedOrWhere(data.where, 'count');
           if (hasOrWhere(data.where)) {
             const results = await asyncMap(data.where, async (w) =>
               handlePagination(
@@ -361,7 +364,7 @@ export const httpAdapter = <
           if (!('runMutation' in ctx)) {
             throw new Error('ctx is not a mutation ctx');
           }
-          assertSupportedBulkOrWhere(data.where, 'deleteMany');
+          assertSupportedOrWhere(data.where, 'deleteMany');
           if (hasOrWhere(data.where)) {
             const ids = await collectIdsForOrWhere({
               model: data.model,
@@ -395,6 +398,7 @@ export const httpAdapter = <
           if (data.offset) {
             throw new Error('offset not supported');
           }
+          assertSupportedOrWhere(data.where, 'findMany');
           if (hasOrWhere(data.where)) {
             const { select: _ignoredSelect, ...queryData } = data;
             const results = await asyncMap(data.where, async (w) =>
@@ -507,7 +511,7 @@ export const httpAdapter = <
           if (!('runMutation' in ctx)) {
             throw new Error('ctx is not a mutation ctx');
           }
-          assertSupportedBulkOrWhere(data.where, 'updateMany');
+          assertSupportedOrWhere(data.where, 'updateMany');
           if (hasOrWhere(data.where)) {
             const ids = await collectIdsForOrWhere({
               model: data.model,
@@ -617,6 +621,7 @@ export const dbAdapter = <
           isRunMutationCtx: isRunMutationCtx(ctx),
         },
         count: async (data) => {
+          assertSupportedOrWhere(data.where, 'count');
           if (hasOrWhere(data.where)) {
             const results = await asyncMap(data.where, async (w) =>
               handlePagination(
@@ -682,7 +687,7 @@ export const dbAdapter = <
           if (!('runMutation' in ctx)) {
             throw new Error('ctx is not a mutation ctx');
           }
-          assertSupportedBulkOrWhere(data.where, 'deleteMany');
+          assertSupportedOrWhere(data.where, 'deleteMany');
           if (hasOrWhere(data.where)) {
             const ids = await collectIdsForOrWhere({
               model: data.model,
@@ -716,6 +721,7 @@ export const dbAdapter = <
           if (data.offset) {
             throw new Error('offset not supported');
           }
+          assertSupportedOrWhere(data.where, 'findMany');
           if (hasOrWhere(data.where)) {
             const { select: _ignoredSelect, ...queryData } = data;
             const results = await asyncMap(data.where, async (w) =>
@@ -851,7 +857,7 @@ export const dbAdapter = <
           if (!('runMutation' in ctx)) {
             throw new Error('ctx is not a mutation ctx');
           }
-          assertSupportedBulkOrWhere(data.where, 'updateMany');
+          assertSupportedOrWhere(data.where, 'updateMany');
           if (hasOrWhere(data.where)) {
             const ids = await collectIdsForOrWhere({
               model: data.model,

--- a/packages/kitcn/src/auth/adapter.vitest.ts
+++ b/packages/kitcn/src/auth/adapter.vitest.ts
@@ -1,0 +1,81 @@
+import { defineSchema, defineTable } from 'convex/server';
+import { v } from 'convex/values';
+import { describe, expect, test } from 'vitest';
+import { convexTest } from '../../../../convex/setup.testing';
+import { handlePagination } from './adapter';
+import { paginate } from './adapter-utils';
+
+const schema = defineSchema({
+  member: defineTable({
+    organizationId: v.string(),
+    role: v.string(),
+    userId: v.string(),
+  }).index('organizationId', ['organizationId']),
+});
+
+const betterAuthSchema = {
+  member: {
+    fields: { organizationId: {}, role: {}, userId: {} },
+    modelName: 'member',
+  },
+} as any;
+
+// Rows that fail a post-index filter still consume scan budget, so pages come
+// back as SplitRecommended. Alternating roles guarantees that.
+const seedMembers = async (ctx: any, count: number) => {
+  for (let index = 0; index < count; index++) {
+    await ctx.db.insert('member', {
+      organizationId: 'org1',
+      role: index % 2 === 0 ? 'guest' : 'admin',
+      userId: `u${index}`,
+    });
+  }
+};
+
+const where = [
+  { field: 'organizationId', operator: 'eq' as const, value: 'org1' },
+  { field: 'role', operator: 'contains' as const, value: 'admin' },
+];
+
+describe('handlePagination over split pages', () => {
+  test('returns each matching document exactly once', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      await seedMembers(ctx, 16);
+
+      const result = await handlePagination(
+        async ({ paginationOpts }) =>
+          await paginate(ctx as any, schema, betterAuthSchema, {
+            model: 'member',
+            paginationOpts,
+            where,
+          }),
+        { numItems: 5 }
+      );
+      const ids = result.docs.map((doc: any) => doc._id);
+
+      expect(ids).toHaveLength(8);
+      expect(new Set(ids).size).toBe(8);
+    });
+  });
+
+  test('stops at the requested limit without replaying rows', async () => {
+    const t = convexTest(schema);
+    await t.run(async (ctx) => {
+      await seedMembers(ctx, 16);
+
+      const result = await handlePagination(
+        async ({ paginationOpts }) =>
+          await paginate(ctx as any, schema, betterAuthSchema, {
+            model: 'member',
+            paginationOpts,
+            where,
+          }),
+        { limit: 6, numItems: 5 }
+      );
+      const ids = result.docs.map((doc: any) => doc._id);
+
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});

--- a/packages/kitcn/src/auth/create-api.factory.test.ts
+++ b/packages/kitcn/src/auth/create-api.factory.test.ts
@@ -135,6 +135,7 @@ describe('auth/create-api createApi()', () => {
         delete: async (id: string) => {
           store.delete(id);
         },
+        normalizeId: (_table: string, id: string) => id,
         get: async (id: string) => store.get(id) ?? null,
         insert: async (_model: string, data: Record<string, unknown>) => {
           const id = `user-${store.size + 1}`;
@@ -311,6 +312,7 @@ describe('auth/create-api createApi()', () => {
     const store = new Map<string, any>();
     const ctx = {
       db: {
+        normalizeId: (_table: string, id: string) => id,
         get: async (id: string) => store.get(id) ?? null,
         insert: async (_model: string, data: Record<string, unknown>) => {
           const id = `user-${store.size + 1}`;
@@ -418,6 +420,7 @@ describe('auth/create-api createApi()', () => {
         ctx: {
           db: {
             delete: dbDelete,
+            normalizeId: (_table: string, id: string) => id,
             get: async (id: string) => store.get(id) ?? null,
             insert: dbInsert,
             patch: dbPatch,
@@ -529,6 +532,7 @@ describe('auth/create-api createApi()', () => {
           delete: mock(async () => {
             throw new Error('db.delete should not be called when orm exists');
           }),
+          normalizeId: (_table: string, id: string) => id,
           get: async (id: string) => store.get(id) ?? null,
           insert: mock(async () => {
             throw new Error('db.insert should not be called when orm exists');
@@ -584,6 +588,7 @@ describe('auth/create-api createApi()', () => {
           delete: mock(async () => {
             throw new Error('db.delete should not be called when orm exists');
           }),
+          normalizeId: (_table: string, id: string) => id,
           get: async (id: string) => store.get(id) ?? null,
           insert: mock(async () => {
             throw new Error('db.insert should not be called when orm exists');
@@ -736,6 +741,7 @@ describe('auth/create-api createApi()', () => {
           delete: mock(async () => {
             throw new Error('db.delete should not be called when orm exists');
           }),
+          normalizeId: (_table: string, id: string) => id,
           get: async (id: string) => store.get(id) ?? null,
           insert: mock(async () => {
             throw new Error('db.insert should not be called when orm exists');
@@ -805,6 +811,7 @@ describe('auth/create-api createApi()', () => {
           delete: mock(async () => {
             throw new Error('db.delete should not be called when orm exists');
           }),
+          normalizeId: (_table: string, id: string) => id,
           get: async () => null,
           insert: mock(async () => {
             throw new Error('db.insert should not be called when orm exists');
@@ -886,6 +893,7 @@ describe('auth/create-api createApi()', () => {
           delete: mock(async () => {
             throw new Error('db.delete should not be called when orm exists');
           }),
+          normalizeId: (_table: string, id: string) => id,
           get: async () => null,
           insert: mock(async () => {
             throw new Error('db.insert should not be called when orm exists');
@@ -953,6 +961,7 @@ describe('auth/create-api createApi()', () => {
       const ctx = {
         db: {
           delete: dbDelete,
+          normalizeId: (_table: string, id: string) => id,
           get: async (id: string) => store.get(id) ?? null,
           insert: dbInsert,
           patch: dbPatch,
@@ -999,6 +1008,7 @@ describe('auth/create-api createApi()', () => {
       const ctx = {
         db: {
           delete: mock(async () => undefined),
+          normalizeId: (_table: string, id: string) => id,
           get: async (id: string) => ({
             _id: id,
             email: 'c@site.com',

--- a/packages/kitcn/src/auth/create-api.test.ts
+++ b/packages/kitcn/src/auth/create-api.test.ts
@@ -71,6 +71,7 @@ const createMemoryCtx = (docsById: Record<string, any>) => {
     delete: async (id: string) => {
       store.delete(id);
     },
+    normalizeId: (_table: string, id: string) => id,
     get: async (id: string) => store.get(id) ?? null,
     patch: async (id: string, update: Record<string, unknown>) => {
       const existing = store.get(id);
@@ -103,6 +104,7 @@ describe('createHandler', () => {
     const triggerCtx = { orm: true };
     const ctx = {
       db: {
+        normalizeId: (_table: string, id: string) => id,
         get: async (_id: string) =>
           insertedDoc ? { _id: 'user-1', ...insertedDoc } : null,
         insert: async (_model: string, data: Record<string, unknown>) => {
@@ -185,6 +187,7 @@ describe('createHandler', () => {
       createHandler(
         {
           db: {
+            normalizeId: (_table: string, id: string) => id,
             get: async () => null,
             insert: async () => 'user-1',
           },
@@ -208,6 +211,7 @@ describe('createHandler', () => {
     const insertCalls: Array<Record<string, unknown>> = [];
     const ctx = {
       db: {
+        normalizeId: (_table: string, id: string) => id,
         get: async (_id: string) => ({
           _id: 'user-1',
           createdAt: now,
@@ -261,6 +265,7 @@ describe('createHandler', () => {
     let insertedDoc: Record<string, unknown> | undefined;
     const ctx = {
       db: {
+        normalizeId: (_table: string, id: string) => id,
         get: async (_id: string) =>
           insertedDoc ? { _id: 'subscription-1', ...insertedDoc } : null,
         insert: async (_model: string, data: Record<string, unknown>) => {
@@ -308,6 +313,7 @@ describe('createHandler', () => {
       createHandler(
         {
           db: {
+            normalizeId: (_table: string, id: string) => id,
             get: async () => ({ _id: 'user-1', email: 'a@b.com' }),
             insert: async () => 'user-1',
           },

--- a/packages/kitcn/src/auth/create-client.test.ts
+++ b/packages/kitcn/src/auth/create-client.test.ts
@@ -49,6 +49,7 @@ describe('createClient', () => {
 
     const ctx = {
       db: {
+        normalizeId: (_table: string, id: string) => id,
         get: async () => ({ _id: 'user-1', email: 'a@b.com' }),
       },
     } as any;

--- a/packages/kitcn/src/cli/commands/dev.test.ts
+++ b/packages/kitcn/src/cli/commands/dev.test.ts
@@ -339,19 +339,23 @@ describe('cli/commands/dev', () => {
     await closeHttpServer(reservedProxy);
     const originalFetch = globalThis.fetch;
     globalThis.fetch = Bun.fetch as typeof fetch;
-    const proxy = await startLocalSiteProxy({
-      listenHost: '127.0.0.1',
-      listenPort: proxyPort,
-      targetOrigin: `http://127.0.0.1:${upstreamPort}`,
-    });
+    // Everything after the stub is installed must sit inside the try, or a
+    // throw here leaks Bun.fetch into every later test file in the process.
+    let proxy: Awaited<ReturnType<typeof startLocalSiteProxy>> | undefined;
 
     try {
+      proxy = await startLocalSiteProxy({
+        listenHost: '127.0.0.1',
+        listenPort: proxyPort,
+        targetOrigin: `http://127.0.0.1:${upstreamPort}`,
+      });
+
       await expect(postChunked(proxyPort)).resolves.toBe(204);
 
       expect(upstreamContentType).toBe('application/json');
       expect(upstreamTransferEncoding).toBeUndefined();
     } finally {
-      proxy.kill();
+      proxy?.kill();
       globalThis.fetch = originalFetch;
       await closeHttpServer(upstream);
     }


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

Fixes five Better Auth adapter correctness defects:

- normalize `_id` against the queried table before reads and writes;
- resume pagination from `continueCursor`;
- preserve authentication when `auth.jwtCache` is `false`;
- apply `not_in` before pagination;
- reject mixed AND/OR clauses instead of silently unioning them.

Deterministic proof covers model-scoped IDs, pagination/filtering, and disabled JWT caching. Local verification passed focused Vitest (12), focused Bun tests (93), package build, typecheck, lint, fixtures, verification scenarios, runtime scenarios, independent autoreview, and the complete `bun check` gate.
