### PR TITLE
fix(crpc): input validation, middleware wrapping, HTTP error mapping

### DIFF
--- a/.changeset/crpc-procedure-contracts.md
+++ b/.changeset/crpc-procedure-contracts.md
@@ -4,11 +4,11 @@
 
 ## Breaking changes
 
-- Improve middleware to wrap the whole procedure: `next()` resolves after the
-  handler runs, so timing, error reporting, and cleanup around it observe the
-  handler, and handler errors propagate through every wrapping `catch`. A `ctx`
-  changed on the return path no longer reaches the handler — pass it to `next()`
-  instead.
+- Improve Convex and HTTP middleware to wrap the whole procedure: `next()`
+  resolves after the handler runs, so timing, error reporting, and cleanup
+  around it observe the handler, and handler errors propagate through every
+  wrapping `catch`. A `ctx` changed on the return path no longer reaches the
+  handler — pass it to `next()` instead.
 
   ```ts
   // Before — logged 0ms, never saw handler errors, and this ctx was ignored
@@ -61,4 +61,5 @@
 - Fix HTTP routes returning `500` for the twelve error codes missing from the
   route status map, including `PAYLOAD_TOO_LARGE` (`413`),
   `UNSUPPORTED_MEDIA_TYPE` (`415`), and `PRECONDITION_FAILED` (`412`).
-- Fix a malformed or empty JSON body returning `500` instead of `400`.
+- Fix a malformed or empty JSON body returning `500` instead of `400`,
+  including when HTTP middleware reads it through `getRawInput()`.

--- a/.changeset/crpc-procedure-contracts.md
+++ b/.changeset/crpc-procedure-contracts.md
@@ -1,0 +1,63 @@
+---
+"kitcn": minor
+---
+
+## Breaking changes
+
+- `next()` now resolves after the handler runs, so middleware wraps the whole
+  procedure. Timing, error reporting, and cleanup around `next()` now observe
+  the handler, and handler errors propagate through every wrapping `catch`. A
+  `ctx` changed on the return path no longer reaches the handler — pass it to
+  `next()` instead.
+
+  ```ts
+  // Before — logged 0ms, never saw handler errors, and this ctx was ignored
+  .use(async ({ ctx, next }) => {
+    const start = Date.now();
+    const result = await next({ ctx });
+    console.log(`${Date.now() - start}ms`);
+    return { ...result, ctx: { ...ctx, tenant } };
+  })
+
+  // After — times the handler, sees its errors, and passes ctx forward
+  .use(async ({ ctx, next }) => {
+    const start = Date.now();
+    try {
+      return await next({ ctx: { ...ctx, tenant } });
+    } finally {
+      console.log(`${Date.now() - start}ms`);
+    }
+  })
+  ```
+
+- Chained `.input()` schemas are each applied on their own instead of being
+  flattened into one shape, so object-level rules now run. A key declared by
+  more than one schema is validated only by the last schema to declare it.
+
+  ```ts
+  // Before — the object-level rule was dropped and both fields reached the handler
+  .input(z.object({ password: z.string(), confirm: z.string() }))
+
+  // After — mismatched values are rejected before the handler runs
+  .input(
+    z
+      .object({ password: z.string(), confirm: z.string() })
+      .refine((v) => v.password === v.confirm)
+  )
+  ```
+
+## Patches
+
+- Fix `.input()` schemas running twice per request, which made field transforms
+  apply to their own output — `z.string().transform(s => s.length)` threw on
+  valid input and `z.number().transform(n => n * 2)` doubled twice. Transforms
+  and refinements now run exactly once.
+- Fix `next({ input })` being dropped for every middleware after the first, so
+  input enrichment placed after an auth middleware no longer silently no-ops.
+- Fix HTTP routes returning a retryable `500` for errors raised by a procedure
+  they called through a caller. `NOT_FOUND`, `FORBIDDEN`, and other codes now
+  keep their status and message.
+- Fix HTTP routes returning `500` for the twelve error codes missing from the
+  route status map, including `PAYLOAD_TOO_LARGE` (`413`),
+  `UNSUPPORTED_MEDIA_TYPE` (`415`), and `PRECONDITION_FAILED` (`412`).
+- Fix a malformed or empty JSON body returning `500` instead of `400`.

--- a/.changeset/crpc-procedure-contracts.md
+++ b/.changeset/crpc-procedure-contracts.md
@@ -4,11 +4,11 @@
 
 ## Breaking changes
 
-- `next()` now resolves after the handler runs, so middleware wraps the whole
-  procedure. Timing, error reporting, and cleanup around `next()` now observe
-  the handler, and handler errors propagate through every wrapping `catch`. A
-  `ctx` changed on the return path no longer reaches the handler — pass it to
-  `next()` instead.
+- Improve middleware to wrap the whole procedure: `next()` resolves after the
+  handler runs, so timing, error reporting, and cleanup around it observe the
+  handler, and handler errors propagate through every wrapping `catch`. A `ctx`
+  changed on the return path no longer reaches the handler — pass it to `next()`
+  instead.
 
   ```ts
   // Before — logged 0ms, never saw handler errors, and this ctx was ignored
@@ -30,9 +30,10 @@
   })
   ```
 
-- Chained `.input()` schemas are each applied on their own instead of being
-  flattened into one shape, so object-level rules now run. A key declared by
-  more than one schema is validated only by the last schema to declare it.
+- Improve chained `.input()` to apply each schema on its own instead of
+  flattening them into one shape, so object-level rules run. A key declared by
+  more than one schema is validated only by the last schema to declare it, even
+  when an earlier schema carries object-level rules.
 
   ```ts
   // Before — the object-level rule was dropped and both fields reached the handler

--- a/docs/plans/320-close-crpc-correctness-pr.md
+++ b/docs/plans/320-close-crpc-correctness-pr.md
@@ -68,23 +68,23 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused server tests | pending |
-| package/API/build | yes | Package build/types | pending |
+| source behavior | yes | 71 focused server tests after review repairs | complete |
+| package/API/build | yes | Package build and root typecheck | complete |
 | generated output | no | N/A: no generated output | N/A |
 | fixtures/scenarios | no | N/A: no scaffold output | N/A |
 | docs/package skill | no | N/A: no docs/skill delta | N/A |
-| changeset | yes | `.changeset/crpc-procedure-contracts.md` audit | pending |
+| changeset | yes | Minor changeset names Convex/HTTP middleware and raw-input behavior | complete |
 | agent workflow | no | N/A: no agent action | N/A |
-| cleanup/review | yes | Deslop and autoreview | pending |
+| cleanup/review | yes | Deslop tradeoff audited; autoreview clean at 0.98 | complete |
 | repository check | yes | `bun check` | pending |
 | GitHub delivery | yes | PR 320 update/merge/read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Each pre-delivery lane is proven or N/A with a concrete reason.
 - [x] Generated output is N/A: no generated owner is touched.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: no rule/generated mirror changed.
@@ -97,20 +97,21 @@ Work Checklist:
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
-| None yet | 0 | | |
+| HTTP middleware returned before its handler | 1 | Make the resolver the shared runner terminal | Red event-order test became green |
+| Middleware raw JSON parse returned 500 | 1 | Route cloned JSON through the owned BAD_REQUEST reader | Red public route test became green |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused server tests | pending |
+| Targeted behavior proof | yes | Run focused server tests | passed: 71 tests, 182 assertions |
 | Source/generated audit | no | N/A: source-only runtime change | N/A |
-| Package/docs/scenario closure | yes | Build package and audit changeset | pending |
-| Deslop | yes | Run changed-file cleanup review | pending |
+| Package/docs/scenario closure | yes | Build package and audit changeset | passed |
+| Deslop | yes | Run changed-file cleanup review | Score +2.06; one fan-out finding accepted for canonical shared runner |
 | Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
-| Final lint | yes | Run `bun lint:fix` | pending |
+| Final lint | yes | Run `bun lint:fix` | passed: 880 files; one formatting fix applied |
 | Repository check | yes | Run `bun check` | pending |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | clean at 0.98; zero actionable findings |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/320-close-crpc-correctness-pr.md` | pending |
 | Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
 | Installed lock audit | no | N/A: no skill state change | N/A |
@@ -121,29 +122,43 @@ Completion Gates:
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
+| Inventory | complete | VISION, PR, changeset, source, tests, checks, and four threads read | repair |
+| Repair | complete | Rebased onto `b80d7340`; fixed both live HTTP findings with TDD | review |
+| Review/checks | in_progress | Focused tests, build, typecheck, lint, deslop, and autoreview pass | exact check |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
 Verification evidence:
-- PR 320 CI/Vercel green at goal creation; no approval yet.
+- Pre-rebase PR 320 CI/Vercel green; stale after rebasing onto PR 322 merge.
+- Rebased both commits onto main at `b80d7340` without conflicts.
+- Focused builder/error/http-builder proof passes 71 tests with 182 assertions.
+- Red-to-green HTTP proof establishes middleware order as
+  `before -> handler -> after` and maps malformed JSON read through
+  `getRawInput()` to `400 BAD_REQUEST`.
+- Convex and HTTP procedures share `middleware-runner.ts` as the one terminal
+  chain owner; package build and root typecheck pass.
+- Changeset starts each bullet with an action verb and covers Convex/HTTP
+  wrapping plus middleware raw-input errors.
+- Deslop score improves by 2.06; the one new directory fan-out occurrence is
+  accepted because a canonical shared runner is safer than duplicated recursion.
+- Final autoreview reports zero actionable findings at 0.98 confidence.
 
 Timeline:
 - 2026-08-14T18:17:54.952Z Autoclosure plan created.
+- 2026-08-14T23:35:00+02:00 Rebased onto PR 322, closed both live HTTP
+  findings with red-to-green tests, and completed pre-gate review proof.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Review/checks |
+| Where am I going? | Exact repository gate, delivery, final audit |
 | What is the goal? | Merge proven cRPC validation, middleware, and HTTP correctness |
-| What have I learned? | See closure matrix |
-| What have I done? | See timeline |
+| What have I learned? | HTTP and Convex middleware need one terminal-chain owner |
+| What have I done? | Rebased, repaired both live findings, and proved focused behavior |
 
 Open risks:
-- Middleware terminal-chain changes can double-run or skip handlers if review misses propagation paths.
+- GitHub CI and final merge receipt remain pending.
 
 Findings:
 - cRPC error identity crosses a Convex syscall boundary and needs behavior-level tests.
@@ -152,4 +167,10 @@ Decisions and tradeoffs:
 - Keep the resolver as terminal middleware owner; reject adjacent API redesign.
 
 Review fixes:
-- Pending.
+- Last-schema ownership for overlapping refined inputs: fixed by the second
+  original commit and proved by focused tests.
+- Changeset action verbs: fixed by the second original commit and re-audited.
+- HTTP middleware terminal chaining: fixed with the shared resolver runner and
+  a public event-order regression.
+- Middleware `getRawInput()` malformed JSON: fixed through the BAD_REQUEST body
+  reader and a public 400-response regression.

--- a/docs/plans/322-close-cli-safety-pr.md
+++ b/docs/plans/322-close-cli-safety-pr.md
@@ -79,7 +79,7 @@ Closure matrix:
 | agent workflow | yes | Active `cli.ts` add route has JSON refusal receipt and nonzero exit tests | complete |
 | cleanup/review | yes | Zero slop delta; agent-native audit and autoreview clean | complete |
 | repository check | yes | `bun check` | complete |
-| GitHub delivery | yes | PR 322 update/merge/read-back | pending |
+| GitHub delivery | yes | PR 322 update/merge/read-back | passed: squash-merged as `b80d7340` |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
@@ -87,8 +87,8 @@ Work Checklist:
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
 - [x] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: package skill source owner/mirror boundary recorded.
 - [x] Agent-native pack: safe CLI refusal and overwrite routes are discoverable.
 - [x] Agent-native pack: package skill mirror and fixtures are regenerated/proved.
@@ -112,9 +112,9 @@ Completion Gates:
 | Agent-native reviewer | yes | Review CLI agent route and receipts | Pass; active route and all proof surfaces mapped |
 | Final lint | yes | Run `bun lint:fix` | Pass; 879 files clean |
 | Repository check | yes | Run `bun check` | Pass; full tests, fixtures, and runtime scenarios |
-| GitHub delivery | yes | Update, squash-merge, read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/322-close-cli-safety-pr.md` | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | passed: merged 2026-08-14T21:33:37Z as `b80d7340` |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: all three GitHub threads resolved; final local review clean |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/322-close-cli-safety-pr.md` | passed after merge receipt |
 | Agent source / generated sync | yes | Prove package skill mirror; `.agents/rules` N/A | Package skill and mirror byte-identical |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
 | Agent action discoverability | yes | Audit package skill CLI guidance | Package skill and CLI docs document `add --yes/--overwrite/--json` |
@@ -127,8 +127,8 @@ Phase / pass table:
 | Inventory | complete | PR, source owners, active dispatch, mirrors, and docs audited | repair |
 | Repair | complete | Two review regressions fixed with tests | review |
 | Review/checks | complete | Focused tests, build, typecheck, fixtures, sync, deslop, reviews, lint, and exact check pass | delivery |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Delivery | completed | Exact head `53bd56d4` passed CI/Vercel, all threads resolved, and PR merged as `b80d7340` | final audit |
+| Closeout | completed | Merge read-back and child goal checker passed | final |
 
 Verification evidence:
 - `bun test` for planner and schema ownership: 31 pass.
@@ -141,6 +141,9 @@ Verification evidence:
   findings with 0.99 confidence.
 - Exact `bun check` passes, including lint, typecheck, Bun/Vitest suites, 124
   CLI tests, Concave smoke, every fixture comparison, and runtime scenarios.
+- Exact head `53bd56d4` passed CI in 7m03s and Vercel, all three review
+  threads were source-backed and resolved, and PR 322 squash-merged as
+  `b80d7340` with auto-release unchecked.
 - Agent-native capability map: action `kitcn add --yes/--overwrite/--json`;
   active route `cli.ts` to `commands/add.ts`; mutation owner planner/apply helpers
   in `backend-core.ts`; guidance owners are CLI docs and package skill; generated
@@ -154,18 +157,20 @@ Timeline:
   focused regressions, synchronized generated owners, and completed pre-gate
   review evidence.
 - 2026-08-14T23:19:57+02:00 Exact repository check passed end to end.
+- 2026-08-14T21:33:37Z PR 322 squash-merged as `b80d7340` after exact-head
+  CI/Vercel passed and the post-CI thread audit was clean.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Push, GitHub checks, merge, final audit |
+| Where am I? | Complete |
+| Where am I going? | Next ranked batch PR |
 | What is the goal? | Merge safe CLI ownership and schema editing with full generated proof |
 | What have I learned? | Active add dispatch is modular; generated owners are synchronized |
 | What have I done? | Fixed both findings and proved every pre-delivery lane |
 
 Open risks:
-- GitHub CI and final merge receipt remain pending.
+- None for PR 322.
 
 Findings:
 - This is the batch's widest generated/fixture/agent-facing closeout surface.
@@ -174,6 +179,8 @@ Decisions and tradeoffs:
 - Require fixture sync/check and structured refusal proof before merge.
 
 Review fixes:
+- Replaced parse snapshots and suffix sweeps with in-memory transformed-module
+  parsing; user-owned former-suffix paths are preserved.
 - Replaced textual backward dot search with the AST property-access dot token,
   so periods inside chained-call comments cannot corrupt schema insertion.
 - Moved required runtime bindings out of whole type-only `kitcn/orm` imports

--- a/packages/kitcn/src/server/builder.test.ts
+++ b/packages/kitcn/src/server/builder.test.ts
@@ -92,6 +92,98 @@ describe('server/builder', () => {
     });
   });
 
+  test('next({ input }) is honored from any position in the middleware chain', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const passthrough = async ({ ctx, next }: any) => next({ ctx });
+    const enrich = async ({ ctx, next }: any) =>
+      next({ ctx, input: { x: 99 } });
+
+    const enrichFirst = c.query
+      .input(z.object({ x: z.number() }))
+      .use(enrich)
+      .use(passthrough)
+      .query(async ({ input }) => input.x);
+
+    const enrichSecond = c.query
+      .input(z.object({ x: z.number() }))
+      .use(passthrough)
+      .use(enrich)
+      .query(async ({ input }) => input.x);
+
+    await expect((enrichFirst as any)._handler({}, { x: 1 })).resolves.toBe(99);
+    await expect((enrichSecond as any)._handler({}, { x: 1 })).resolves.toBe(
+      99
+    );
+  });
+
+  test('middleware wrapping next() observes the resolver', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const events: string[] = [];
+    let elapsed = -1;
+
+    const fn = c.query
+      .use(async ({ ctx, next }) => {
+        const start = Date.now();
+        events.push('middleware-start');
+        try {
+          return await next({ ctx });
+        } finally {
+          elapsed = Date.now() - start;
+          events.push('middleware-end');
+        }
+      })
+      .query(async () => {
+        events.push('handler-start');
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        events.push('handler-end');
+        return 'ok';
+      });
+
+    await expect((fn as any)._handler({}, {})).resolves.toBe('ok');
+    expect(events).toEqual([
+      'middleware-start',
+      'handler-start',
+      'handler-end',
+      'middleware-end',
+    ]);
+    expect(elapsed).toBeGreaterThanOrEqual(25);
+  });
+
+  test('middleware wrapping next() catches resolver errors', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const reported: string[] = [];
+
+    const fn = c.query
+      .use(async ({ ctx, next }) => {
+        try {
+          return await next({ ctx });
+        } catch (error) {
+          reported.push((error as Error).message);
+          throw error;
+        }
+      })
+      .query(async () => {
+        throw new CRPCError({ code: 'NOT_FOUND', message: 'missing' });
+      });
+
+    await expect((fn as any)._handler({}, {})).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(reported).toEqual(['missing']);
+  });
+
   test('middleware receives procedure info from server-only procedure name', async () => {
     const seen: unknown[] = [];
     const c = initCRPC
@@ -279,6 +371,246 @@ describe('server/builder', () => {
     });
 
     await expect((fn as any)._handler({}, { a: 'x' })).rejects.toBeTruthy();
+  });
+
+  test('object-level .refine() on an input schema is enforced', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .object({ password: z.string(), confirm: z.string() })
+          .refine((v) => v.password === v.confirm, {
+            message: 'Passwords must match',
+          })
+      )
+      .query(async ({ input }) => input.password);
+
+    await expect(
+      (fn as any)._handler({}, { password: 'a', confirm: 'a' })
+    ).resolves.toBe('a');
+
+    await expect(
+      (fn as any)._handler({}, { password: 'a', confirm: 'b' })
+    ).rejects.toBeTruthy();
+  });
+
+  test('object-level .superRefine() on an input schema is enforced', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .object({ start: z.number(), end: z.number() })
+          .superRefine((v, ctx) => {
+            if (v.end <= v.start) {
+              ctx.addIssue({
+                code: 'custom',
+                message: 'end must be after start',
+              });
+            }
+          })
+      )
+      .query(async ({ input }) => input.end - input.start);
+
+    await expect((fn as any)._handler({}, { start: 1, end: 5 })).resolves.toBe(
+      4
+    );
+
+    await expect(
+      (fn as any)._handler({}, { start: 5, end: 1 })
+    ).rejects.toBeTruthy();
+  });
+
+  test('chained .input() keeps each schema object-level checks independent', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .strictObject({ start: z.number(), end: z.number() })
+          .refine((v) => v.end > v.start, {
+            message: 'end must be after start',
+          })
+      )
+      .input(z.object({ label: z.string() }))
+      .query(async ({ input }) => `${input.label}:${input.end - input.start}`);
+
+    await expect(
+      (fn as any)._handler({}, { start: 1, end: 5, label: 'range' })
+    ).resolves.toBe('range:4');
+
+    await expect(
+      (fn as any)._handler({}, { start: 5, end: 1, label: 'range' })
+    ).rejects.toBeTruthy();
+  });
+
+  test('a redeclared key is validated only by the schema that declares it last', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    // `.paginated()` redeclares `limit`, so its `.default(20)` fills the gap
+    // rather than the earlier required declaration rejecting the payload.
+    const fn = c.query
+      .input(z.object({ limit: z.number() }))
+      .paginated({ limit: 20, item: z.object({ id: z.string() }) })
+      .query(async ({ input }) => ({
+        continueCursor: null,
+        isDone: true,
+        page: [{ id: String(input.limit) }],
+      }));
+
+    await expect((fn as any)._handler({}, {})).resolves.toMatchObject({
+      page: [{ id: '20' }],
+    });
+
+    await expect((fn as any)._handler({}, { limit: 5 })).resolves.toMatchObject(
+      { page: [{ id: '5' }] }
+    );
+
+    await expect(
+      (fn as any)._handler({}, { limit: 999 })
+    ).resolves.toMatchObject({ page: [{ id: '20' }] });
+  });
+
+  test('a shadowed key takes the later declaration type, not the earlier one', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    // `cursor` starts as a required string, then `.paginated()` redeclares it
+    // as `string | null` defaulting to null.
+    const fn = c.query
+      .input(z.object({ cursor: z.string() }))
+      .paginated({ limit: 10, item: z.object({ id: z.string() }) })
+      .query(async ({ input }) => ({
+        continueCursor: null,
+        isDone: true,
+        page: [{ id: String((input as any).cursor) }],
+      }));
+
+    await expect((fn as any)._handler({}, {})).resolves.toMatchObject({
+      page: [{ id: 'null' }],
+    });
+
+    await expect(
+      (fn as any)._handler({}, { cursor: 'c1' })
+    ).resolves.toMatchObject({ page: [{ id: 'c1' }] });
+  });
+
+  test('a redeclared key keeps the later schema type across plain .input() chaining', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(z.object({ value: z.string(), keep: z.string() }))
+      .input(z.object({ value: z.number() }))
+      .query(async ({ input }) => `${input.keep}:${input.value * 2}`);
+
+    await expect(
+      (fn as any)._handler({}, { value: 21, keep: 'k' })
+    ).resolves.toBe('k:42');
+
+    // the surviving declaration still validates
+    await expect(
+      (fn as any)._handler({}, { value: 'nope', keep: 'k' })
+    ).rejects.toBeTruthy();
+  });
+
+  test('paginated() composes with an .input() schema carrying object-level checks', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .object({ min: z.number(), max: z.number() })
+          .refine((v) => v.max >= v.min, { message: 'max must be >= min' })
+      )
+      .paginated({ limit: 10, item: z.object({ id: z.string() }) })
+      .query(async ({ input }) => ({
+        continueCursor: null,
+        isDone: true,
+        page: [{ id: `${input.min}-${input.max}:${input.limit}` }],
+      }));
+
+    await expect(
+      (fn as any)._handler({}, { min: 1, max: 4, limit: 999 })
+    ).resolves.toMatchObject({ page: [{ id: '1-4:10' }] });
+
+    await expect(
+      (fn as any)._handler({}, { min: 4, max: 1, limit: 5 })
+    ).rejects.toBeTruthy();
+  });
+
+  test('input transforms run exactly once', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    let stringTransforms = 0;
+    const stringFn = c.query
+      .input(
+        z.object({
+          s: z.string().transform((s) => {
+            stringTransforms += 1;
+            return s.length;
+          }),
+        })
+      )
+      .query(async ({ input }) => input.s);
+
+    await expect((stringFn as any)._handler({}, { s: 'hello' })).resolves.toBe(
+      5
+    );
+    expect(stringTransforms).toBe(1);
+
+    const doubleFn = c.query
+      .input(z.object({ n: z.number().transform((n) => n * 2) }))
+      .query(async ({ input }) => input.n);
+
+    await expect((doubleFn as any)._handler({}, { n: 3 })).resolves.toBe(6);
+  });
+
+  test('input refinements run exactly once', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    let refinements = 0;
+    const fn = c.query
+      .input(
+        z.object({
+          email: z.string().refine((value) => {
+            refinements += 1;
+            return value.includes('@');
+          }),
+        })
+      )
+      .query(async ({ input }) => input.email);
+
+    await expect((fn as any)._handler({}, { email: 'a@b.com' })).resolves.toBe(
+      'a@b.com'
+    );
+    expect(refinements).toBe(1);
   });
 
   test('paginated() records limit in _crpcMeta', () => {

--- a/packages/kitcn/src/server/builder.test.ts
+++ b/packages/kitcn/src/server/builder.test.ts
@@ -531,6 +531,57 @@ describe('server/builder', () => {
     ).rejects.toBeTruthy();
   });
 
+  test('a redeclared key is not re-validated by an earlier refined schema', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .object({ value: z.string(), label: z.string() })
+          .refine((v) => v.label.length > 0, { message: 'label required' })
+      )
+      .input(z.object({ value: z.number() }))
+      .query(async ({ input }) => `${input.label}:${input.value * 2}`);
+
+    await expect(
+      (fn as any)._handler({}, { value: 21, label: 'k' })
+    ).resolves.toBe('k:42');
+
+    // the earlier schema's object-level rule still runs
+    await expect(
+      (fn as any)._handler({}, { value: 21, label: '' })
+    ).rejects.toBeTruthy();
+
+    // the surviving declaration still validates
+    await expect(
+      (fn as any)._handler({}, { value: 'nope', label: 'k' })
+    ).rejects.toBeTruthy();
+  });
+
+  test('an earlier object-level check reads the redeclared value the last schema produced', async () => {
+    const c = initCRPC.create({
+      query: queryGeneric,
+      mutation: mutationGeneric,
+    } as any);
+
+    const fn = c.query
+      .input(
+        z
+          .object({ limit: z.number() })
+          .refine((v) => v.limit <= 10, { message: 'limit too high' })
+      )
+      .input(z.object({ limit: z.number().default(5) }))
+      .query(async ({ input }) => input.limit);
+
+    // the later default fills the gap and satisfies the earlier rule
+    await expect((fn as any)._handler({}, {})).resolves.toBe(5);
+
+    await expect((fn as any)._handler({}, { limit: 50 })).rejects.toBeTruthy();
+  });
+
   test('paginated() composes with an .input() schema carrying object-level checks', async () => {
     const c = initCRPC.create({
       query: queryGeneric,

--- a/packages/kitcn/src/server/builder.ts
+++ b/packages/kitcn/src/server/builder.ts
@@ -44,6 +44,7 @@ import {
   type HttpRouterRecord,
 } from './http-router';
 import type { HttpActionConstructor, HttpMethod } from './http-types';
+import { executeMiddlewares } from './middleware-runner';
 import { inferProcedureNameFromCallsite } from './procedure-name';
 import type {
   AnyMiddleware,
@@ -51,9 +52,7 @@ import type {
   IntersectIfDefined,
   MiddlewareBuilder,
   MiddlewareFunction,
-  MiddlewareNext,
   MiddlewareProcedureInfo,
-  MiddlewareResult,
   Overwrite,
   UnsetMarker,
 } from './types';
@@ -243,23 +242,6 @@ export function createMiddlewareFactory<TDefaultContext, TMeta = object>() {
   };
 }
 
-// =============================================================================
-// Middleware Execution
-// =============================================================================
-
-/** Result from middleware execution including potentially modified input */
-type MiddlewareExecutionResult = MiddlewareResult<unknown> & {
-  input: unknown;
-  /** Value produced by the resolver at the end of the chain */
-  output?: unknown;
-};
-
-/** Terminal link of a middleware chain - runs the procedure resolver */
-type MiddlewareResolver = (opts: {
-  ctx: unknown;
-  input: unknown;
-}) => Promise<unknown>;
-
 const FUNCTION_NAME_SYMBOL = Symbol.for('functionName');
 
 const resolveProcedureInfo = (
@@ -283,84 +265,6 @@ const resolveProcedureInfo = (
     name: symbolName ?? procedureName,
   };
 };
-
-/**
- * Execute the middleware chain, with the resolver as its terminal link.
- *
- * `next()` walks the remaining middleware and then runs the resolver, so a
- * middleware that wraps `next()` can time the handler, catch its errors, and
- * post-process its result - matching tRPC.
- */
-async function executeMiddlewares(
-  middlewares: AnyMiddleware[],
-  ctx: unknown,
-  meta: unknown,
-  procedure: MiddlewareProcedureInfo,
-  input: unknown,
-  getRawInput: GetRawInputFn,
-  resolve: MiddlewareResolver,
-  index = 0
-): Promise<MiddlewareExecutionResult> {
-  // Base case: the whole chain ran, so the resolver is next
-  if (index >= middlewares.length) {
-    return {
-      marker: undefined as never, // Runtime doesn't need the marker
-      ctx,
-      input,
-      output: await resolve({ ctx, input }),
-    };
-  }
-
-  const middleware = middlewares[index];
-
-  // Track modifications made by this frame through the rest of the chain
-  let currentInput = input;
-  let innerResult: MiddlewareExecutionResult | undefined;
-
-  // Create next function for this middleware (tRPC-compatible signature)
-  const next: MiddlewareNext<any, any> = async <
-    TNextContext extends object = Record<string, never>,
-  >(opts?: {
-    ctx?: TNextContext;
-    input?: unknown;
-  }) => {
-    const nextCtx = opts?.ctx ?? ctx;
-    // Track input modification
-    if (opts?.input !== undefined) {
-      currentInput = opts.input;
-    }
-    innerResult = await executeMiddlewares(
-      middlewares,
-      nextCtx,
-      meta,
-      procedure,
-      currentInput,
-      getRawInput,
-      resolve,
-      index + 1
-    );
-    return innerResult as MiddlewareResult<any>;
-  };
-
-  // Execute current middleware with input and getRawInput
-  const result = (await middleware({
-    ctx: ctx as any,
-    meta,
-    procedure,
-    input,
-    getRawInput,
-    next,
-  })) as MiddlewareExecutionResult;
-
-  // Carry the inner frames' input and resolver output back out, so an override
-  // made by any middleware - not just the first - survives the return trip.
-  return {
-    marker: undefined as never,
-    ctx: result.ctx ?? ctx,
-    input: result.input ?? innerResult?.input ?? currentInput,
-    output: result.output ?? innerResult?.output,
-  };
-}
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   !!value &&

--- a/packages/kitcn/src/server/builder.ts
+++ b/packages/kitcn/src/server/builder.ts
@@ -679,24 +679,25 @@ const resolveConvexArgsShape = (
 };
 
 /**
- * Drop keys a later `.input()` redeclares.
+ * Strip the field validators for keys a later `.input()` redeclares.
  *
- * Returns `undefined` when the schema carries object-level checks, since zod
- * refuses to omit from those - such a schema keeps the key and reads the value
- * its owner parsed.
+ * The keys stay on the schema so its object-level checks still see them - and
+ * read the value their owner parsed - while only the last declaration validates
+ * them. `safeExtend` is the one zod object operation that rewrites keys on a
+ * schema carrying object-level checks; `omit` and `extend` both refuse.
  */
-const omitSupersededKeys = (
+const relaxSupersededKeys = (
   schema: z.ZodObject<any>,
   superseded: string[]
-): z.ZodObject<any> | undefined => {
+): z.ZodObject<any> => {
   if (superseded.length === 0) return schema;
 
   try {
-    return schema.omit(
-      Object.fromEntries(superseded.map((key) => [key, true])) as any
+    return schema.safeExtend(
+      Object.fromEntries(superseded.map((key) => [key, z.any()])) as any
     );
   } catch {
-    return;
+    return schema;
   }
 };
 
@@ -727,28 +728,27 @@ const parseInput = (
     const source = isPlainObject(value) ? value : {};
     const parsed: Record<string, unknown> = {};
 
-    // Walk owners first, so a schema still holding a superseded key can read
-    // the value its owner produced.
+    // Walk owners first, so a schema holding a superseded key can read the
+    // value its owner produced.
     for (let index = inputSchemas.length - 1; index >= 0; index -= 1) {
       const schema = inputSchemas[index];
       const keys = Object.keys(schema.shape);
-      const superseded = keys.filter((key) => ownerOf.get(key) !== index);
-      const scoped = omitSupersededKeys(schema, superseded);
+      const superseded = new Set(
+        keys.filter((key) => ownerOf.get(key) !== index)
+      );
+      const scoped = relaxSupersededKeys(schema, [...superseded]);
 
       const narrowed: Record<string, unknown> = {};
       for (const key of keys) {
-        if (superseded.includes(key)) {
-          // Omitted outright when zod allowed it, otherwise fed the owner value.
-          if (!scoped && key in parsed) narrowed[key] = parsed[key];
+        if (superseded.has(key)) {
+          // Fed the owner value, so object-level checks see the final input.
+          if (key in parsed) narrowed[key] = parsed[key];
           continue;
         }
         if (Object.hasOwn(source, key)) narrowed[key] = source[key];
       }
 
-      const result = (scoped ?? schema).parse(narrowed) as Record<
-        string,
-        unknown
-      >;
+      const result = scoped.parse(narrowed) as Record<string, unknown>;
       for (const key of keys) {
         if (ownerOf.get(key) === index && key in result) {
           parsed[key] = result[key];

--- a/packages/kitcn/src/server/builder.ts
+++ b/packages/kitcn/src/server/builder.ts
@@ -17,6 +17,7 @@ import {
   mutationGeneric,
   queryGeneric,
 } from 'convex/server';
+import { ConvexError, type Value } from 'convex/values';
 import { z } from 'zod';
 import {
   type DataTransformerOptions,
@@ -24,11 +25,13 @@ import {
 } from '../crpc/transformer';
 import { customCtx } from '../internal/upstream/server/customFunctions';
 import {
+  convexToZodFields,
   zCustomAction,
   zCustomMutation,
   zCustomQuery,
   zodOutputToConvex,
   zodToConvex,
+  zodToConvexFields,
 } from '../internal/upstream/server/zod4';
 import { toCRPCError } from './error';
 import {
@@ -247,7 +250,15 @@ export function createMiddlewareFactory<TDefaultContext, TMeta = object>() {
 /** Result from middleware execution including potentially modified input */
 type MiddlewareExecutionResult = MiddlewareResult<unknown> & {
   input: unknown;
+  /** Value produced by the resolver at the end of the chain */
+  output?: unknown;
 };
+
+/** Terminal link of a middleware chain - runs the procedure resolver */
+type MiddlewareResolver = (opts: {
+  ctx: unknown;
+  input: unknown;
+}) => Promise<unknown>;
 
 const FUNCTION_NAME_SYMBOL = Symbol.for('functionName');
 
@@ -273,7 +284,13 @@ const resolveProcedureInfo = (
   };
 };
 
-/** Execute middleware chain recursively with input access */
+/**
+ * Execute the middleware chain, with the resolver as its terminal link.
+ *
+ * `next()` walks the remaining middleware and then runs the resolver, so a
+ * middleware that wraps `next()` can time the handler, catch its errors, and
+ * post-process its result - matching tRPC.
+ */
 async function executeMiddlewares(
   middlewares: AnyMiddleware[],
   ctx: unknown,
@@ -281,21 +298,24 @@ async function executeMiddlewares(
   procedure: MiddlewareProcedureInfo,
   input: unknown,
   getRawInput: GetRawInputFn,
+  resolve: MiddlewareResolver,
   index = 0
 ): Promise<MiddlewareExecutionResult> {
-  // Base case: no more middleware, return final context and input
+  // Base case: the whole chain ran, so the resolver is next
   if (index >= middlewares.length) {
     return {
       marker: undefined as never, // Runtime doesn't need the marker
       ctx,
       input,
+      output: await resolve({ ctx, input }),
     };
   }
 
   const middleware = middlewares[index];
 
-  // Track input modifications through the chain
+  // Track modifications made by this frame through the rest of the chain
   let currentInput = input;
+  let innerResult: MiddlewareExecutionResult | undefined;
 
   // Create next function for this middleware (tRPC-compatible signature)
   const next: MiddlewareNext<any, any> = async <
@@ -305,38 +325,40 @@ async function executeMiddlewares(
     input?: unknown;
   }) => {
     const nextCtx = opts?.ctx ?? ctx;
-    const nextInput = opts?.input ?? currentInput;
     // Track input modification
     if (opts?.input !== undefined) {
       currentInput = opts.input;
     }
-    const result = await executeMiddlewares(
+    innerResult = await executeMiddlewares(
       middlewares,
       nextCtx,
       meta,
       procedure,
-      nextInput,
+      currentInput,
       getRawInput,
+      resolve,
       index + 1
     );
-    return result as MiddlewareResult<any>;
+    return innerResult as MiddlewareResult<any>;
   };
 
   // Execute current middleware with input and getRawInput
-  const result = await middleware({
+  const result = (await middleware({
     ctx: ctx as any,
     meta,
     procedure,
     input,
     getRawInput,
     next,
-  });
+  })) as MiddlewareExecutionResult;
 
-  // Return result with potentially modified context and input
+  // Carry the inner frames' input and resolver output back out, so an override
+  // made by any middleware - not just the first - survives the return trip.
   return {
     marker: undefined as never,
     ctx: result.ctx ?? ctx,
-    input: currentInput,
+    input: result.input ?? innerResult?.input ?? currentInput,
+    output: result.output ?? innerResult?.output,
   };
 }
 
@@ -496,7 +518,12 @@ const withConvexSafeRunners = <TCtx>(ctx: TCtx): TCtx => {
 /** Internal definition storing procedure state */
 type ProcedureBuilderDef<TMeta = object> = {
   middlewares: AnyMiddleware[];
-  inputSchemas: Record<string, any>[];
+  /**
+   * Full `.input()` schemas, not their shapes: object-level checks
+   * (`.refine()`, `.superRefine()`, strict/catchall) only survive on the
+   * schema itself.
+   */
+  inputSchemas: z.ZodObject<any>[];
   outputSchema?: z.ZodTypeAny;
   meta?: TMeta;
   procedureName?: string;
@@ -607,6 +634,27 @@ const replaceUnencodableInputTypes = (schema: z.ZodTypeAny): z.ZodTypeAny => {
   return schema;
 };
 
+/**
+ * Rebuild a shape from the Convex validator it produces.
+ *
+ * The result is structurally identical (so the generated Convex validator is
+ * unchanged) but carries no checks, transforms, or defaults. cRPC's own
+ * `.input()` parse stays the single authoritative one, so refinements and
+ * transforms never run twice.
+ */
+const toWireShape = (
+  shape: Record<string, z.ZodTypeAny>
+): Record<string, z.ZodTypeAny> => {
+  try {
+    return convexToZodFields(zodToConvexFields(shape)) as Record<
+      string,
+      z.ZodTypeAny
+    >;
+  } catch {
+    return shape;
+  }
+};
+
 const resolveConvexArgsShape = (
   inputShape?: Record<string, z.ZodTypeAny>
 ): Record<string, z.ZodTypeAny> | undefined => {
@@ -615,18 +663,108 @@ const resolveConvexArgsShape = (
   const rawSchema = z.object(inputShape);
   try {
     zodToConvex(rawSchema as any);
-    return inputShape;
+    return toWireShape(inputShape);
   } catch {
     const compatibleSchema = replaceUnencodableInputTypes(rawSchema);
     try {
       zodToConvex(compatibleSchema as any);
-      return (compatibleSchema as z.ZodObject<any>).shape;
+      return toWireShape((compatibleSchema as z.ZodObject<any>).shape);
     } catch {
       const permissiveShape = Object.fromEntries(
         Object.keys(inputShape).map((key) => [key, z.any()])
       ) as Record<string, z.ZodTypeAny>;
       return permissiveShape;
     }
+  }
+};
+
+/**
+ * Drop keys a later `.input()` redeclares.
+ *
+ * Returns `undefined` when the schema carries object-level checks, since zod
+ * refuses to omit from those - such a schema keeps the key and reads the value
+ * its owner parsed.
+ */
+const omitSupersededKeys = (
+  schema: z.ZodObject<any>,
+  superseded: string[]
+): z.ZodObject<any> | undefined => {
+  if (superseded.length === 0) return schema;
+
+  try {
+    return schema.omit(
+      Object.fromEntries(superseded.map((key) => [key, true])) as any
+    );
+  } catch {
+    return;
+  }
+};
+
+/**
+ * Parse the wire payload through every `.input()` schema.
+ *
+ * Each schema parses only the keys it owns - the last `.input()` to declare a
+ * key wins, matching the merged shape the Convex arg validator is built from -
+ * so object-level checks run against the shape they were written for without an
+ * earlier, superseded declaration vetoing the payload.
+ */
+const parseInput = (
+  inputSchemas: z.ZodObject<any>[],
+  value: unknown
+): unknown => {
+  try {
+    if (inputSchemas.length === 1) {
+      return inputSchemas[0].parse(value);
+    }
+
+    const ownerOf = new Map<string, number>();
+    inputSchemas.forEach((schema, index) => {
+      for (const key of Object.keys(schema.shape)) {
+        ownerOf.set(key, index);
+      }
+    });
+
+    const source = isPlainObject(value) ? value : {};
+    const parsed: Record<string, unknown> = {};
+
+    // Walk owners first, so a schema still holding a superseded key can read
+    // the value its owner produced.
+    for (let index = inputSchemas.length - 1; index >= 0; index -= 1) {
+      const schema = inputSchemas[index];
+      const keys = Object.keys(schema.shape);
+      const superseded = keys.filter((key) => ownerOf.get(key) !== index);
+      const scoped = omitSupersededKeys(schema, superseded);
+
+      const narrowed: Record<string, unknown> = {};
+      for (const key of keys) {
+        if (superseded.includes(key)) {
+          // Omitted outright when zod allowed it, otherwise fed the owner value.
+          if (!scoped && key in parsed) narrowed[key] = parsed[key];
+          continue;
+        }
+        if (Object.hasOwn(source, key)) narrowed[key] = source[key];
+      }
+
+      const result = (scoped ?? schema).parse(narrowed) as Record<
+        string,
+        unknown
+      >;
+      for (const key of keys) {
+        if (ownerOf.get(key) === index && key in result) {
+          parsed[key] = result[key];
+        }
+      }
+    }
+
+    return parsed;
+  } catch (cause) {
+    if (cause instanceof z.ZodError) {
+      // Match the error shape the upstream Convex zod layer produces.
+      throw new ConvexError({
+        ZodError: JSON.parse(JSON.stringify(cause.issues, null, 2)) as Value[],
+      });
+    }
+    throw cause;
   }
 };
 
@@ -700,7 +838,7 @@ export class ProcedureBuilder<
   ): ProcedureBuilderDef<TMeta> {
     return {
       ...this._def,
-      inputSchemas: [...this._def.inputSchemas, schema.shape],
+      inputSchemas: [...this._def.inputSchemas, schema],
     };
   }
 
@@ -734,11 +872,11 @@ export class ProcedureBuilder<
   // Private Methods
   // ===========================================================================
 
-  /** Merge all input schemas into one */
+  /** Merge every `.input()` shape - used to build the Convex arg validator */
   protected _getMergedInput(): Record<string, any> | undefined {
     const { inputSchemas } = this._def;
     if (inputSchemas.length === 0) return;
-    return Object.assign({}, ...inputSchemas);
+    return Object.assign({}, ...inputSchemas.map((schema) => schema.shape));
   }
 
   protected _createFunction(
@@ -752,6 +890,7 @@ export class ProcedureBuilder<
   ) {
     const {
       middlewares,
+      inputSchemas,
       outputSchema,
       meta,
       procedureName,
@@ -761,7 +900,6 @@ export class ProcedureBuilder<
     const mergedInput = this._getMergedInput() as
       | Record<string, z.ZodTypeAny>
       | undefined;
-    const inputSchema = mergedInput ? z.object(mergedInput) : undefined;
     const convexArgs = resolveConvexArgsShape(mergedInput);
 
     // Use customCtx for initial context transformation only
@@ -792,9 +930,10 @@ export class ProcedureBuilder<
       handler: async (ctx: any, rawInput: any) => {
         const decodedInput =
           functionConfig.transformer.input.deserialize(rawInput);
-        const parsedInput = inputSchema
-          ? inputSchema.parse(decodedInput)
-          : decodedInput;
+        const parsedInput =
+          inputSchemas.length > 0
+            ? parseInput(inputSchemas, decodedInput)
+            : decodedInput;
         // Create getRawInput function for middleware
         const getRawInput: GetRawInputFn = async () => parsedInput;
 
@@ -804,30 +943,32 @@ export class ProcedureBuilder<
             resolvedProcedureName,
             fn
           );
-          // Execute middleware chain with input access
+          // Run the middleware chain, which invokes the handler at its end so
+          // wrapping middleware can observe it.
           const result = await executeMiddlewares(
             middlewares,
             ctx,
             meta,
             procedure,
             parsedInput,
-            getRawInput
+            getRawInput,
+            async ({ ctx: resolvedCtx, input: resolvedInput }) => {
+              const handlerInput =
+                resolvedInput === parsedInput
+                  ? parsedInput
+                  : functionConfig.transformer.input.deserialize(
+                      resolvedInput ?? parsedInput
+                    );
+              return await handler({
+                ctx: resolvedCtx,
+                input: handlerInput,
+              });
+            }
           );
 
-          // Call handler with middleware-modified context and input
-          const handlerInput =
-            result.input === parsedInput
-              ? parsedInput
-              : functionConfig.transformer.input.deserialize(
-                  result.input ?? parsedInput
-                );
-          const output = await handler({
-            ctx: result.ctx,
-            input: handlerInput,
-          });
           const validatedOutput = shouldValidateOutputWithZod
-            ? outputSchema.parse(output)
-            : output;
+            ? outputSchema.parse(result.output)
+            : result.output;
           return functionConfig.transformer.output.serialize(validatedOutput);
         } catch (cause) {
           const err = toCRPCError(cause);
@@ -995,10 +1136,7 @@ export class QueryProcedureBuilder<
 
     return new QueryProcedureBuilder({
       ...this._def,
-      inputSchemas: [
-        ...this._def.inputSchemas,
-        paginationSchemaWithDefault.shape,
-      ],
+      inputSchemas: [...this._def.inputSchemas, paginationSchemaWithDefault],
       outputSchema,
       meta: {
         ...this._def.meta,

--- a/packages/kitcn/src/server/error.test.ts
+++ b/packages/kitcn/src/server/error.test.ts
@@ -1,3 +1,5 @@
+import { ConvexError } from 'convex/values';
+
 import {
   CRPCError,
   getCRPCErrorFromUnknown,
@@ -5,6 +7,17 @@ import {
   isCRPCError,
   toCRPCError,
 } from './error';
+
+/**
+ * Convex's `performAsyncSyscall` never rethrows the original error object.
+ * It builds a fresh `ConvexError` from the message and re-attaches `.data`,
+ * so class identity is always lost across `runQuery`/`runMutation`.
+ */
+function acrossConvexSyscall(error: CRPCError): ConvexError<any> {
+  const rethrown = new ConvexError(error.message);
+  rethrown.data = JSON.parse(JSON.stringify(error.data));
+  return rethrown;
+}
 
 describe('server/error', () => {
   test('CRPCError sets code/data/message and preserves cause when provided', () => {
@@ -99,6 +112,45 @@ describe('server/error', () => {
     expect(err).toBeInstanceOf(CRPCError);
     expect(err?.code).toBe('UNAUTHORIZED');
     expect(err?.message).toBe('Nope');
+  });
+
+  test('toCRPCError rebuilds CRPCError from a ConvexError carrying cRPC data', () => {
+    const err = toCRPCError(
+      acrossConvexSyscall(
+        new CRPCError({ code: 'NOT_FOUND', message: 'Todo not found' })
+      )
+    );
+
+    expect(err).toBeInstanceOf(CRPCError);
+    expect(err?.code).toBe('NOT_FOUND');
+    expect(err?.message).toBe('Todo not found');
+  });
+
+  test('toCRPCError preserves structured data across the Convex syscall boundary', () => {
+    const err = toCRPCError(
+      acrossConvexSyscall(
+        new CRPCError({
+          code: 'CONFLICT',
+          message: 'Domain already exists',
+          data: { existingSiteId: 'site_123' },
+        })
+      )
+    );
+
+    expect(err?.code).toBe('CONFLICT');
+    expect(err?.data).toEqual({
+      code: 'CONFLICT',
+      message: 'Domain already exists',
+      existingSiteId: 'site_123',
+    });
+  });
+
+  test('toCRPCError ignores ConvexError payloads that are not cRPC errors', () => {
+    const zodFailure = new ConvexError({ ZodError: [{ message: 'bad' }] });
+    expect(toCRPCError(zodFailure)).toBeNull();
+
+    const unknownCode = new ConvexError({ code: 'NOT_A_CRPC_CODE' });
+    expect(toCRPCError(unknownCode)).toBeNull();
   });
 
   test('toCRPCError returns null for unhandled errors', () => {

--- a/packages/kitcn/src/server/error.ts
+++ b/packages/kitcn/src/server/error.ts
@@ -142,6 +142,30 @@ function isOrmNotFoundErrorLike(cause: unknown): cause is Error {
   return cause instanceof Error && cause.name === 'OrmNotFoundError';
 }
 
+type ConvexErrorLike = Error & { data: unknown };
+
+function isConvexErrorLike(cause: unknown): cause is ConvexErrorLike {
+  return cause instanceof Error && 'data' in cause;
+}
+
+/**
+ * `ctx.runQuery`/`ctx.runMutation` never rethrow the original error object:
+ * Convex builds a fresh `ConvexError` from the message and re-attaches `.data`.
+ * A cRPC error therefore arrives as a plain `ConvexError` whose `data` still
+ * carries the original `code`/`message`.
+ */
+function isCRPCErrorData(data: unknown): data is CRPCErrorData<any> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+
+  const { code, message } = data as { code?: unknown; message?: unknown };
+
+  return (
+    typeof code === 'string' &&
+    code in CRPC_ERROR_CODES_BY_KEY &&
+    (message === undefined || typeof message === 'string')
+  );
+}
+
 type APIErrorLike = Error & {
   status?: unknown;
   statusCode?: unknown;
@@ -216,6 +240,18 @@ export function toCRPCError(cause: unknown): CRPCError | null {
   if (cause instanceof CRPCError) return cause;
   if (cause instanceof Error && cause.name === 'CRPCError') {
     return cause as CRPCError;
+  }
+
+  if (isConvexErrorLike(cause) && isCRPCErrorData(cause.data)) {
+    const { code, message, ...data } = cause.data;
+    const err = new CRPCError({
+      code,
+      message,
+      cause,
+      data: data as Record<string, Value | undefined>,
+    }) as CRPCError;
+    if (cause.stack) err.stack = cause.stack;
+    return err;
   }
 
   if (isOrmNotFoundErrorLike(cause)) {

--- a/packages/kitcn/src/server/http-builder.test.ts
+++ b/packages/kitcn/src/server/http-builder.test.ts
@@ -1,6 +1,7 @@
+import { ConvexError } from 'convex/values';
 import { z } from 'zod';
 
-import { CRPCError } from './error';
+import { CRPC_ERROR_CODE_TO_HTTP, CRPCError } from './error';
 import {
   createHttpProcedureBuilder,
   extractPathParams,
@@ -39,6 +40,64 @@ describe('server/http-builder', () => {
     expect(resp.status).toBe(401);
     await expect(resp.json()).resolves.toEqual({
       error: { code: 'UNAUTHORIZED', message: 'Nope' },
+    });
+  });
+
+  test('handleHttpError maps every cRPC error code to its canonical status', async () => {
+    for (const [code, status] of Object.entries(CRPC_ERROR_CODE_TO_HTTP)) {
+      const resp = handleHttpError(
+        new CRPCError({ code: code as keyof typeof CRPC_ERROR_CODE_TO_HTTP })
+      );
+      expect([code, resp.status]).toEqual([code, status]);
+    }
+  });
+
+  test('handleHttpError recovers cRPC errors thrown across a Convex syscall boundary', async () => {
+    // `ctx.runQuery`/`ctx.runMutation` never rethrow the original error object:
+    // Convex builds a fresh ConvexError from the message and re-attaches `.data`.
+    const rethrown = new ConvexError('Todo not found');
+    rethrown.data = { code: 'NOT_FOUND', message: 'Todo not found' };
+
+    const resp = handleHttpError(rethrown);
+
+    expect(resp.status).toBe(404);
+    await expect(resp.json()).resolves.toEqual({
+      error: { code: 'NOT_FOUND', message: 'Todo not found' },
+    });
+  });
+
+  test('route surfaces a cRPC error raised by a procedure it called through ctx.runQuery', async () => {
+    const http = createHttpProcedureBuilder({
+      base: (handler) => handler as any,
+      createContext: (ctx) => ctx as any,
+      meta: {},
+    });
+
+    const proc = http
+      .get('/api/todos/:id')
+      .params(z.object({ id: z.string() }))
+      .query(async ({ ctx, params }) =>
+        (ctx as any).runQuery('todosInternal:get', { id: params.id })
+      );
+
+    const convexCtx = {
+      runQuery: () => {
+        // Convex rebuilds the error across the syscall boundary, so the
+        // route only ever sees a ConvexError carrying `.data`.
+        const rethrown = new ConvexError('Todo not found');
+        rethrown.data = { code: 'NOT_FOUND', message: 'Todo not found' };
+        return Promise.reject(rethrown);
+      },
+    };
+
+    const resp = await (proc as any)(
+      convexCtx,
+      new Request('https://example.com/api/todos/123')
+    );
+
+    expect(resp.status).toBe(404);
+    await expect(resp.json()).resolves.toEqual({
+      error: { code: 'NOT_FOUND', message: 'Todo not found' },
     });
   });
 
@@ -84,6 +143,64 @@ describe('server/http-builder', () => {
     expect(resp.status).toBe(400);
     await expect(resp.json()).resolves.toEqual({
       error: { code: 'BAD_REQUEST', message: 'Invalid input' },
+    });
+  });
+
+  test('procedure returns 400 BAD_REQUEST for an unparseable JSON body', async () => {
+    const http = createHttpProcedureBuilder({
+      base: (handler) => handler as any,
+      createContext: () => ({}) as any,
+      meta: {},
+    });
+
+    const proc = http
+      .post('/x')
+      .input(z.object({ name: z.string() }))
+      .mutation(async ({ input }) => input);
+
+    for (const body of ['{"name": ', '']) {
+      const resp = await (proc as any)(
+        {},
+        new Request('https://example.com/x', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body,
+        })
+      );
+
+      expect(resp.status).toBe(400);
+      await expect(resp.json()).resolves.toEqual({
+        error: { code: 'BAD_REQUEST', message: 'Invalid JSON body' },
+      });
+    }
+  });
+
+  test('procedure returns 400 BAD_REQUEST for an unparseable form body', async () => {
+    const http = createHttpProcedureBuilder({
+      base: (handler) => handler as any,
+      createContext: () => ({}) as any,
+      meta: {},
+    });
+
+    const proc = http
+      .post('/upload')
+      .form(z.object({ note: z.string() }))
+      .mutation(async ({ form }) => form);
+
+    const resp = await (proc as any)(
+      {},
+      new Request('https://example.com/upload', {
+        method: 'POST',
+        headers: {
+          'content-type': 'multipart/form-data; boundary=----nope',
+        },
+        body: 'not actually multipart',
+      })
+    );
+
+    expect(resp.status).toBe(400);
+    await expect(resp.json()).resolves.toEqual({
+      error: { code: 'BAD_REQUEST', message: 'Invalid form data' },
     });
   });
 

--- a/packages/kitcn/src/server/http-builder.test.ts
+++ b/packages/kitcn/src/server/http-builder.test.ts
@@ -333,6 +333,69 @@ describe('server/http-builder', () => {
     ]);
   });
 
+  test('http middleware wraps the procedure handler', async () => {
+    const events: string[] = [];
+    const http = createHttpProcedureBuilder({
+      base: (handler) => handler as any,
+      createContext: () => ({}) as any,
+      meta: {},
+    });
+
+    const proc = http
+      .get('/x')
+      .use(async ({ next }) => {
+        events.push('before');
+        const result = await next();
+        events.push('after');
+        return result;
+      })
+      .query(async () => {
+        events.push('handler');
+        return { ok: true };
+      });
+
+    const resp = await (proc as any)({}, new Request('https://example.com/x'));
+
+    expect(resp.status).toBe(200);
+    expect(events).toEqual(['before', 'handler', 'after']);
+  });
+
+  test('middleware getRawInput reports malformed JSON as BAD_REQUEST', async () => {
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const http = createHttpProcedureBuilder({
+        base: (handler) => handler as any,
+        createContext: () => ({}) as any,
+        meta: {},
+      });
+
+      const proc = http
+        .post('/x')
+        .use(async ({ getRawInput, next }) => {
+          await getRawInput();
+          return next();
+        })
+        .mutation(async () => ({ ok: true }));
+
+      const resp = await (proc as any)(
+        {},
+        new Request('https://example.com/x', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{"name": ',
+        })
+      );
+
+      expect(resp.status).toBe(400);
+      await expect(resp.json()).resolves.toEqual({
+        error: { code: 'BAD_REQUEST', message: 'Invalid JSON body' },
+      });
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   test('procedure parses multipart form data via .form()', async () => {
     const http = createHttpProcedureBuilder({
       base: (handler) => handler as any,

--- a/packages/kitcn/src/server/http-builder.ts
+++ b/packages/kitcn/src/server/http-builder.ts
@@ -5,7 +5,7 @@ import {
   type DataTransformerOptions,
   getTransformer,
 } from '../crpc/transformer';
-import { CRPCError } from './error';
+import { CRPCError, getHTTPStatusCodeFromError, toCRPCError } from './error';
 import type {
   CRPCHonoHandler,
   HttpHandlerOpts,
@@ -60,28 +60,19 @@ export function matchPathParams(
 
 // Convert CRPCError to HTTP Response
 export function handleHttpError(error: unknown): Response {
-  if (error instanceof CRPCError) {
-    const statusMap: Record<string, number> = {
-      BAD_REQUEST: 400,
-      UNAUTHORIZED: 401,
-      FORBIDDEN: 403,
-      NOT_FOUND: 404,
-      METHOD_NOT_SUPPORTED: 405,
-      CONFLICT: 409,
-      UNPROCESSABLE_CONTENT: 422,
-      TOO_MANY_REQUESTS: 429,
-      INTERNAL_SERVER_ERROR: 500,
-    };
+  // `toCRPCError` also recovers cRPC errors that lost their class identity
+  // crossing a `ctx.runQuery`/`ctx.runMutation` boundary.
+  const crpcError = toCRPCError(error);
 
-    const status = statusMap[error.code] ?? 500;
+  if (crpcError) {
     return Response.json(
       {
         error: {
-          code: error.code,
-          message: error.message,
+          code: crpcError.code,
+          message: crpcError.message,
         },
       },
-      { status }
+      { status: getHTTPStatusCodeFromError(crpcError) }
     );
   }
 
@@ -95,6 +86,32 @@ export function handleHttpError(error: unknown): Response {
     },
     { status: 500 }
   );
+}
+
+/** Read a JSON body, reporting parse failures as client errors. */
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch (cause) {
+    throw new CRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Invalid JSON body',
+      cause,
+    });
+  }
+}
+
+/** Read a form body, reporting parse failures as client errors. */
+async function readFormDataBody(request: Request): Promise<FormData> {
+  try {
+    return await request.formData();
+  } catch (cause) {
+    throw new CRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Invalid form data',
+      cause,
+    });
+  }
 }
 
 // Helper to get base schema type (unwrap Optional/Nullable/Default wrappers)
@@ -606,9 +623,9 @@ function createProcedure(
         let body: unknown;
 
         if (contentType.includes('application/json')) {
-          body = await request.json();
+          body = await readJsonBody(request);
         } else if (contentType.includes('application/x-www-form-urlencoded')) {
-          const formData = await request.formData();
+          const formData = await readFormDataBody(request);
           body = Object.fromEntries(formData.entries());
         } else {
           body = await request.json().catch(() => ({}));
@@ -633,7 +650,7 @@ function createProcedure(
       // Parse form data (multipart/form-data)
       let parsedForm: unknown;
       if (def.formSchema && request.method !== 'GET') {
-        const formData = await request.formData();
+        const formData = await readFormDataBody(request);
         const formObj: Record<string, unknown> = {};
         for (const [key, value] of formData.entries()) {
           formObj[key] = value;

--- a/packages/kitcn/src/server/http-builder.ts
+++ b/packages/kitcn/src/server/http-builder.ts
@@ -14,6 +14,7 @@ import type {
   HttpProcedureBuilderDef,
   ProcedureMeta,
 } from './http-types';
+import { executeMiddlewares } from './middleware-runner';
 import type {
   AnyMiddleware,
   GetRawInputFn,
@@ -546,163 +547,154 @@ function createProcedure(
         c.req.param() ?? matchPathParams(def.route!.path, url.pathname) ?? {};
 
       // Create base context
-      let ctx = def.functionConfig.createContext(convexCtx as any) as any;
+      const initialCtx = def.functionConfig.createContext(convexCtx as any);
 
       // getRawInput for HTTP - returns raw request body
       const getRawInput: GetRawInputFn = async () => {
         const contentType = request.headers.get('content-type') ?? '';
         if (contentType.includes('application/json')) {
-          return request.clone().json();
+          return readJsonBody(request.clone());
         }
         return null;
       };
 
-      // Execute middlewares (input is unknown for HTTP middleware - parsed after)
-      let currentInput: unknown;
-      for (const middleware of def.middlewares) {
-        const result = await middleware({
-          ctx: ctx as any,
-          procedure: middlewareProcedure,
-          input: currentInput,
-          getRawInput,
-          next: async (opts?: any) => {
-            if (opts?.ctx) {
-              ctx = { ...ctx, ...opts.ctx };
+      const middlewareResult = await executeMiddlewares(
+        def.middlewares,
+        initialCtx,
+        def.meta,
+        middlewareProcedure,
+        undefined,
+        getRawInput,
+        async ({ ctx }) => {
+          // Parse path params
+          let parsedParams: unknown;
+          if (def.paramsSchema) {
+            try {
+              parsedParams = def.paramsSchema.parse(pathParams as any);
+            } catch (error) {
+              if (error instanceof z.ZodError) {
+                throw new CRPCError({
+                  code: 'BAD_REQUEST',
+                  message: 'Invalid path params',
+                  cause: error,
+                });
+              }
+              throw error;
             }
-            if (opts?.input !== undefined) {
-              currentInput = opts.input;
+          }
+
+          // Parse query params - pass schema for array coercion
+          let parsedQuery: unknown;
+          if (def.querySchema) {
+            const queryParams = parseQueryParams(url, def.querySchema);
+            try {
+              parsedQuery = def.querySchema.parse(queryParams as any);
+            } catch (error) {
+              if (error instanceof z.ZodError) {
+                throw new CRPCError({
+                  code: 'BAD_REQUEST',
+                  message: 'Invalid query params',
+                  cause: error,
+                });
+              }
+              throw error;
             }
-            return { ctx, marker: undefined as any };
-          },
-          meta: def.meta,
-        });
-        if (result?.ctx) {
-          ctx = { ...ctx, ...(result.ctx as any) };
-        }
-      }
-
-      // Parse path params
-      let parsedParams: unknown;
-      if (def.paramsSchema) {
-        try {
-          parsedParams = def.paramsSchema.parse(pathParams as any);
-        } catch (error) {
-          if (error instanceof z.ZodError) {
-            throw new CRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Invalid path params',
-              cause: error,
-            });
           }
-          throw error;
-        }
-      }
 
-      // Parse query params - pass schema for array coercion
-      let parsedQuery: unknown;
-      if (def.querySchema) {
-        const queryParams = parseQueryParams(url, def.querySchema);
-        try {
-          parsedQuery = def.querySchema.parse(queryParams as any);
-        } catch (error) {
-          if (error instanceof z.ZodError) {
-            throw new CRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Invalid query params',
-              cause: error,
-            });
+          // Parse body for non-GET methods
+          let parsedInput: unknown;
+          if (def.inputSchema && request.method !== 'GET') {
+            const contentType = request.headers.get('content-type') ?? '';
+            let body: unknown;
+
+            if (contentType.includes('application/json')) {
+              body = await readJsonBody(request);
+            } else if (
+              contentType.includes('application/x-www-form-urlencoded')
+            ) {
+              const formData = await readFormDataBody(request);
+              body = Object.fromEntries(formData.entries());
+            } else {
+              body = await request.json().catch(() => ({}));
+            }
+
+            try {
+              parsedInput = def.inputSchema.parse(
+                def.functionConfig.transformer.input.deserialize(body) as any
+              );
+            } catch (error) {
+              if (error instanceof z.ZodError) {
+                throw new CRPCError({
+                  code: 'BAD_REQUEST',
+                  message: 'Invalid input',
+                  cause: error,
+                });
+              }
+              throw error;
+            }
           }
-          throw error;
-        }
-      }
 
-      // Parse body for non-GET methods
-      let parsedInput: unknown;
-      if (def.inputSchema && request.method !== 'GET') {
-        const contentType = request.headers.get('content-type') ?? '';
-        let body: unknown;
+          // Parse form data (multipart/form-data)
+          let parsedForm: unknown;
+          if (def.formSchema && request.method !== 'GET') {
+            const formData = await readFormDataBody(request);
+            const formObj: Record<string, unknown> = {};
+            for (const [key, value] of formData.entries()) {
+              formObj[key] = value;
+            }
+            try {
+              parsedForm = def.formSchema.parse(formObj);
+            } catch (error) {
+              if (error instanceof z.ZodError) {
+                throw new CRPCError({
+                  code: 'BAD_REQUEST',
+                  message: 'Invalid form data',
+                  cause: error,
+                });
+              }
+              throw error;
+            }
+          }
 
-        if (contentType.includes('application/json')) {
-          body = await readJsonBody(request);
-        } else if (contentType.includes('application/x-www-form-urlencoded')) {
-          const formData = await readFormDataBody(request);
-          body = Object.fromEntries(formData.entries());
-        } else {
-          body = await request.json().catch(() => ({}));
-        }
+          // Build handler options - ctx namespaced, include Hono Context `c`
+          const handlerOpts: any = {
+            ctx,
+            c,
+          };
 
-        try {
-          parsedInput = def.inputSchema.parse(
-            def.functionConfig.transformer.input.deserialize(body) as any
+          if (parsedInput !== undefined) {
+            handlerOpts.input = parsedInput;
+          }
+
+          if (parsedParams !== undefined) {
+            handlerOpts.params = parsedParams;
+          }
+
+          if (parsedQuery !== undefined) {
+            handlerOpts.searchParams = parsedQuery;
+          }
+
+          if (parsedForm !== undefined) {
+            handlerOpts.form = parsedForm;
+          }
+
+          const result = await handler(handlerOpts);
+
+          // If handler returned Response (from c.json, c.text, etc.), return it directly
+          if (result instanceof Response) {
+            return result;
+          }
+
+          // Validate and return JSON response via Hono
+          const output = def.outputSchema
+            ? def.outputSchema.parse(result as any)
+            : result;
+          return c.json(
+            def.functionConfig.transformer.output.serialize(output)
           );
-        } catch (error) {
-          if (error instanceof z.ZodError) {
-            throw new CRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Invalid input',
-              cause: error,
-            });
-          }
-          throw error;
         }
-      }
-
-      // Parse form data (multipart/form-data)
-      let parsedForm: unknown;
-      if (def.formSchema && request.method !== 'GET') {
-        const formData = await readFormDataBody(request);
-        const formObj: Record<string, unknown> = {};
-        for (const [key, value] of formData.entries()) {
-          formObj[key] = value;
-        }
-        try {
-          parsedForm = def.formSchema.parse(formObj);
-        } catch (error) {
-          if (error instanceof z.ZodError) {
-            throw new CRPCError({
-              code: 'BAD_REQUEST',
-              message: 'Invalid form data',
-              cause: error,
-            });
-          }
-          throw error;
-        }
-      }
-
-      // Build handler options - ctx namespaced, include Hono Context `c`
-      const handlerOpts: any = {
-        ctx,
-        c,
-      };
-
-      if (parsedInput !== undefined) {
-        handlerOpts.input = parsedInput;
-      }
-
-      if (parsedParams !== undefined) {
-        handlerOpts.params = parsedParams;
-      }
-
-      if (parsedQuery !== undefined) {
-        handlerOpts.searchParams = parsedQuery;
-      }
-
-      if (parsedForm !== undefined) {
-        handlerOpts.form = parsedForm;
-      }
-
-      const result = await handler(handlerOpts);
-
-      // If handler returned Response (from c.json, c.text, etc.), return it directly
-      if (result instanceof Response) {
-        return result;
-      }
-
-      // Validate and return JSON response via Hono
-      const output = def.outputSchema
-        ? def.outputSchema.parse(result as any)
-        : result;
-      return c.json(def.functionConfig.transformer.output.serialize(output));
+      );
+      return middlewareResult.output as Response;
     } catch (error) {
       return handleHttpError(error);
     }

--- a/packages/kitcn/src/server/middleware-runner.ts
+++ b/packages/kitcn/src/server/middleware-runner.ts
@@ -1,0 +1,81 @@
+import type {
+  AnyMiddleware,
+  GetRawInputFn,
+  MiddlewareNext,
+  MiddlewareProcedureInfo,
+  MiddlewareResult,
+} from './types';
+
+export type MiddlewareExecutionResult = MiddlewareResult<unknown> & {
+  input: unknown;
+  output?: unknown;
+};
+
+type MiddlewareResolver = (opts: {
+  ctx: unknown;
+  input: unknown;
+}) => Promise<unknown>;
+
+/** Run middleware around a terminal procedure resolver. */
+export const executeMiddlewares = async (
+  middlewares: AnyMiddleware[],
+  ctx: unknown,
+  meta: unknown,
+  procedure: MiddlewareProcedureInfo,
+  input: unknown,
+  getRawInput: GetRawInputFn,
+  resolve: MiddlewareResolver,
+  index = 0
+): Promise<MiddlewareExecutionResult> => {
+  if (index >= middlewares.length) {
+    return {
+      marker: undefined as never,
+      ctx,
+      input,
+      output: await resolve({ ctx, input }),
+    };
+  }
+
+  const middleware = middlewares[index];
+  let currentInput = input;
+  let innerResult: MiddlewareExecutionResult | undefined;
+
+  const next: MiddlewareNext<any, any> = async <
+    TNextContext extends object = Record<string, never>,
+  >(opts?: {
+    ctx?: TNextContext;
+    input?: unknown;
+  }) => {
+    const nextCtx = opts?.ctx ?? ctx;
+    if (opts?.input !== undefined) {
+      currentInput = opts.input;
+    }
+    innerResult = await executeMiddlewares(
+      middlewares,
+      nextCtx,
+      meta,
+      procedure,
+      currentInput,
+      getRawInput,
+      resolve,
+      index + 1
+    );
+    return innerResult as MiddlewareResult<any>;
+  };
+
+  const result = (await middleware({
+    ctx: ctx as any,
+    meta,
+    procedure,
+    input,
+    getRawInput,
+    next,
+  })) as MiddlewareExecutionResult;
+
+  return {
+    marker: undefined as never,
+    ctx: result.ctx ?? ctx,
+    input: result.input ?? innerResult?.input ?? currentInput,
+    output: result.output ?? innerResult?.output,
+  };
+};


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

cRPC now preserves the contract across validation, middleware, Convex syscall errors, and HTTP routes:

- Each chained `.input()` schema keeps object-level refinements and runs once; when keys overlap, only the last declaring schema validates that key.
- `next({ input })` propagates from every middleware position.
- Convex and HTTP middleware share one terminal runner, so `await next()` wraps the handler and observes its output, errors, timing, and cleanup.
- cRPC errors reconstructed across `runQuery` and `runMutation` keep their code, message, structured data, and canonical HTTP status.
- Malformed JSON and form bodies return `400`, including JSON read by middleware through `getRawInput()`.

Review fixes:

- Preserve last-schema ownership when an earlier overlapping schema has object-level checks.
- Start changeset bullets with action verbs.
- Extend terminal middleware chaining to HTTP routes through the shared runner.
- Route middleware raw JSON parsing through the BAD_REQUEST reader.

Proof:

- 71 focused builder/error/HTTP tests pass with 182 assertions.
- Package build, root typecheck, lint, deslop audit, and final autoreview pass.
- Exact final-tree `bun check` passes, including all tests, generated fixtures, and runtime scenarios.
- `.changeset/crpc-procedure-contracts.md` records the minor breaking contract.
