### PR TITLE
fix(react): JWT decoding, auth cache scoping, no replay of failed calls

### DIFF
--- a/.changeset/react-rsc-auth-cache.md
+++ b/.changeset/react-rsc-auth-cache.md
@@ -4,15 +4,10 @@
 
 ## Patches
 
-- Fix signed-in users being logged out when their name or email contains
-  non-ASCII characters. JWT expirations are now read from the token's base64url
-  payload instead of being misread as an opaque session token.
-- Fix server callers replaying a failed call after any error when the JWT came
-  from the cookie cache, which could charge a card or write a row twice. Calls
-  are now replayed only when the failure is an authorization error, so
-  mutations and actions are never re-executed after a business-logic failure.
-  Recovery from an expired cached token still happens automatically, without
-  needing to configure `isUnauthorized`.
+- Fix signed-in users being signed out when their name or email contains
+  non-ASCII characters.
+- Fix server callers re-running a failed mutation or action after a
+  non-authorization error, which could charge a card or write a row twice.
 - Fix results of auth-scoped actions surviving sign-out and being served to the
   next user in the same tab.
 - Fix `skipUnauth` being ignored on queries and action queries, so backend

--- a/.changeset/react-rsc-auth-cache.md
+++ b/.changeset/react-rsc-auth-cache.md
@@ -1,0 +1,28 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix signed-in users being logged out when their name or email contains
+  non-ASCII characters. JWT expirations are now read from the token's base64url
+  payload instead of being misread as an opaque session token.
+- Fix server callers replaying a failed call after any error when the JWT came
+  from the cookie cache, which could charge a card or write a row twice. Calls
+  are now replayed only when the failure is an authorization error, so
+  mutations and actions are never re-executed after a business-logic failure.
+  Recovery from an expired cached token still happens automatically, without
+  needing to configure `isUnauthorized`.
+- Fix results of auth-scoped actions surviving sign-out and being served to the
+  next user in the same tab.
+- Fix `skipUnauth` being ignored on queries and action queries, so backend
+  authorization errors resolve to `null` as documented instead of surfacing as
+  query errors.
+- Fix `Date` values in query args crashing the render.
+- Fix a function-form `enabled` being ignored on queries, action queries, and
+  infinite queries, which ran queries the caller had disabled.
+- Fix mutating a query args object in place returning another component's args
+  for a previously used key, which subscribed to the wrong Convex query.
+- Fix RSC prefetch of `crpc.http.*` building a different URL than the browser
+  client for `params` and `searchParams`, so prefetched data now hydrates
+  instead of being refetched.

--- a/docs/plans/319-close-ratelimit-accounting-pr.md
+++ b/docs/plans/319-close-ratelimit-accounting-pr.md
@@ -77,7 +77,7 @@ Closure matrix:
 | agent workflow | yes | Published behavior/guard discoverability | complete |
 | cleanup/review | yes | 29 findings fixed; final autoreview clean at 0.91 confidence | complete |
 | repository check | yes | `bun check` | complete |
-| GitHub delivery | yes | PR 319 update/merge/read-back | pending |
+| GitHub delivery | yes | PR 319 update/merge/read-back | complete |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
@@ -85,8 +85,8 @@ Work Checklist:
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
 - [x] Accepted cleanup and review findings are closed in focused proof.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver: none.
 - [x] Agent-native pack: package skill owner/mirror boundary recorded.
 - [x] Agent-native pack: ratelimit semantics and invalid shard guard are discoverable.
 - [x] Agent-native pack: package skill/mirror parity proved; `.agents/rules` N/A.
@@ -138,9 +138,9 @@ Completion Gates:
 | Agent-native reviewer | yes | Review published ratelimit guidance | pass: complete route/owner/mirror/proof chain |
 | Final lint | yes | Run `bun lint:fix` | passed: 880 files; no fixes |
 | Repository check | yes | Run `bun check` | passed: lint, types, tests, CLI, Concave, fixtures, and runtime scenarios |
-| GitHub delivery | yes | Update, squash-merge, read back | pending |
+| GitHub delivery | yes | Update, squash-merge, read back | passed: merged at `2aee478fcc75` |
 | Autoreview | yes | Resolve every accepted actionable finding | passed: 29 fixed; compatibility fallback rejected by hard-cut doctrine; final review clean at 0.91 confidence |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/319-close-ratelimit-accounting-pr.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/319-close-ratelimit-accounting-pr.md` | passed after merge receipt |
 | Agent source / generated sync | yes | Verify package skill/mirror | passed after `sync-kitcn-skill.ts` |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
 | Agent action discoverability | yes | Audit published ratelimit skill route | passed: main skill links exact reference |
@@ -153,8 +153,8 @@ Phase / pass table:
 | Inventory | complete | PR, source, tests, docs, skill owners, changeset, and seven threads read | repair |
 | Repair | complete | Rebased and closed original plus independent review findings with TDD | review |
 | Review/checks | complete | 62 focused tests, final autoreview clean at 0.91 confidence, and exact `bun check` passed | delivery |
-| Delivery | in_progress | local head ready for lease-protected push | remote gates and merge |
-| Closeout | pending | | final |
+| Delivery | complete | CI/Vercel green, 13 threads resolved, auto-release off, squash merge read back | final |
+| Closeout | complete | merge receipt recorded and goal checker passed | final |
 
 Verification evidence:
 - PR 319 CI/Vercel green at goal creation; no approval yet.
@@ -177,6 +177,9 @@ Verification evidence:
   protocol are internally consistent; no compatibility shim is warranted.
 - Final committed-head autoreview reports zero accepted/actionable findings at
   0.91 confidence after all 29 accepted fixes.
+- PR 319 merged on 2026-08-15T01:36:00Z as squash commit
+  `2aee478fcc750d06bd914bf5cd701045d1c79736`; all 13 review threads were
+  resolved and auto-release was disabled.
 
 Timeline:
 - 2026-08-14T18:17:55.073Z Autoclosure plan created.
@@ -209,18 +212,20 @@ Timeline:
   accepted/actionable findings at 0.91 confidence.
 - 2026-08-15T03:27:00+02:00 Exact `bun check` passed through lint, types,
   tests, CLI, Concave, fixture reproduction, and runtime scenarios.
+- 2026-08-15T03:36:00+02:00 Remote checks passed, all review threads resolved,
+  auto-release remained disabled, and PR 319 squash-merged at `2aee478fcc75`.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Remote gates, squash merge, final audit |
+| Where am I? | Closeout |
+| Where am I going? | Goal checker |
 | What is the goal? | Merge correct limiter accounting with synchronized guidance |
 | What have I learned? | Exact global quotas need fallback and capacity-aware scaling, not only per-shard division |
-| What have I done? | Rebased, repaired, synchronized, and proved all focused ratelimit lanes |
+| What have I done? | Rebased, repaired, proved, delivered, and read back the merge |
 
 Open risks:
-- Refreshed remote gates and merge receipt remain.
+- None.
 
 Findings:
 - The preferred-shard fast path must fall back before it can claim global exhaustion.

--- a/docs/plans/321-close-react-auth-pr.md
+++ b/docs/plans/321-close-react-auth-pr.md
@@ -76,7 +76,7 @@ Closure matrix:
 | changeset | yes | `.changeset/react-rsc-auth-cache.md` audit | complete |
 | agent workflow | no | N/A: no agent action | N/A |
 | cleanup/review | yes | Deslop and committed-head autoreview clean at 0.86 confidence | complete |
-| repository check | yes | `bun check` | pending |
+| repository check | yes | `bun check` | complete |
 | GitHub delivery | yes | PR 321 merge plus Version Packages/publish read-back | pending |
 
 Work Checklist:
@@ -85,6 +85,7 @@ Work Checklist:
 - [x] Generated output is N/A: no generated owner is touched.
 - [x] Package and changeset contracts are synchronized; docs/skill/fixture/scenario are N/A.
 - [x] Accepted cleanup and review findings are closed.
+- [x] Exact repository check passed on committed code head.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: no rule/generated mirror changed.
@@ -109,7 +110,7 @@ Completion Gates:
 | Deslop | yes | Run changed-file cleanup review | passed: no added or worsened findings; score improved 3.09 |
 | Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
 | Final lint | yes | Run `bun lint:fix` | passed: 882 files; no fixes |
-| Repository check | yes | Run `bun check` | pending |
+| Repository check | yes | Run `bun check` | passed on `23d05d9f1b76` |
 | GitHub delivery | yes | Merge last and verify release/publish | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | passed: zero accepted/actionable findings at 0.86 confidence |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/321-close-react-auth-pr.md` | pending |
@@ -124,8 +125,8 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | complete | PR, source, tests, changeset, checks, and two threads read | repair |
 | Repair | complete | Transformer ownership and explicit enabled gating fixed with TDD | review |
-| Review/checks | in_progress | 102 focused tests, build, typecheck, lint, deslop, and autoreview pass | repository check |
-| Delivery | pending | | final audit |
+| Review/checks | complete | 102 focused tests, build, typecheck, lint, deslop, autoreview, and exact check pass | delivery |
+| Delivery | in_progress | local rebased head ready for lease-protected push | remote gates and merge |
 | Closeout | pending | | final |
 
 Verification evidence:
@@ -141,6 +142,8 @@ Verification evidence:
 - `bun --cwd packages/kitcn build`, root typecheck, lint, and deslop pass.
 - Committed-head autoreview reports zero accepted/actionable findings at 0.86
   confidence after the two local review repairs.
+- Exact `bun check` passed on code head `23d05d9f1b76`, covering lint, types,
+  unit and CLI tests, Concave smoke, fixture reproduction, and runtime scenarios.
 
 Timeline:
 - 2026-08-14T18:17:55.196Z Autoclosure plan created.
@@ -149,18 +152,20 @@ Timeline:
   and completed focused package proof.
 - 2026-08-15T03:45:00+02:00 Committed-head autoreview passed with zero
   accepted/actionable findings at 0.86 confidence.
+- 2026-08-15T03:52:00+02:00 Exact `bun check` passed on `23d05d9f1b76`
+  through all fixture and live runtime lanes.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Autoreview, repository check, delivery, release audit |
+| Where am I? | Delivery |
+| Where am I going? | Push, remote gates, merge, release audit |
 | What is the goal? | Merge final client/auth fix and publish the complete batch once |
 | What have I learned? | See closure matrix |
 | What have I done? | Rebased, repaired two findings, and completed focused proof |
 
 Open risks:
-- Committed-head review, repository check, remote gates, and release proof remain.
+- Remote gates, merge, and release proof remain.
 
 Findings:
 - PR 321 is intentionally last solely because it owns the single release trigger.

--- a/docs/plans/321-close-react-auth-pr.md
+++ b/docs/plans/321-close-react-auth-pr.md
@@ -43,7 +43,7 @@ Boundaries:
 - intended delta: PR 321 JWT/auth cache/query metadata/RSC/caller retry behavior
 - allowed repairs: touched React/RSC/server/internal source/tests and changeset
 - unrelated files: preserve; do not treat as blockers
-- non-goals: Solid client repair, unrelated query APIs, release-policy changes
+- non-goals: unrelated query APIs or release-policy changes
 
 Output budget strategy:
 - Exact changed files and focused failures; compact GitHub release checks; exclude artifacts.
@@ -68,22 +68,22 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused React/RSC/server tests | pending |
-| package/API/build | yes | Package build/types | pending |
+| source behavior | yes | 102 focused React/Solid/RSC/server tests | complete |
+| package/API/build | yes | Package build and root typecheck | complete |
 | generated output | no | N/A: no generated output | N/A |
 | fixtures/scenarios | no | N/A: no scaffold output | N/A |
 | docs/package skill | no | N/A: no docs/skill delta | N/A |
-| changeset | yes | `.changeset/react-rsc-auth-cache.md` audit | pending |
+| changeset | yes | `.changeset/react-rsc-auth-cache.md` audit | complete |
 | agent workflow | no | N/A: no agent action | N/A |
-| cleanup/review | yes | Deslop and autoreview | pending |
+| cleanup/review | yes | Deslop complete; committed-head autoreview pending | in_progress |
 | repository check | yes | `bun check` | pending |
 | GitHub delivery | yes | PR 321 merge plus Version Packages/publish read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
+- [x] Each pre-review lane is proven or N/A with a concrete reason.
 - [x] Generated output is N/A: no generated owner is touched.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Package and changeset contracts are synchronized; docs/skill/fixture/scenario are N/A.
 - [ ] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
@@ -97,17 +97,18 @@ Work Checklist:
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
-| None yet | 0 | | |
+| Normalized RSC transformer was composed again in the HTTP layer | 1 | Pass the combined transformer directly | Red identity regression became green |
+| `resolveEnabled(true, false)` enabled a caller-disabled query | 1 | Preserve explicit booleans at the shared helper | Red helper regression became green |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused React/RSC/server tests | pending |
+| Targeted behavior proof | yes | Run focused React/Solid/RSC/server tests | passed: 102 tests across ten files |
 | Source/generated audit | no | N/A: source-only runtime change | N/A |
-| Package/docs/scenario closure | yes | Build package and audit changeset | pending |
-| Deslop | yes | Run changed-file cleanup review | pending |
+| Package/docs/scenario closure | yes | Build package and audit changeset | passed; docs/scenarios N/A |
+| Deslop | yes | Run changed-file cleanup review | passed: no added or worsened findings; score improved 3.09 |
 | Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
-| Final lint | yes | Run `bun lint:fix` | pending |
+| Final lint | yes | Run `bun lint:fix` | passed: 882 files; no fixes |
 | Repository check | yes | Run `bun check` | pending |
 | GitHub delivery | yes | Merge last and verify release/publish | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | pending |
@@ -121,36 +122,52 @@ Completion Gates:
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
+| Inventory | complete | PR, source, tests, changeset, checks, and two threads read | repair |
+| Repair | complete | Transformer ownership and explicit enabled gating fixed with TDD | review |
+| Review/checks | in_progress | 102 focused tests, package build, typecheck, lint, and deslop pass | autoreview and check |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
 Verification evidence:
 - PR 321 CI/Vercel green at goal creation; auto-release checked; no approval yet.
+- All six earlier PRs are merged. PR 319 merged at `2aee478fcc75` on
+  2026-08-15T01:36:00Z without triggering a release.
+- Focused proof passes 89 Bun tests and 13 Vitest tests across React, Solid,
+  internal query keys/gates, RSC HTTP execution, and the server caller.
+- The RSC query owner normalizes a custom transformer once and the HTTP request
+  layer preserves that exact combined transformer.
+- Explicit `enabled: false` remains false, predicates remain predicates, and
+  prefetched infinite data hydrates without network work while auth is loading.
+- `bun --cwd packages/kitcn build`, root typecheck, lint, and deslop pass.
 
 Timeline:
 - 2026-08-14T18:17:55.196Z Autoclosure plan created.
+- 2026-08-15T03:41:00+02:00 Rebased onto the six merged predecessors, closed
+  transformer recomposition and explicit enabled gating with red-to-green tests,
+  and completed focused package proof.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Review/checks |
+| Where am I going? | Autoreview, repository check, delivery, release audit |
 | What is the goal? | Merge final client/auth fix and publish the complete batch once |
 | What have I learned? | See closure matrix |
-| What have I done? | See timeline |
+| What have I done? | Rebased, repaired two findings, and completed focused proof |
 
 Open risks:
-- Auth-cache scoping and failed-action retry can leak data or duplicate effects if review misses a path.
-- Release proof is external and must be read back after merge.
+- Committed-head review, repository check, remote gates, and release proof remain.
 
 Findings:
 - PR 321 is intentionally last solely because it owns the single release trigger.
 
 Decisions and tradeoffs:
-- Keep Solid's matching decoder bug out of scope as the PR explicitly states.
+- Keep React and Solid JWT decoding aligned because both clients implement the
+  same signed-in token contract and the branch already carries both repairs.
 
 Review fixes:
-- Pending.
+- The changeset uses separate user-facing outcomes instead of a combined retry narrative.
+- The RSC HTTP layer accepts the already-normalized transformer and forwards it
+  unchanged; a regression asserts object identity at the request executor.
+- The shared enabled gate preserves explicit false and prevents prefetched data
+  from starting network work while authentication is still loading.

--- a/docs/plans/321-close-react-auth-pr.md
+++ b/docs/plans/321-close-react-auth-pr.md
@@ -75,7 +75,7 @@ Closure matrix:
 | docs/package skill | no | N/A: no docs/skill delta | N/A |
 | changeset | yes | `.changeset/react-rsc-auth-cache.md` audit | complete |
 | agent workflow | no | N/A: no agent action | N/A |
-| cleanup/review | yes | Deslop complete; committed-head autoreview pending | in_progress |
+| cleanup/review | yes | Deslop and committed-head autoreview clean at 0.86 confidence | complete |
 | repository check | yes | `bun check` | pending |
 | GitHub delivery | yes | PR 321 merge plus Version Packages/publish read-back | pending |
 
@@ -84,7 +84,7 @@ Work Checklist:
 - [x] Each pre-review lane is proven or N/A with a concrete reason.
 - [x] Generated output is N/A: no generated owner is touched.
 - [x] Package and changeset contracts are synchronized; docs/skill/fixture/scenario are N/A.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: no rule/generated mirror changed.
@@ -111,7 +111,7 @@ Completion Gates:
 | Final lint | yes | Run `bun lint:fix` | passed: 882 files; no fixes |
 | Repository check | yes | Run `bun check` | pending |
 | GitHub delivery | yes | Merge last and verify release/publish | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | passed: zero accepted/actionable findings at 0.86 confidence |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/321-close-react-auth-pr.md` | pending |
 | Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
 | Installed lock audit | no | N/A: no skill state change | N/A |
@@ -124,7 +124,7 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | complete | PR, source, tests, changeset, checks, and two threads read | repair |
 | Repair | complete | Transformer ownership and explicit enabled gating fixed with TDD | review |
-| Review/checks | in_progress | 102 focused tests, package build, typecheck, lint, and deslop pass | autoreview and check |
+| Review/checks | in_progress | 102 focused tests, build, typecheck, lint, deslop, and autoreview pass | repository check |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
@@ -139,12 +139,16 @@ Verification evidence:
 - Explicit `enabled: false` remains false, predicates remain predicates, and
   prefetched infinite data hydrates without network work while auth is loading.
 - `bun --cwd packages/kitcn build`, root typecheck, lint, and deslop pass.
+- Committed-head autoreview reports zero accepted/actionable findings at 0.86
+  confidence after the two local review repairs.
 
 Timeline:
 - 2026-08-14T18:17:55.196Z Autoclosure plan created.
 - 2026-08-15T03:41:00+02:00 Rebased onto the six merged predecessors, closed
   transformer recomposition and explicit enabled gating with red-to-green tests,
   and completed focused package proof.
+- 2026-08-15T03:45:00+02:00 Committed-head autoreview passed with zero
+  accepted/actionable findings at 0.86 confidence.
 
 Reboot status:
 | Question | Answer |

--- a/packages/kitcn/src/crpc/query-options.ts
+++ b/packages/kitcn/src/crpc/query-options.ts
@@ -143,8 +143,9 @@ export function convexInfiniteQueryOptions<
     limit,
   };
 
-  // Determine enabled state: explicit false or skip takes precedence
-  const finalEnabled = enabled === false || isSkip ? false : undefined;
+  // Determine enabled state: skip takes precedence, otherwise keep the
+  // caller's value (including a TanStack Query predicate).
+  const finalEnabled = isSkip ? false : enabled;
 
   return {
     queryKey: ['convexQuery', funcName, firstPageArgs] as const,
@@ -154,7 +155,7 @@ export function convexInfiniteQueryOptions<
     refetchOnReconnect: false as const,
     refetchOnWindowFocus: false as const,
     ...queryOptions,
-    ...(finalEnabled === false ? { enabled: false } : {}),
+    ...(finalEnabled === undefined ? {} : { enabled: finalEnabled }),
     meta: {
       authType,
       skipUnauth,

--- a/packages/kitcn/src/internal/enabled.test.ts
+++ b/packages/kitcn/src/internal/enabled.test.ts
@@ -1,0 +1,20 @@
+import { resolveEnabled } from './enabled';
+
+describe('internal/enabled', () => {
+  test('preserves an explicit false when the computed gate allows the query', () => {
+    expect(resolveEnabled(true, false)).toBe(false);
+  });
+
+  test('overrides a predicate when the computed gate blocks the query', () => {
+    expect(resolveEnabled(false, () => true)).toBe(false);
+  });
+
+  test('preserves a predicate when the computed gate allows the query', () => {
+    const predicate = mock(() => false);
+    const enabled = resolveEnabled(true, predicate);
+
+    expect(typeof enabled).toBe('function');
+    expect((enabled as typeof predicate)({})).toBe(false);
+    expect(predicate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kitcn/src/internal/enabled.ts
+++ b/packages/kitcn/src/internal/enabled.ts
@@ -24,5 +24,5 @@ export function resolveEnabled(
   if (typeof enabled === 'function') {
     return (query) => enabled(query) !== false;
   }
-  return true;
+  return enabled ?? true;
 }

--- a/packages/kitcn/src/internal/enabled.ts
+++ b/packages/kitcn/src/internal/enabled.ts
@@ -1,0 +1,28 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: TanStack query type compatibility */
+
+/**
+ * Shared handling for TanStack Query v5's `enabled` option, which may be a
+ * boolean or a predicate evaluated against the query.
+ * No React dependencies, so both the query and infinite query paths can use it.
+ */
+
+export type EnabledFn = (query: any) => boolean;
+export type EnabledOption = boolean | EnabledFn | undefined;
+
+/**
+ * Combine a computed gate with the caller's `enabled` option.
+ * A predicate is preserved (never collapsed to a boolean) so TanStack Query
+ * keeps evaluating it; `allowed: false` always wins.
+ */
+export function resolveEnabled(
+  allowed: boolean,
+  enabled: EnabledOption
+): boolean | EnabledFn {
+  if (!allowed) {
+    return false;
+  }
+  if (typeof enabled === 'function') {
+    return (query) => enabled(query) !== false;
+  }
+  return true;
+}

--- a/packages/kitcn/src/internal/hash.test.ts
+++ b/packages/kitcn/src/internal/hash.test.ts
@@ -11,4 +11,18 @@ describe('internal/hash', () => {
     expect(hashFn(key)).toBe('fallback:["not-convex",{"value":1}]');
     expect(fallback).toHaveBeenCalledWith(key);
   });
+
+  test('hashes Date args in Convex query and action keys', () => {
+    const hashFn = createHashFn();
+    const at = new Date(1_700_000_000_000);
+
+    const queryHash = hashFn(['convexQuery', 'todos:list', { at }]);
+    const actionHash = hashFn(['convexAction', 'ai:analyze', { at }]);
+
+    expect(queryHash).toBe(hashFn(['convexQuery', 'todos:list', { at }]));
+    expect(queryHash).not.toBe(
+      hashFn(['convexQuery', 'todos:list', { at: new Date(0) }])
+    );
+    expect(actionHash.startsWith('convexAction|ai:analyze|')).toBe(true);
+  });
 });

--- a/packages/kitcn/src/internal/query-key.ts
+++ b/packages/kitcn/src/internal/query-key.ts
@@ -6,6 +6,8 @@
 
 import { convexToJson, type Value } from 'convex/values';
 
+import { encodeWire } from '../crpc/transformer';
+
 /**
  * Check if query key is for a Convex query function.
  * Format: ['convexQuery', 'namespace:functionName', { args }]
@@ -27,6 +29,14 @@ export function isConvexAction(
 }
 
 /**
+ * Serialize args the same way they go over the wire, so non-native Convex
+ * types the transformer supports (e.g. `Date`) can be hashed.
+ */
+function hashArgs(args: Record<string, unknown>): string {
+  return JSON.stringify(convexToJson(encodeWire(args) as Value));
+}
+
+/**
  * Create stable hash for Convex query keys.
  * Uses Convex's JSON serialization for consistent argument hashing.
  */
@@ -34,7 +44,7 @@ export function hashConvexQuery(
   queryKey: ['convexQuery', string, Record<string, unknown>]
 ): string {
   const [, funcName, args] = queryKey;
-  return `convexQuery|${funcName}|${JSON.stringify(convexToJson(args as Value))}`;
+  return `convexQuery|${funcName}|${hashArgs(args)}`;
 }
 
 /**
@@ -45,5 +55,5 @@ export function hashConvexAction(
   queryKey: ['convexAction', string, Record<string, unknown>]
 ): string {
   const [, funcName, args] = queryKey;
-  return `convexAction|${funcName}|${JSON.stringify(convexToJson(args as Value))}`;
+  return `convexAction|${funcName}|${hashArgs(args)}`;
 }

--- a/packages/kitcn/src/react/auth-store.test.tsx
+++ b/packages/kitcn/src/react/auth-store.test.tsx
@@ -111,6 +111,20 @@ describe('decodeJwtExp', () => {
     expect(decodeJwtExp(token)).toBeNull();
   });
 
+  test('decodes base64url payloads carrying non-ASCII claims', () => {
+    // Better Auth embeds user.name/user.email in the Convex JWT payload, so
+    // multi-byte characters routinely push `-`/`_` into the payload segment.
+    const token = makeJwt({
+      email: 'zoe@example.com',
+      exp: 1_786_000_900,
+      name: 'Zoë 🌍 佐藤',
+      sessionId: 'sess_1',
+    });
+
+    expect(/[-_]/.test(token.split('.')[1] ?? '')).toBe(true);
+    expect(decodeJwtExp(token)).toBe(1_786_000_900_000);
+  });
+
   test('returns null for malformed tokens', () => {
     expect(decodeJwtExp('not-a-jwt')).toBeNull();
   });

--- a/packages/kitcn/src/react/auth-store.tsx
+++ b/packages/kitcn/src/react/auth-store.tsx
@@ -233,7 +233,18 @@ export const isSessionSyncGraceActive = (
 /** Decode JWT expiration (ms timestamp) from token */
 export function decodeJwtExp(token: string): number | null {
   try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
+    const segment = token.split('.')[1];
+    if (!segment) {
+      return null;
+    }
+
+    // JWT segments are base64url; atob only accepts the standard alphabet.
+    const binary = atob(segment.replaceAll('-', '+').replaceAll('_', '/'));
+    const payload = JSON.parse(
+      new TextDecoder().decode(
+        Uint8Array.from(binary, (char) => char.charCodeAt(0))
+      )
+    );
     return payload.exp ? payload.exp * 1000 : null;
   } catch {
     return null;

--- a/packages/kitcn/src/react/use-infinite-query.test.tsx
+++ b/packages/kitcn/src/react/use-infinite-query.test.tsx
@@ -41,7 +41,7 @@ describe('useInfiniteQuery', () => {
 
   function createOptions(opts: {
     args?: Record<string, unknown>;
-    enabled?: boolean;
+    enabled?: boolean | ((query: any) => boolean);
     limit?: number;
     skipUnauth?: boolean;
   }) {
@@ -145,6 +145,37 @@ describe('useInfiniteQuery', () => {
     expect(result.current.pages).toEqual([]);
     expect(result.current.isPlaceholderData).toBe(false);
     expect(onQueryUnauthorized).toHaveBeenCalledTimes(0);
+  });
+
+  test('forwards a function-form enabled predicate to the page queries', () => {
+    const predicate = mock(() => false);
+
+    const queryClient = new QueryClient();
+    const wrapper = makeWrapper(queryClient);
+
+    const options = createOptions({ enabled: predicate, limit: 2 });
+    renderHook(() => useInfiniteQuery(options), { wrapper });
+
+    expect(useQueriesCalls.length).toBeGreaterThan(0);
+    const pageEnabled = (useQueriesCalls[0].queries[0] as any).enabled;
+
+    // The predicate must survive all the way to useQueries, not be collapsed
+    // into a boolean by the enabled === false checks along the way.
+    expect(typeof pageEnabled).toBe('function');
+    expect(pageEnabled({} as any)).toBe(false);
+    expect(predicate).toHaveBeenCalled();
+  });
+
+  test('still disables page queries for a boolean enabled: false', () => {
+    const queryClient = new QueryClient();
+    const wrapper = makeWrapper(queryClient);
+
+    const options = createOptions({ enabled: false, limit: 2 });
+    renderHook(() => useInfiniteQuery(options), { wrapper });
+
+    expect(useQueriesCalls.length).toBeGreaterThan(0);
+    // A boolean false skips before any page query is built.
+    expect(useQueriesCalls[0].queries).toHaveLength(0);
   });
 
   test('prefetched first page bypasses auth-loading skip and passes initialData to useQueries', () => {

--- a/packages/kitcn/src/react/use-infinite-query.test.tsx
+++ b/packages/kitcn/src/react/use-infinite-query.test.tsx
@@ -178,7 +178,7 @@ describe('useInfiniteQuery', () => {
     expect(useQueriesCalls[0].queries).toHaveLength(0);
   });
 
-  test('prefetched first page bypasses auth-loading skip and passes initialData to useQueries', () => {
+  test('prefetched first page hydrates while auth loading without fetching', () => {
     useSafeConvexAuthSpy.mockImplementation(() => ({
       isLoading: true,
       isAuthenticated: false,
@@ -202,7 +202,7 @@ describe('useInfiniteQuery', () => {
     const firstCall = useQueriesCalls[0];
     expect(firstCall.queries).toHaveLength(1);
     expect((firstCall.queries[0] as any).initialData).toBe(prefetched);
-    expect((firstCall.queries[0] as any).enabled).toBe(true);
+    expect((firstCall.queries[0] as any).enabled).toBe(false);
   });
 
   test('does not split a native Convex page solely because it has a split cursor', () => {

--- a/packages/kitcn/src/react/use-infinite-query.ts
+++ b/packages/kitcn/src/react/use-infinite-query.ts
@@ -300,8 +300,8 @@ const useInfiniteQueryInternal = <Query extends PaginatedQueryReference>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, JSON.stringify(args), limit, queryClient]);
 
-  // Don't skip if we have prefetched data - use it for instant hydration
-  // Prefetched data bypasses both auth loading AND explicit disabled
+  // Build the first page when prefetched data exists so it can hydrate while
+  // auth is loading. The page-level enabled gate still blocks network work.
   const skip = !prefetchedFirstPage && (isAuthLoading || enabled === false);
 
   // Helper to get/set pagination state from queryClient with gcTime: Infinity

--- a/packages/kitcn/src/react/use-infinite-query.ts
+++ b/packages/kitcn/src/react/use-infinite-query.ts
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CRPCClientError, isCRPCClientError } from '../crpc/error';
 import { convexQuery } from '../crpc/query-options';
 import { type ExtractPaginatedItem, FUNC_REF_SYMBOL } from '../crpc/types';
+import { resolveEnabled } from '../internal/enabled';
 import { shouldSplitPaginationPage } from '../internal/pagination';
 import type { DistributiveOmit } from '../internal/types';
 import { useAuthValue, useSafeConvexAuth } from './auth-store';
@@ -461,7 +462,9 @@ const useInfiniteQueryInternal = <Query extends PaginatedQueryReference>(
 
         return {
           ...convexQuery(query, convexArgs as any, meta),
-          enabled: !skip && !!state.queries[key],
+          // Resolve the caller's `enabled` here so a predicate is evaluated
+          // per page instead of being collapsed into a boolean upstream.
+          enabled: resolveEnabled(!skip && !!state.queries[key], enabled),
           structuralSharing: false,
           // Apply TanStack Query options to all pages
           ...(queryOptions ?? {}),
@@ -486,6 +489,7 @@ const useInfiniteQueryInternal = <Query extends PaginatedQueryReference>(
       state.pageKeys,
       state.queries,
       skip,
+      enabled,
       meta,
       queryOptions,
       prefetchedFirstPage,
@@ -761,8 +765,9 @@ export function useInfiniteQuery<
   const result = useInfiniteQueryInternal(query as any, args as any, {
     limit,
     ...(queryOptions as any),
-    // Internal hook handles prefetch detection and will bypass skip if data exists
-    enabled: !shouldSkip,
+    // Internal hook handles prefetch detection and will bypass skip if data exists.
+    // Forward a predicate untouched so the internal hook can resolve it per page.
+    enabled: resolveEnabled(!shouldSkip, factoryEnabled),
   });
 
   // Include auth loading in loading state for optional and required types

--- a/packages/kitcn/src/react/use-query-options.test.tsx
+++ b/packages/kitcn/src/react/use-query-options.test.tsx
@@ -158,6 +158,118 @@ describe('use-query-options', () => {
     ]);
   });
 
+  test('useConvexQueryOptions forwards skipUnauth to query meta', () => {
+    const fn = makeFunctionReference<'query'>('user:getCurrentUser');
+
+    const { result } = renderHook(() =>
+      useConvexQueryOptions(fn, {} as any, { skipUnauth: true })
+    );
+
+    expect(result.current.meta.skipUnauth).toBe(true);
+  });
+
+  test('useConvexQueryOptions keeps a function-form enabled predicate', () => {
+    const fn = makeFunctionReference<'query'>('user:get');
+    const predicate = mock(() => false);
+
+    const { result } = renderHook(() =>
+      useConvexQueryOptions(fn, { id: 'u1' } as any, {
+        enabled: predicate as any,
+      })
+    );
+
+    const { enabled } = result.current;
+    expect(typeof enabled).toBe('function');
+    expect((enabled as (query: any) => boolean)({} as any)).toBe(false);
+    expect(predicate).toHaveBeenCalledTimes(1);
+  });
+
+  test('useConvexQueryOptions overrides a function-form enabled when auth skips', () => {
+    const fn = makeFunctionReference<'query'>('user:get');
+    useAuthSkipSpy.mockImplementation(
+      () => ({ authType: 'required', shouldSkip: true }) as any
+    );
+
+    const { result } = renderHook(() =>
+      useConvexQueryOptions(fn, { id: 'u1' } as any, {
+        enabled: (() => true) as any,
+      })
+    );
+
+    expect(result.current.enabled).toBe(false);
+  });
+
+  test('useConvexQueryOptions does not reuse args mutated in place for an older hash', () => {
+    const fn = makeFunctionReference<'query'>('pets:stable');
+    const args = { petId: 'p1' };
+
+    const first = renderHook(
+      ({ input }: { input: typeof args }) =>
+        useConvexQueryOptions(fn, input as any),
+      { initialProps: { input: args } }
+    );
+
+    args.petId = 'p2';
+    first.rerender({ input: args });
+    expect(first.result.current.queryKey[2]).toEqual({ petId: 'p2' });
+
+    const second = renderHook(() =>
+      useConvexQueryOptions(fn, { petId: 'p1' } as any)
+    );
+
+    expect(second.result.current.queryKey[2]).toEqual({ petId: 'p1' });
+  });
+
+  test('useConvexActionQueryOptions forwards authType and skipUnauth to query meta', () => {
+    const fn = makeFunctionReference<'action'>('ai:analyze');
+    useAuthSkipSpy.mockImplementation(
+      () => ({ authType: 'required', shouldSkip: false }) as any
+    );
+
+    const { result } = renderHook(() =>
+      useConvexActionQueryOptions(fn, { docId: 'd1' } as any, {
+        skipUnauth: true,
+      })
+    );
+
+    expect(result.current.meta).toMatchObject({
+      authType: 'required',
+      skipUnauth: true,
+      subscribe: false,
+    });
+  });
+
+  test('useConvexActionQueryOptions keeps a function-form enabled predicate', () => {
+    const fn = makeFunctionReference<'action'>('ai:analyze');
+    const predicate = mock(() => false);
+
+    const { result } = renderHook(() =>
+      useConvexActionQueryOptions(fn, { docId: 'd1' } as any, {
+        enabled: predicate as any,
+      })
+    );
+
+    const { enabled } = result.current;
+    expect(typeof enabled).toBe('function');
+    expect((enabled as (query: any) => boolean)({} as any)).toBe(false);
+  });
+
+  test('useConvexInfiniteQueryOptions keeps a function-form enabled predicate', () => {
+    const fn = makeFunctionReference<'query'>('posts:list');
+    const predicate = mock(() => false);
+
+    const { result } = renderHook(() =>
+      useConvexInfiniteQueryOptions(fn, {} as any, {
+        enabled: predicate as any,
+        limit: 20,
+      })
+    );
+
+    const { enabled } = result.current;
+    expect(typeof enabled).toBe('function');
+    expect((enabled as (query: any) => boolean)({} as any)).toBe(false);
+  });
+
   test('useConvexActionQueryOptions uses convexAction key prefix and respects shouldSkip', () => {
     const fn = makeFunctionReference<'action'>('ai:generate');
     useAuthSkipSpy.mockImplementation(

--- a/packages/kitcn/src/react/use-query-options.ts
+++ b/packages/kitcn/src/react/use-query-options.ts
@@ -39,6 +39,7 @@ import type {
   InfiniteQueryInput,
 } from '../crpc/types';
 import { useAuthSkip } from '../internal/auth';
+import { resolveEnabled } from '../internal/enabled';
 import { createHashFn } from '../internal/hash';
 import type { DistributiveOmit } from '../internal/types';
 import { useAuthGuard } from './auth-store';
@@ -73,7 +74,10 @@ function getStableArgsByHash<TArgs>(hash: string, args: TArgs): TArgs {
     return stableArgs as TArgs;
   }
 
-  stableArgsByHash.set(hash, args);
+  // Store a copy: callers may mutate their args object in place, which would
+  // otherwise silently rewrite the entry every other hash still points at.
+  const stored = structuredClone(args);
+  stableArgsByHash.set(hash, stored);
 
   if (stableArgsByHash.size > MAX_STABLE_ARGS) {
     const oldestHash = stableArgsByHash.keys().next().value;
@@ -83,7 +87,7 @@ function getStableArgsByHash<TArgs>(hash: string, args: TArgs): TArgs {
     }
   }
 
-  return args;
+  return stored;
 }
 
 function useStableQueryArgs<TArgs>(
@@ -165,15 +169,21 @@ export function useConvexQueryOptions<T extends FunctionReference<'query'>>(
 
   return useMemo(() => {
     // Extract ConvexQueryHookOptions from merged options
-    const { skipUnauth: _, subscribe, ...queryOptions } = options ?? {};
+    const {
+      enabled: userEnabled,
+      skipUnauth,
+      subscribe,
+      ...queryOptions
+    } = options ?? {};
 
     return {
       ...baseOptions,
       ...queryOptions, // Spread user options
-      enabled: isSkipped ? false : !shouldSkip,
+      enabled: resolveEnabled(!(isSkipped || shouldSkip), userEnabled),
       meta: {
         ...baseOptions.meta,
         authType,
+        skipUnauth,
         subscribe: subscribe !== false,
       },
     };
@@ -224,8 +234,8 @@ export function useConvexInfiniteQueryOptions<
     skipUnauth: opts.skipUnauth,
   });
 
-  // Determine final enabled state
-  const enabled = isSkipped || shouldSkip ? false : enabledOpt;
+  // Determine final enabled state (keeps a caller-supplied predicate)
+  const enabled = resolveEnabled(!(isSkipped || shouldSkip), opts.enabled);
 
   const baseOptions = convexInfiniteQueryOptions(
     funcRef,
@@ -271,13 +281,13 @@ export function useConvexActionQueryOptions<
     UseQueryOptions<FunctionReturnType<Action>, DefaultError>,
     ReservedQueryOptions
   >
-): ConvexActionOptions<Action> {
+): ConvexActionOptions<Action> & { meta: ConvexQueryMeta } {
   const isSkipped = args === skipToken;
 
   // Convert enabled to boolean (TanStack Query allows function)
   const enabled =
     typeof options?.enabled === 'function' ? undefined : options?.enabled;
-  const { shouldSkip } = useAuthSkip(action, {
+  const { authType, shouldSkip } = useAuthSkip(action, {
     enabled: isSkipped ? false : enabled,
     skipUnauth: options?.skipUnauth,
   });
@@ -295,14 +305,19 @@ export function useConvexActionQueryOptions<
 
   return useMemo(() => {
     // Extract skipUnauth from options before spreading
-    const { skipUnauth: _, ...queryOptions } = options ?? {};
+    const { enabled: userEnabled, skipUnauth, ...queryOptions } = options ?? {};
 
     return {
       ...baseOptions,
       ...queryOptions,
-      enabled: isSkipped ? false : !shouldSkip,
+      enabled: resolveEnabled(!(isSkipped || shouldSkip), userEnabled),
+      meta: {
+        ...baseOptions.meta,
+        authType,
+        skipUnauth,
+      },
     };
-  }, [baseOptions, isSkipped, options, shouldSkip]);
+  }, [authType, baseOptions, isSkipped, options, shouldSkip]);
 }
 
 type AuthType = 'required' | 'optional' | undefined;

--- a/packages/kitcn/src/rsc/http-server.test.ts
+++ b/packages/kitcn/src/rsc/http-server.test.ts
@@ -1,6 +1,12 @@
+import { HttpClientError } from '../crpc/http-types';
 import { buildHttpQueryOptions, fetchHttpRoute } from './http-server';
 
-const HTTP_403_NOPE_RE = /HTTP 403: nope/;
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    ...init,
+    headers: { 'content-type': 'application/json', ...init?.headers },
+  });
 
 describe('rsc/http-server', () => {
   let fetchSpy: ReturnType<typeof spyOn> | undefined;
@@ -21,31 +27,21 @@ describe('rsc/http-server', () => {
     expect(opts.meta).toEqual({ path: '/api/health', method: 'GET' });
   });
 
-  test('fetchHttpRoute builds URL with path params and query params, and sends auth header', async () => {
-    const mockFetch = Object.assign(
-      async (input: RequestInfo | URL, init?: RequestInit) => {
-        expect(String(input)).toBe(
-          'https://example.convex.site/api/todos/a%20b?foo=bar&n=1'
-        );
+  test('fetchHttpRoute builds URL from params/searchParams and sends auth header', async () => {
+    const seen: { url: string; init?: RequestInit }[] = [];
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: RequestInfo | URL,
+      init?: RequestInit
+    ) => {
+      seen.push({ url: String(input), init });
+      return jsonResponse({ ok: true });
+    }) as any);
 
-        expect(init?.method).toBe('GET');
-        expect(init?.headers).toMatchObject({
-          'Content-Type': 'application/json',
-          Authorization: 'Bearer t0',
-        });
+    const args = {
+      params: { id: 'a b' },
+      searchParams: { foo: 'bar', tag: ['x', 'y'] },
+    };
 
-        return new Response(JSON.stringify({ ok: true }), {
-          status: 200,
-          headers: { 'content-length': '12' },
-        });
-      },
-      // Bun's fetch has extra static helpers like fetch.preconnect().
-      { preconnect: () => {} }
-    ) as typeof fetch;
-
-    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(mockFetch);
-
-    const args = { id: 'a b', foo: 'bar', n: 1, ignore: null };
     await expect(
       fetchHttpRoute(
         'https://example.convex.site',
@@ -55,8 +51,35 @@ describe('rsc/http-server', () => {
       )
     ).resolves.toEqual({ ok: true });
 
+    expect(seen[0]?.url).toBe(
+      'https://example.convex.site/api/todos/a%20b?foo=bar&tag=x&tag=y'
+    );
+    expect(seen[0]?.init?.method).toBe('GET');
+    expect(seen[0]?.init?.headers).toMatchObject({
+      Authorization: 'Bearer t0',
+    });
+
     // Ensure args are not mutated.
-    expect(args).toEqual({ id: 'a b', foo: 'bar', n: 1, ignore: null });
+    expect(args).toEqual({
+      params: { id: 'a b' },
+      searchParams: { foo: 'bar', tag: ['x', 'y'] },
+    });
+  });
+
+  test('fetchHttpRoute decodes wire-tagged payloads', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ dueDate: { __crpc: 1, t: '$date', v: 1_700_000_000_000 } })
+    );
+
+    const result = (await fetchHttpRoute(
+      'https://example.convex.site',
+      { path: '/api/todos', method: 'GET' },
+      {},
+      undefined
+    )) as { dueDate: Date };
+
+    expect(result.dueDate).toBeInstanceOf(Date);
+    expect(result.dueDate.getTime()).toBe(1_700_000_000_000);
   });
 
   test('fetchHttpRoute returns null for empty responses', async () => {
@@ -88,9 +111,12 @@ describe('rsc/http-server', () => {
     ).resolves.toBeNull();
   });
 
-  test('fetchHttpRoute throws for non-ok responses and includes status and body', async () => {
+  test('fetchHttpRoute throws HttpClientError for non-ok responses', async () => {
     fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('nope', { status: 403 })
+      jsonResponse(
+        { error: { code: 'FORBIDDEN', message: 'nope' } },
+        { status: 403 }
+      )
     );
 
     await expect(
@@ -100,6 +126,9 @@ describe('rsc/http-server', () => {
         {},
         undefined
       )
-    ).rejects.toThrow(HTTP_403_NOPE_RE);
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      status: 403,
+    } satisfies Partial<HttpClientError>);
   });
 });

--- a/packages/kitcn/src/rsc/http-server.test.ts
+++ b/packages/kitcn/src/rsc/http-server.test.ts
@@ -1,4 +1,6 @@
+import * as httpClient from '../crpc/http-client';
 import { HttpClientError } from '../crpc/http-types';
+import { getTransformer } from '../crpc/transformer';
 import { buildHttpQueryOptions, fetchHttpRoute } from './http-server';
 
 const jsonResponse = (body: unknown, init?: ResponseInit) =>
@@ -8,12 +10,17 @@ const jsonResponse = (body: unknown, init?: ResponseInit) =>
     headers: { 'content-type': 'application/json', ...init?.headers },
   });
 
+const defaultTransformer = getTransformer();
+
 describe('rsc/http-server', () => {
   let fetchSpy: ReturnType<typeof spyOn> | undefined;
+  let executeHttpRequestSpy: ReturnType<typeof spyOn> | undefined;
 
   afterEach(() => {
     fetchSpy?.mockRestore();
     fetchSpy = undefined;
+    executeHttpRequestSpy?.mockRestore();
+    executeHttpRequestSpy = undefined;
   });
 
   test('buildHttpQueryOptions matches client key format and stores route meta', () => {
@@ -47,7 +54,8 @@ describe('rsc/http-server', () => {
         'https://example.convex.site',
         { path: '/api/todos/:id', method: 'GET' },
         args,
-        't0'
+        't0',
+        defaultTransformer
       )
     ).resolves.toEqual({ ok: true });
 
@@ -66,6 +74,29 @@ describe('rsc/http-server', () => {
     });
   });
 
+  test('fetchHttpRoute preserves a normalized transformer', async () => {
+    const transformer = getTransformer({
+      serialize: (value) => value,
+      deserialize: (value) => value,
+    });
+    executeHttpRequestSpy = spyOn(
+      httpClient,
+      'executeHttpRequest'
+    ).mockResolvedValue({ ok: true });
+
+    await fetchHttpRoute(
+      'https://example.convex.site',
+      { path: '/api/todos', method: 'POST' },
+      { title: 'Ship it' },
+      undefined,
+      transformer
+    );
+
+    expect(executeHttpRequestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ transformer })
+    );
+  });
+
   test('fetchHttpRoute decodes wire-tagged payloads', async () => {
     fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
       jsonResponse({ dueDate: { __crpc: 1, t: '$date', v: 1_700_000_000_000 } })
@@ -75,7 +106,8 @@ describe('rsc/http-server', () => {
       'https://example.convex.site',
       { path: '/api/todos', method: 'GET' },
       {},
-      undefined
+      undefined,
+      defaultTransformer
     )) as { dueDate: Date };
 
     expect(result.dueDate).toBeInstanceOf(Date);
@@ -92,7 +124,8 @@ describe('rsc/http-server', () => {
         'https://example.convex.site',
         { path: '/api/health', method: 'GET' },
         {},
-        undefined
+        undefined,
+        defaultTransformer
       )
     ).resolves.toBeNull();
 
@@ -106,7 +139,8 @@ describe('rsc/http-server', () => {
         'https://example.convex.site',
         { path: '/api/health', method: 'GET' },
         {},
-        undefined
+        undefined,
+        defaultTransformer
       )
     ).resolves.toBeNull();
   });
@@ -124,7 +158,8 @@ describe('rsc/http-server', () => {
         'https://example.convex.site',
         { path: '/api/secret', method: 'GET' },
         {},
-        undefined
+        undefined,
+        defaultTransformer
       )
     ).rejects.toMatchObject({
       code: 'FORBIDDEN',

--- a/packages/kitcn/src/rsc/http-server.ts
+++ b/packages/kitcn/src/rsc/http-server.ts
@@ -8,11 +8,7 @@
 import type { QueryOptions } from '@tanstack/react-query';
 import { executeHttpRequest, type HttpInputArgs } from '../crpc/http-client';
 import type { HttpRouteInfo } from '../crpc/http-types';
-import type {
-  CombinedDataTransformer,
-  DataTransformerOptions,
-} from '../crpc/transformer';
-import { getTransformer } from '../crpc/transformer';
+import type { CombinedDataTransformer } from '../crpc/transformer';
 
 /** Metadata attached to HTTP query options for execution by QueryClient */
 export interface HttpQueryMeta {
@@ -51,8 +47,8 @@ export async function fetchHttpRoute(
   convexSiteUrl: string,
   routeMeta: HttpQueryMeta,
   args: unknown,
-  token?: string,
-  transformer?: DataTransformerOptions | CombinedDataTransformer
+  token: string | undefined,
+  transformer: CombinedDataTransformer
 ): Promise<unknown> {
   const result = await executeHttpRequest({
     args: args as HttpInputArgs | undefined,
@@ -60,7 +56,7 @@ export async function fetchHttpRoute(
     convexSiteUrl,
     procedureName: `${routeMeta.method} ${routeMeta.path}`,
     route: routeMeta,
-    transformer: getTransformer(transformer),
+    transformer,
   });
 
   // TanStack Query rejects `undefined` as query data.

--- a/packages/kitcn/src/rsc/http-server.ts
+++ b/packages/kitcn/src/rsc/http-server.ts
@@ -6,12 +6,13 @@
  */
 
 import type { QueryOptions } from '@tanstack/react-query';
+import { executeHttpRequest, type HttpInputArgs } from '../crpc/http-client';
 import type { HttpRouteInfo } from '../crpc/http-types';
 import type {
   CombinedDataTransformer,
   DataTransformerOptions,
 } from '../crpc/transformer';
-import { decodeWire } from '../crpc/transformer';
+import { getTransformer } from '../crpc/transformer';
 
 /** Metadata attached to HTTP query options for execution by QueryClient */
 export interface HttpQueryMeta {
@@ -42,6 +43,9 @@ export function buildHttpQueryOptions(
 /**
  * Execute an HTTP route fetch.
  * Called by getServerQueryClientOptions queryFn.
+ *
+ * Shares the browser client's request builder so a prefetched entry hydrates
+ * the client cache instead of being refetched from a different URL.
  */
 export async function fetchHttpRoute(
   convexSiteUrl: string,
@@ -50,64 +54,15 @@ export async function fetchHttpRoute(
   token?: string,
   transformer?: DataTransformerOptions | CombinedDataTransformer
 ): Promise<unknown> {
-  const url = buildUrl(
+  const result = await executeHttpRequest({
+    args: args as HttpInputArgs | undefined,
+    baseHeaders: token ? { Authorization: `Bearer ${token}` } : undefined,
     convexSiteUrl,
-    routeMeta.path,
-    args as Record<string, unknown>
-  );
-
-  const response = await fetch(url, {
-    method: routeMeta.method,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
+    procedureName: `${routeMeta.method} ${routeMeta.path}`,
+    route: routeMeta,
+    transformer: getTransformer(transformer),
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
-  }
-
-  // Handle empty responses
-  const contentLength = response.headers.get('content-length');
-  if (contentLength === '0' || response.status === 204) {
-    return null;
-  }
-
-  return decodeWire(await response.json(), transformer);
-}
-
-/**
- * Build URL with path params and query params.
- */
-function buildUrl(
-  convexSiteUrl: string,
-  pathTemplate: string,
-  args: Record<string, unknown>
-): string {
-  // Clone args to avoid mutation
-  const remaining = { ...args };
-
-  // Replace path params: /todos/:id -> /todos/123
-  const path = pathTemplate.replace(/:(\w+)/g, (_, key) => {
-    const value = remaining[key];
-    delete remaining[key];
-    return value !== null && value !== undefined
-      ? encodeURIComponent(String(value))
-      : '';
-  });
-
-  // Remaining args -> query params for GET
-  const queryEntries = Object.entries(remaining).filter(
-    ([_, v]) => v !== undefined && v !== null
-  );
-  if (queryEntries.length > 0) {
-    const params = new URLSearchParams();
-    for (const [key, value] of queryEntries) {
-      params.set(key, String(value));
-    }
-    return `${convexSiteUrl}${path}?${params.toString()}`;
-  }
-
-  return convexSiteUrl + path;
+  // TanStack Query rejects `undefined` as query data.
+  return result ?? null;
 }

--- a/packages/kitcn/src/server/caller-factory.test.ts
+++ b/packages/kitcn/src/server/caller-factory.test.ts
@@ -1,5 +1,6 @@
 import * as convexNextjs from 'convex/nextjs';
 import { makeFunctionReference } from 'convex/server';
+import { defaultIsUnauthorized } from '../crpc/error';
 import { encodeWire } from '../crpc/transformer';
 
 import { createCallerFactory } from './caller-factory';
@@ -160,13 +161,186 @@ describe('server/caller-factory', () => {
     expect(getToken.mock.calls.length).toBe(1);
   });
 
-  test('refreshes token and retries once on non-unauthorized errors when token is not fresh', async () => {
+  test('throws unauthorized mutations without a configured isUnauthorized', async () => {
+    // Scaffold shape: `auth: { getToken }` with no predicate. A genuine
+    // authorization failure must surface, never resolve to null.
+    const fetchMutationSpy = spyOn(
+      convexNextjs,
+      'fetchMutation'
+    ).mockImplementation(async () => {
+      throw Object.assign(new Error('unauthorized'), {
+        data: { code: 'UNAUTHORIZED' },
+      });
+    });
+
+    const ref = makeFunctionReference<'mutation'>('todos:create');
+    const apiWithMeta = {
+      todos: {
+        create: Object.assign(ref, { functionRef: ref, type: 'mutation' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'x' })
+    ).rejects.toThrow('unauthorized');
+
+    // Retried once against a fresh token, then surfaced rather than swallowed.
+    expect(fetchMutationSpy.mock.calls.length).toBe(2);
+  });
+
+  test('swallows unauthorized to null only when isUnauthorized is configured', async () => {
+    const fetchMutationSpy = spyOn(
+      convexNextjs,
+      'fetchMutation'
+    ).mockImplementation(async () => {
+      throw Object.assign(new Error('unauthorized'), {
+        data: { code: 'UNAUTHORIZED' },
+      });
+    });
+
+    const ref = makeFunctionReference<'mutation'>('todos:create');
+    const apiWithMeta = {
+      todos: {
+        create: Object.assign(ref, { functionRef: ref, type: 'mutation' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: { getToken, isUnauthorized: defaultIsUnauthorized },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'x' })
+    ).resolves.toBeNull();
+    expect(fetchMutationSpy.mock.calls.length).toBe(2);
+  });
+
+  // Pins the `defaultIsUnauthorized` retry default. Note this assertion also
+  // held under the old blanket-retry code; the negative tests above and below
+  // are what prove the retry is now gated on the error being an auth failure.
+  test('recovers a stale cached token without a configured isUnauthorized', async () => {
     const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
       async (_fn: any, _args: any, opts: any) => {
         if (opts?.token === 't0') {
-          throw new Error('boom');
+          // Shape Convex throws for an expired token.
+          throw Object.assign(new Error('unauthorized'), {
+            data: { code: 'UNAUTHORIZED' },
+          });
         }
         return 'ok';
+      }
+    );
+
+    const api = {
+      posts: { list: makeFunctionReference<'query'>('posts:list') },
+    };
+    const apiWithMeta = withQueryLeafMeta(api);
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta,
+      auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(ctx.caller.posts.list({})).resolves.toBe('ok');
+
+    expect(fetchQuerySpy.mock.calls.length).toBe(2);
+    expect(getToken.mock.calls.length).toBe(2);
+    expect(getToken.mock.calls[1]?.[2]?.forceRefresh).toBe(true);
+  });
+
+  test('does not retry non-auth errors without a configured isUnauthorized', async () => {
+    const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
+      async () => {
+        throw new Error('boom');
+      }
+    );
+
+    const api = {
+      posts: { list: makeFunctionReference<'query'>('posts:list') },
+    };
+    const apiWithMeta = withQueryLeafMeta(api);
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta,
+      auth: { getToken },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(ctx.caller.posts.list({})).rejects.toThrow('boom');
+
+    expect(fetchQuerySpy.mock.calls.length).toBe(1);
+    expect(getToken.mock.calls.length).toBe(1);
+  });
+
+  test('surfaces unauthorized errors when no auth is configured', async () => {
+    const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
+      async () => {
+        throw Object.assign(new Error('unauthorized'), {
+          data: { code: 'UNAUTHORIZED' },
+        });
+      }
+    );
+
+    const api = {
+      posts: { list: makeFunctionReference<'query'>('posts:list') },
+    };
+    const apiWithMeta = withQueryLeafMeta(api);
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta,
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(ctx.caller.posts.list({})).rejects.toThrow('unauthorized');
+    expect(fetchQuerySpy.mock.calls.length).toBe(1);
+  });
+
+  test('does not retry non-unauthorized errors even when token is not fresh', async () => {
+    const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
+      async () => {
+        throw new Error('boom');
       }
     );
 
@@ -189,10 +363,130 @@ describe('server/caller-factory', () => {
     });
 
     const ctx = await createContext({ headers: new Headers() });
-    await expect(ctx.caller.posts.list({ tag: 'x' })).resolves.toBe('ok');
+    await expect(ctx.caller.posts.list({ tag: 'x' })).rejects.toThrow('boom');
 
-    expect(fetchQuerySpy.mock.calls.length).toBe(2);
-    expect(getToken.mock.calls.length).toBe(2);
+    expect(fetchQuerySpy.mock.calls.length).toBe(1);
+    expect(getToken.mock.calls.length).toBe(1);
+  });
+
+  test('does not replay mutations on non-unauthorized errors', async () => {
+    const fetchMutationSpy = spyOn(
+      convexNextjs,
+      'fetchMutation'
+    ).mockImplementation(async () => {
+      throw new Error('title already exists');
+    });
+
+    const ref = makeFunctionReference<'mutation'>('todos:create');
+    const apiWithMeta = {
+      todos: {
+        create: Object.assign(ref, { functionRef: ref, type: 'mutation' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: { getToken, isUnauthorized: () => false },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'x' })
+    ).rejects.toThrow('title already exists');
+
+    expect(fetchMutationSpy.mock.calls.length).toBe(1);
+  });
+
+  test('does not replay actions on non-unauthorized errors', async () => {
+    const fetchActionSpy = spyOn(
+      convexNextjs,
+      'fetchAction'
+    ).mockImplementation(async () => {
+      throw new Error('receipt write failed');
+    });
+
+    const ref = makeFunctionReference<'action'>('billing:charge');
+    const apiWithMeta = {
+      billing: {
+        charge: Object.assign(ref, { functionRef: ref, type: 'action' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: { getToken, isUnauthorized: () => false },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).billing.charge({ orderId: 'o1' })
+    ).rejects.toThrow('receipt write failed');
+
+    expect(fetchActionSpy.mock.calls.length).toBe(1);
+  });
+
+  test('refreshes token and replays mutations on unauthorized errors when token is not fresh', async () => {
+    const fetchMutationSpy = spyOn(
+      convexNextjs,
+      'fetchMutation'
+    ).mockImplementation(async (_fn: any, _args: any, opts: any) => {
+      if (opts?.token === 't0') {
+        throw Object.assign(new Error('unauthorized'), {
+          code: 'UNAUTHORIZED',
+        });
+      }
+      return 'ok';
+    });
+
+    const ref = makeFunctionReference<'mutation'>('todos:create');
+    const apiWithMeta = {
+      todos: {
+        create: Object.assign(ref, { functionRef: ref, type: 'mutation' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: {
+        getToken,
+        isUnauthorized: (e) =>
+          !!e &&
+          typeof e === 'object' &&
+          'code' in e &&
+          (e as any).code === 'UNAUTHORIZED',
+      },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'x' })
+    ).resolves.toBe('ok');
+
+    expect(fetchMutationSpy.mock.calls.length).toBe(2);
     expect(getToken.mock.calls[1]?.[2]?.forceRefresh).toBe(true);
   });
 

--- a/packages/kitcn/src/server/caller-factory.ts
+++ b/packages/kitcn/src/server/caller-factory.ts
@@ -11,6 +11,7 @@ import type {
   FunctionReference,
   FunctionReturnType,
 } from 'convex/server';
+import { defaultIsUnauthorized } from '../crpc/error';
 import type { DataTransformerOptions } from '../crpc/transformer';
 import type { EmptyObject } from '../internal/upstream';
 import { buildMetaIndex } from '../shared/meta-utils';
@@ -40,7 +41,13 @@ type GetTokenFn = (
 type AuthOptions = {
   /** Function to extract auth token from request headers. */
   getToken: GetTokenFn;
-  /** Custom function to detect UNAUTHORIZED errors. Default checks code property. */
+  /**
+   * Custom function to detect UNAUTHORIZED errors.
+   * Set this to resolve those errors to `null` instead of throwing.
+   *
+   * Refreshing an expired cached token and retrying does not require this:
+   * that always falls back to `defaultIsUnauthorized`.
+   */
   isUnauthorized?: (error: unknown) => boolean;
 };
 
@@ -124,7 +131,14 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
   const siteUrl = parseConvexSiteUrl(opts.convexSiteUrl);
   const convexUrl = getConvexUrl(siteUrl, opts.convexUrl);
   const getToken = opts.auth?.getToken ?? noAuthGetToken;
-  const isUnauthorized = opts.auth?.isUnauthorized;
+  // Two distinct jobs, deliberately not sharing a predicate:
+  // - retry: defaults on, so an expired cached token still refreshes itself.
+  // - swallow-to-null: opt-in only, so authorization failures keep throwing
+  //   unless the app asked for them to be turned into null.
+  const isRetryableAuthError = opts.auth
+    ? (opts.auth.isUnauthorized ?? defaultIsUnauthorized)
+    : undefined;
+  const shouldReturnNullOnUnauthorized = opts.auth?.isUnauthorized;
   const crpcMeta = buildMetaIndex(opts.api);
 
   // Internal: call with token and retry logic
@@ -136,14 +150,15 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
     tokenResult: TokenResult,
     headers: Headers
   ): Promise<FunctionReturnType<Fn> | null> => {
-    const shouldRetryWithFreshToken = !!opts.auth && !tokenResult.isFresh;
+    const canRefreshToken = !!opts.auth && !tokenResult.isFresh;
 
     try {
       return await fn(tokenResult.token);
     } catch (error) {
-      // Only refresh when the initial token came from cache and may be stale.
-      if (!shouldRetryWithFreshToken) {
-        if (isUnauthorized?.(error)) {
+      // Only replay the call when the cached token may be the cause. Any other
+      // failure is surfaced as-is: mutations and actions are not idempotent.
+      if (!(canRefreshToken && isRetryableAuthError?.(error))) {
+        if (shouldReturnNullOnUnauthorized?.(error)) {
           return null;
         }
         throw error;
@@ -157,7 +172,7 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
       try {
         return await fn(newToken.token);
       } catch (retryError) {
-        if (isUnauthorized?.(retryError)) {
+        if (shouldReturnNullOnUnauthorized?.(retryError)) {
           return null;
         }
         throw retryError;

--- a/packages/kitcn/src/solid/auth-store.tsx
+++ b/packages/kitcn/src/solid/auth-store.tsx
@@ -72,7 +72,18 @@ export type AuthStoreState = {
 /** Decode JWT expiration (ms timestamp) from token */
 export function decodeJwtExp(token: string): number | null {
   try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
+    const segment = token.split('.')[1];
+    if (!segment) {
+      return null;
+    }
+
+    // JWT segments are base64url; atob only accepts the standard alphabet.
+    const binary = atob(segment.replaceAll('-', '+').replaceAll('_', '/'));
+    const payload = JSON.parse(
+      new TextDecoder().decode(
+        Uint8Array.from(binary, (char) => char.charCodeAt(0))
+      )
+    );
     return payload.exp ? payload.exp * 1000 : null;
   } catch {
     return null;

--- a/packages/kitcn/src/solid/auth-store.vitest.tsx
+++ b/packages/kitcn/src/solid/auth-store.vitest.tsx
@@ -18,8 +18,10 @@ import {
 } from './auth-store';
 
 const makeJwt = (payload: Record<string, unknown>) => {
-  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
-  const body = btoa(JSON.stringify(payload));
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'none', typ: 'JWT' })
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
   return `${header}.${body}.sig`;
 };
 
@@ -32,6 +34,21 @@ describe('decodeJwtExp', () => {
   test('returns null when exp claim is missing', () => {
     const token = makeJwt({ sub: 'user-1' });
     expect(decodeJwtExp(token)).toBeNull();
+  });
+
+  test('decodes base64url payloads carrying non-ASCII claims', () => {
+    // Better Auth embeds user.name/user.email in the Convex JWT payload, so
+    // multi-byte characters routinely push `-`/`_` into the payload segment.
+    const token = makeJwt({
+      email: 'zoe@example.com',
+      exp: 1_786_000_900,
+      name: 'Zoë 🌍 佐藤',
+      sessionId: 'sess_1',
+    });
+
+    const payload = token.split('.')[1] ?? '';
+    expect(payload.includes('-') || payload.includes('_')).toBe(true);
+    expect(decodeJwtExp(token)).toBe(1_786_000_900_000);
   });
 
   test('returns null for malformed tokens', () => {


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

Closes the remaining React, Solid, RSC, auth-cache, query-option, and server-caller correctness defects in this batch.

- Decode JWT base64url payloads as UTF-8 in React and Solid so non-ASCII user claims do not clear authentication.
- Attach auth metadata to action queries and preserve `skipUnauth` through rebuilt query options.
- Hash `Date` args safely, snapshot mutable args by value, and preserve boolean or predicate `enabled` gates across query, action, and infinite-query paths.
- Hydrate RSC HTTP queries through the browser request owner, including `params` and `searchParams`, while normalizing custom transformers exactly once.
- Retry server calls only after authorization failures from stale cached tokens; never replay mutations or actions after unrelated failures.

Proof:

- 102 focused tests across ten React, Solid, RSC, internal, and server files.
- `bun --cwd packages/kitcn build`, root typecheck, lint, and deslop pass.
- Final autoreview: zero accepted/actionable findings at 0.86 confidence.
- Exact `bun check` passed on `23d05d9f1b76`, including fixtures and live runtime scenarios.
- All six preceding PRs are merged; this PR intentionally retains auto-release as the sole batch release trigger.
