### PR TITLE
fix(cli): stop overwriting user files and corrupting schema edits

### DIFF
--- a/.agents/skills/kitcn/references/features/create-plugins.md
+++ b/.agents/skills/kitcn/references/features/create-plugins.md
@@ -107,7 +107,7 @@ Trigger composition rules:
 3. Non-function helpers live under `convex/<paths.lib>/plugins/<plugin>/...`.
 4. `kitcn codegen` must not generate plugin runtime modules.
 5. Scaffold templates need stable template IDs.
-6. `add` can merge/upsert scaffold mappings; never clobber custom files unless overwrite is explicit.
+6. `add` can merge/upsert scaffold mappings; never clobber custom files unless overwrite is explicit. Plan files of kind `scaffold`, `config`, and `env` need explicit consent to replace an existing file, so a builder that renders a whole template is safe by default. Only a builder that reads the existing source and patches it may set `requiresExplicitOverwrite: false`. List every shape another kitcn plugin can leave behind in `managedBaselineContent` so a file kitcn itself wrote is still recognized as managed. A refused file makes `add` exit non-zero and report `refused` in `--json`.
 7. `add --dry-run`, `add --diff [path]`, and `add --view [path]` preview one shared install plan: scaffold files, env bootstrap, `kitcn.json`, schema registration, lockfile write, dependency install status, codegen/hooks, env reminders.
 8. Preview comparisons for `.ts`, `.tsx`, `.js`, `.jsx`, and `.json` should be semantic enough to ignore formatter-only churn.
 9. `view` is read-only plan inspection. Default template source is lockfile mappings, fallback is the resolved preset, `--preset` forces preset selection.

--- a/.changeset/cli-safe-file-edits.md
+++ b/.changeset/cli-safe-file-edits.md
@@ -1,0 +1,45 @@
+---
+"kitcn": minor
+---
+
+## Breaking changes
+
+- `kitcn add` no longer replaces scaffold files you have edited. Files that still
+  match the scaffold are upgraded as before; edited files are kept, listed under
+  `Refused files`, and the command exits `1` because the plugin is only partially
+  installed. Pass `--overwrite` for the previous behavior.
+
+```bash
+# Before — edits to crpc.ts were replaced, exit 0
+kitcn add auth --yes
+
+# After — edits are kept and the run fails until you choose
+kitcn add auth --yes --overwrite
+```
+
+- `kitcn add --json` splits the old `skipped` list in two. `skipped` now means
+  "already up to date", refused files move to `refused`, and `complete` reports
+  whether everything was applied.
+
+```jsonc
+// Before
+{ "skipped": ["convex/lib/crpc.ts"] }
+
+// After
+{ "skipped": [], "refused": ["convex/lib/crpc.ts"], "complete": false }
+```
+
+## Patches
+
+- Fix `kitcn codegen` leaving a hidden parse snapshot behind when a Convex module
+  fails to load, which kept reporting the old error after the real file was
+  fixed. Stale snapshots from earlier runs are now cleaned up automatically.
+- Fix plugin registration landing inside a comment or string that happens to
+  mention `defineSchema(`, which recorded the plugin as installed while its
+  tables and relations never reached the schema.
+- Fix `kitcn add auth` deleting a table's index callback when it was written as a
+  block-bodied arrow or a named function. The callback is now preserved while
+  managed fields are merged.
+- Fix schema patching merging value imports into a type-only `kitcn/orm` import,
+  which produced duplicate identifiers, and skipping the import entirely when
+  only `import * as orm from 'kitcn/orm'` was present.

--- a/.changeset/cli-safe-file-edits.md
+++ b/.changeset/cli-safe-file-edits.md
@@ -33,7 +33,11 @@ kitcn add auth --yes --overwrite
 
 - Fix `kitcn codegen` leaving a hidden parse snapshot behind when a Convex module
   fails to load, which kept reporting the old error after the real file was
-  fixed. Stale snapshots from earlier runs are now cleaned up automatically.
+  fixed. Codegen evaluates modules in memory instead of mirroring them to a
+  sibling file, so it no longer writes to — or deletes from — your Convex
+  directory, and import-time stack traces now point at the real module rather
+  than a temporary path. A file of your own ending in `.kitcn-parse.ts` is left
+  untouched.
 - Fix plugin registration landing inside a comment or string that happens to
   mention `defineSchema(`, which recorded the plugin as installed while its
   tables and relations never reached the schema.

--- a/docs/plans/317-close-orm-planner-pr.md
+++ b/docs/plans/317-close-orm-planner-pr.md
@@ -76,7 +76,7 @@ Closure matrix:
 | agent workflow | no | N/A: no agent workflow/action | N/A |
 | cleanup/review | yes | Deslop and autoreview | passed: zero net slop findings; branch review 0.98 and final uncommitted review 0.95 |
 | repository check | yes | `bun check` | passed end to end after rebase and repairs |
-| GitHub delivery | yes | Rebase/push/merge/read-back | pending |
+| GitHub delivery | yes | Rebase/push/merge/read-back | passed: squash-merged as `b765f016` |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
@@ -84,8 +84,8 @@ Work Checklist:
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
 - [x] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: no rule/generated mirror changed.
 - [x] Agent-native pack: no agent action changed; discoverability N/A.
 - [x] Agent-native pack: mirror sync N/A.
@@ -109,9 +109,9 @@ Completion Gates:
 | Agent-native reviewer | no | N/A: no agent-facing change | Applicability audit recorded |
 | Final lint | yes | Run `bun lint:fix` | passed: 877 files; one formatting fix applied, focused proof rerun |
 | Repository check | yes | Run `bun check` | passed end to end after rebase and repairs |
-| GitHub delivery | yes | Rebase/push/squash-merge/read back | pending |
+| GitHub delivery | yes | Rebase/push/squash-merge/read back | passed: merged 2026-08-14T20:57:54Z as `b765f016` |
 | Autoreview | yes | Resolve every accepted actionable finding | passed: branch review 0.98 and final uncommitted review 0.95, both clean |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/317-close-orm-planner-pr.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/317-close-orm-planner-pr.md` | passed after merge receipt |
 | Agent source / generated sync | no | N/A: no agent source/mirror | N/A |
 | Installed lock audit | no | N/A: no skill state change | N/A |
 | Agent action discoverability | no | N/A: no agent action | N/A |
@@ -124,8 +124,8 @@ Phase / pass table:
 | Inventory | completed | PR body/commits/files/checks/threads and overlap reconstructed | rebase |
 | Repair | completed | rebased onto `59b80d0f`; preserved both conflict intents; fixed eager flatMap and relation read bounds | review |
 | Review/checks | completed | focused proof, build/types/lint, deslop, autoreview, and `bun check` passed | publish and resolve threads |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Delivery | completed | exact head `aa406a19` passed CI/Vercel with zero open threads and merged as `b765f016` | final audit |
+| Closeout | completed | merge read-back and child goal checker passed | final |
 
 Verification evidence:
 - Pre-rebase PR 317 CI/Vercel green; evidence becomes stale after PR 316 and must rerun.
@@ -153,18 +153,19 @@ Timeline:
 - 2026-08-14T22:26:00Z Final autoreview and exact repository check passed.
 - 2026-08-14T22:35:14Z Fresh GitHub review added five actionable findings; merge stopped.
 - 2026-08-14T22:48:50Z Five red-to-green repairs, final review, and exact `bun check` passed.
+- 2026-08-14T22:57:54Z PR 317 squash-merged as `b765f016` after exact-head CI and review cleared.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Force-push rebased head, resolve GitHub threads, merge |
+| Where am I? | Complete |
+| Where am I going? | Next ranked batch PR |
 | What is the goal? | Rebase, prove, and merge PR 317 after PR 316 |
 | What have I learned? | See closure matrix |
 | What have I done? | See timeline |
 
 Open risks:
-- Fresh GitHub CI and review remain after the repair head is pushed.
+- None for PR 317.
 
 Findings:
 - PR 317 is the only dependent branch in the batch.

--- a/docs/plans/322-close-cli-safety-pr.md
+++ b/docs/plans/322-close-cli-safety-pr.md
@@ -70,82 +70,102 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | Focused CLI tests | pending |
-| package/API/build | yes | Package build/types | pending |
-| generated output | yes | Package skill to `.agents` mirror plus fixtures | pending |
-| fixtures/scenarios | yes | `fixtures:sync` and `fixtures:check` | pending |
-| docs/package skill | yes | www/package skill/mirror audit | pending |
-| changeset | yes | `.changeset/cli-safe-file-edits.md` audit | pending |
-| agent workflow | yes | Deterministic non-interactive refusal/output contract | pending |
-| cleanup/review | yes | Deslop, agent-native review, autoreview | pending |
-| repository check | yes | `bun check` | pending |
+| source behavior | yes | 31 planner/ownership tests and 124 CLI tests pass | complete |
+| package/API/build | yes | Package build and root typecheck pass | complete |
+| generated output | yes | Skill sync, Intent validation/staleness, and fixture sync pass | complete |
+| fixtures/scenarios | yes | `fixtures:sync` and `fixtures:check` pass without drift | complete |
+| docs/package skill | yes | www guidance audited; package skill equals `.agents` mirror | complete |
+| changeset | yes | `.changeset/cli-safe-file-edits.md` covers the package behavior | complete |
+| agent workflow | yes | Active `cli.ts` add route has JSON refusal receipt and nonzero exit tests | complete |
+| cleanup/review | yes | Zero slop delta; agent-native audit and autoreview clean | complete |
+| repository check | yes | `bun check` | complete |
 | GitHub delivery | yes | PR 322 update/merge/read-back | pending |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
-- [ ] Generated output was changed through its owner and regenerated.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Each pre-delivery lane is proven or N/A with a concrete reason.
+- [x] Generated output was changed through its owner and regenerated.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
 - [ ] Residual blocker/waiver has exact evidence and next owner.
 - [x] Agent-native pack: package skill source owner/mirror boundary recorded.
-- [ ] Agent-native pack: safe CLI refusal and overwrite routes are discoverable.
-- [ ] Agent-native pack: package skill mirror and fixtures are regenerated/proved.
+- [x] Agent-native pack: safe CLI refusal and overwrite routes are discoverable.
+- [x] Agent-native pack: package skill mirror and fixtures are regenerated/proved.
 - [x] Agent-native pack: installed skill membership unchanged.
-- [ ] Agent-native pack: JSON refused receipt, exit status, and forbidden overwrite behavior have tests.
-- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+- [x] Agent-native pack: JSON refused receipt, exit status, and forbidden overwrite behavior have tests.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
 | --- | ---: | --- | --- |
-| None yet | 0 | | |
+| Direct `bunx intent` executable resolution failed | 1 | Use repository-owned scripts | `bun run intent:validate` and `bun run intent:stale` passed |
+| Package-intent saw stale `dist` from the previous PR | 1 | Rebuild the package, then rerun only that proof | Package build passed; 3 package-intent tests passed |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | yes | Run focused CLI tests | pending |
-| Source/generated audit | yes | Regenerate/prove skill mirror and fixtures | pending |
-| Package/docs/scenario closure | yes | Build, docs/skill/changeset, fixtures | pending |
-| Deslop | yes | Run changed-file cleanup review | pending |
-| Agent-native reviewer | yes | Review CLI agent route and receipts | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
-| Repository check | yes | Run `bun check` | pending |
+| Targeted behavior proof | yes | Run focused CLI tests | 31 focused and 124 CLI tests pass |
+| Source/generated audit | yes | Regenerate/prove skill mirror and fixtures | Sync, Intent, `cmp`, and fixture proofs pass |
+| Package/docs/scenario closure | yes | Build, docs/skill/changeset, fixtures | Complete |
+| Deslop | yes | Run changed-file cleanup review | Zero net delta |
+| Agent-native reviewer | yes | Review CLI agent route and receipts | Pass; active route and all proof surfaces mapped |
+| Final lint | yes | Run `bun lint:fix` | Pass; 879 files clean |
+| Repository check | yes | Run `bun check` | Pass; full tests, fixtures, and runtime scenarios |
 | GitHub delivery | yes | Update, squash-merge, read back | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/322-close-cli-safety-pr.md` | pending |
-| Agent source / generated sync | yes | Prove package skill mirror; `.agents/rules` N/A | pending |
+| Agent source / generated sync | yes | Prove package skill mirror; `.agents/rules` N/A | Package skill and mirror byte-identical |
 | Installed lock audit | no | N/A: no skill membership change | N/A |
-| Agent action discoverability | yes | Audit package skill CLI guidance | pending |
-| Helper and template smoke | yes | Focused CLI planner/codegen/refusal tests | pending |
-| Agent-native review | yes | Close accepted CLI agent-route findings | pending |
+| Agent action discoverability | yes | Audit package skill CLI guidance | Package skill and CLI docs document `add --yes/--overwrite/--json` |
+| Helper and template smoke | yes | Focused CLI planner/codegen/refusal tests | Pass |
+| Agent-native review | yes | Close accepted CLI agent-route findings | Pass; zero accepted findings |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
+| Inventory | complete | PR, source owners, active dispatch, mirrors, and docs audited | repair |
+| Repair | complete | Two review regressions fixed with tests | review |
+| Review/checks | complete | Focused tests, build, typecheck, fixtures, sync, deslop, reviews, lint, and exact check pass | delivery |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
 Verification evidence:
-- PR 322 CI/Vercel green at goal creation; no approval yet.
+- `bun test` for planner and schema ownership: 31 pass.
+- `bun run test:cli`: 124 pass, 865 assertions.
+- `bun --cwd packages/kitcn build` and `bun typecheck`: pass.
+- `bun run fixtures:sync` and `bun run fixtures:check`: pass with no fixture drift.
+- `bun run intent:validate`, `bun run intent:stale`, and package-skill-to-mirror
+  byte comparison: pass.
+- Deslop reports zero net regression; final autoreview reports no actionable
+  findings with 0.99 confidence.
+- Exact `bun check` passes, including lint, typecheck, Bun/Vitest suites, 124
+  CLI tests, Concave smoke, every fixture comparison, and runtime scenarios.
+- Agent-native capability map: action `kitcn add --yes/--overwrite/--json`;
+  active route `cli.ts` to `commands/add.ts`; mutation owner planner/apply helpers
+  in `backend-core.ts`; guidance owners are CLI docs and package skill; generated
+  mirror is `.agents/skills/kitcn`; proof owners are CLI, planner, package-intent,
+  Intent, and fixture tests. The legacy `backend-core.run()` is not a package
+  export or the bin dispatch route.
 
 Timeline:
 - 2026-08-14T18:17:54.831Z Autoclosure plan created.
+- 2026-08-14T21:24:00+02:00 Fixed both source-backed review findings with
+  focused regressions, synchronized generated owners, and completed pre-gate
+  review evidence.
+- 2026-08-14T23:19:57+02:00 Exact repository check passed end to end.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Delivery |
+| Where am I going? | Push, GitHub checks, merge, final audit |
 | What is the goal? | Merge safe CLI ownership and schema editing with full generated proof |
-| What have I learned? | See closure matrix |
-| What have I done? | See timeline |
+| What have I learned? | Active add dispatch is modular; generated owners are synchronized |
+| What have I done? | Fixed both findings and proved every pre-delivery lane |
 
 Open risks:
-- Fail-closed file ownership can half-install a plugin unless refusal and lockfile receipts agree.
+- GitHub CI and final merge receipt remain pending.
 
 Findings:
 - This is the batch's widest generated/fixture/agent-facing closeout surface.
@@ -154,4 +174,7 @@ Decisions and tradeoffs:
 - Require fixture sync/check and structured refusal proof before merge.
 
 Review fixes:
-- Pending.
+- Replaced textual backward dot search with the AST property-access dot token,
+  so periods inside chained-call comments cannot corrupt schema insertion.
+- Moved required runtime bindings out of whole type-only `kitcn/orm` imports
+  while preserving unrelated type bindings.

--- a/packages/kitcn/skills/kitcn/references/features/create-plugins.md
+++ b/packages/kitcn/skills/kitcn/references/features/create-plugins.md
@@ -107,7 +107,7 @@ Trigger composition rules:
 3. Non-function helpers live under `convex/<paths.lib>/plugins/<plugin>/...`.
 4. `kitcn codegen` must not generate plugin runtime modules.
 5. Scaffold templates need stable template IDs.
-6. `add` can merge/upsert scaffold mappings; never clobber custom files unless overwrite is explicit.
+6. `add` can merge/upsert scaffold mappings; never clobber custom files unless overwrite is explicit. Plan files of kind `scaffold`, `config`, and `env` need explicit consent to replace an existing file, so a builder that renders a whole template is safe by default. Only a builder that reads the existing source and patches it may set `requiresExplicitOverwrite: false`. List every shape another kitcn plugin can leave behind in `managedBaselineContent` so a file kitcn itself wrote is still recognized as managed. A refused file makes `add` exit non-zero and report `refused` in `--json`.
 7. `add --dry-run`, `add --diff [path]`, and `add --view [path]` preview one shared install plan: scaffold files, env bootstrap, `kitcn.json`, schema registration, lockfile write, dependency install status, codegen/hooks, env reminders.
 8. Preview comparisons for `.ts`, `.tsx`, `.js`, `.jsx`, and `.json` should be semantic enough to ignore formatter-only churn.
 9. `view` is read-only plan inspection. Default template source is lockfile mappings, fallback is the resolved preset, `--preset` forces preset selection.

--- a/packages/kitcn/src/cli/backend-core.ts
+++ b/packages/kitcn/src/cli/backend-core.ts
@@ -274,7 +274,10 @@ export type InitRunResult = {
   cwd: string;
   created: string[];
   updated: string[];
+  /** Left alone: already up to date, or kept because they were edited. */
   skipped: string[];
+  /** The subset of `skipped` that was kept because it had been edited. */
+  refused: string[];
   usedShadcn: boolean;
   template: string | null;
   codegen: InitCodegenStatus;
@@ -3769,7 +3772,10 @@ async function runScaffoldCommandFlow(params: {
       cwd: scaffoldProjectDir,
       created: applyResult.created,
       updated: applyResult.updated,
-      skipped: applyResult.skipped,
+      // Re-running init over an existing project is expected to leave files
+      // alone, so both outcomes stay a single "skipped" count here.
+      skipped: [...applyResult.skipped, ...applyResult.refused],
+      refused: applyResult.refused,
       usedShadcn: params.template !== undefined && params.template !== 'expo',
       template: params.template ?? null,
       codegen: codegenResult.codegen,
@@ -4044,14 +4050,18 @@ export async function applyPluginInstallPlanFiles(
 ): Promise<{
   created: string[];
   manualActions: string[];
-  updated: string[];
+  /** Files that needed explicit consent to be replaced and did not get it. */
+  refused: string[];
+  /** Files that were already up to date. */
   skipped: string[];
+  updated: string[];
 }> {
   const result = {
     created: [] as string[],
     manualActions: [] as string[],
-    updated: [] as string[],
+    refused: [] as string[],
     skipped: [] as string[],
+    updated: [] as string[],
   };
 
   for (const file of files) {
@@ -4076,10 +4086,13 @@ export async function applyPluginInstallPlanFiles(
       : typeof file.managedBaselineContent === 'string'
         ? [file.managedBaselineContent]
         : [];
+    // Fail closed: a scaffold write replaces the file wholesale, so it needs
+    // explicit consent unless the builder opts out because it patches the
+    // user's existing source instead of replacing it.
     const requiresExplicitOverwrite =
       file.requiresExplicitOverwrite ??
       (file.kind === 'config' ||
-        (file.kind === 'scaffold' && file.templateId !== undefined) ||
+        file.kind === 'scaffold' ||
         (file.kind === 'env' &&
           file.templateId !== LOCAL_CONVEX_ENV_TEMPLATE_ID &&
           file.templateId !== KITCN_ENV_HELPER_TEMPLATE_ID));
@@ -4106,7 +4119,7 @@ export async function applyPluginInstallPlanFiles(
     }
 
     if (!shouldOverwrite) {
-      result.skipped.push(file.path);
+      result.refused.push(file.path);
       continue;
     }
 
@@ -7034,13 +7047,14 @@ export async function run(
       created: applyResult.created,
       manualActions: applyResult.manualActions,
       updated: applyResult.updated,
-      skipped: applyResult.skipped,
+      skipped: [...applyResult.skipped, ...applyResult.refused],
+      refused: applyResult.refused,
     };
     if (addArgs.json) {
       console.info(JSON.stringify(payload));
     } else {
       logger.success(
-        `✔ ${selectedPlugin} scaffold results: ${applyResult.created.length} created, ${applyResult.updated.length} updated, ${applyResult.skipped.length} skipped.`
+        `✔ ${selectedPlugin} scaffold results: ${applyResult.created.length} created, ${applyResult.updated.length} updated, ${payload.skipped.length} skipped.`
       );
       if (applyResult.created.length > 0) {
         logger.write(
@@ -7056,9 +7070,9 @@ export async function run(
             .join('\n')}`
         );
       }
-      if (applyResult.skipped.length > 0) {
+      if (payload.skipped.length > 0) {
         logger.write(
-          `Skipped files:\n${applyResult.skipped
+          `Skipped files:\n${payload.skipped
             .map((file) => `  - ${file}`)
             .join('\n')}`
         );

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -1725,6 +1725,68 @@ describe('cli/cli', () => {
     }
   });
 
+  test('run(add ratelimit --yes) reports refused files separately and exits non-zero', async () => {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'kitcn-cli-add-refused-')
+    );
+    const oldCwd = process.cwd();
+    writePackageJson(dir);
+    process.chdir(dir);
+
+    const infoLines: string[] = [];
+    const originalInfo = console.info;
+
+    try {
+      const deps = {
+        realConvex: '/fake/convex/main.js',
+        execa: mock(async () => ({ exitCode: 0 }) as any) as any,
+        generateMeta: mock(async () => {}) as any,
+        syncEnv: mock(async () => {}) as any,
+        loadCliConfig: mock(() => createDefaultConfig()) as any,
+      };
+
+      expect(
+        await run(['add', 'ratelimit', '--yes', '--no-codegen'], deps)
+      ).toBe(0);
+
+      const pluginPath = path.join(
+        dir,
+        'convex',
+        'lib',
+        'plugins',
+        'ratelimit',
+        'plugin.ts'
+      );
+      fs.writeFileSync(
+        pluginPath,
+        `${fs.readFileSync(pluginPath, 'utf8')}\nexport const userOwnedMarker = 42;\n`
+      );
+
+      console.info = (...args: unknown[]) => {
+        infoLines.push(args.map(String).join(' '));
+      };
+      const exitCode = await run(
+        ['add', 'ratelimit', '--yes', '--no-codegen', '--json'],
+        deps
+      );
+      console.info = originalInfo;
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(infoLines.at(-1) ?? '{}');
+      expect(payload.refused).toEqual([
+        'convex/lib/plugins/ratelimit/plugin.ts',
+      ]);
+      expect(payload.skipped).not.toContain(
+        'convex/lib/plugins/ratelimit/plugin.ts'
+      );
+      expect(payload.complete).toBe(false);
+      expect(fs.readFileSync(pluginPath, 'utf8')).toContain('userOwnedMarker');
+    } finally {
+      console.info = originalInfo;
+      process.chdir(oldCwd);
+    }
+  });
+
   test('run(init -t next --yes) falls back to one-shot local bootstrap when cold codegen needs it', async () => {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'kitcn-cli-create-next-bootstrap-')
@@ -5046,7 +5108,9 @@ describe('cli/cli', () => {
         syncEnv: syncEnvStub as any,
         loadCliConfig: loadConfigStub as any,
       });
-      expect(secondRunExitCode).toBe(0);
+      // Refusing to clobber leaves the plugin partially installed, so the run
+      // reports failure instead of a misleading success.
+      expect(secondRunExitCode).toBe(1);
       expect(fs.readFileSync(resendFile, 'utf8')).toBe(
         '// user-customized resend integration\n'
       );
@@ -5881,9 +5945,11 @@ describe('cli/cli', () => {
         loadCliConfig: loadConfigStub as any,
       });
 
-      expect(exitCode).toBe(0);
+      // Refused, not "already up to date": partial install exits non-zero.
+      expect(exitCode).toBe(1);
       expect(fs.readFileSync(apiPath, 'utf8')).toBe('// stale\n');
       expect(infoLines.join('\n')).toContain('--overwrite');
+      expect(infoLines.join('\n')).toContain('Refused files');
     } finally {
       console.info = originalInfo;
       process.chdir(oldCwd);

--- a/packages/kitcn/src/cli/codegen.test.ts
+++ b/packages/kitcn/src/cli/codegen.test.ts
@@ -4297,7 +4297,7 @@ export default createHttpRouter({}, router({}));
     }
   });
 
-  test('generateMeta removes its parse snapshot when a module throws at import time', async () => {
+  test('generateMeta leaves no parse snapshot when a module throws at import time', async () => {
     const dir = mkTempDir();
     const oldCwd = process.cwd();
 
@@ -4365,24 +4365,54 @@ export default createHttpRouter({}, router({}));
     }
   });
 
-  test('generateMeta sweeps stale parse snapshots left by older runs', async () => {
+  test('generateMeta keeps a user file that matches the parse snapshot suffix', async () => {
     const dir = mkTempDir();
     const oldCwd = process.cwd();
 
     process.chdir(dir);
     try {
       writeScopedFixture(dir);
-      writeFile(
-        path.join(dir, 'convex', 'todos.ts.kitcn-parse.ts'),
-        "throw new Error('stale snapshot');"
-      );
+      const userFile = path.join(dir, 'convex', 'parser.kitcn-parse.ts');
+      writeFile(userFile, 'export const userOwned = 42;');
 
       await generateMeta(undefined, { silent: true });
 
-      expect(
-        fs.existsSync(path.join(dir, 'convex', 'todos.ts.kitcn-parse.ts'))
-      ).toBe(false);
+      expect(fs.readFileSync(userFile, 'utf-8')).toBe(
+        'export const userOwned = 42;'
+      );
       const { outputFile } = getConvexConfig();
+      expect(fs.readFileSync(outputFile, 'utf-8')).not.toContain('kitcn-parse');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('generateMeta never overwrites a file sitting at a parse snapshot path', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeScopedFixture(dir);
+      // `todos.ts` imports `kitcn/server`, so earlier builds rewrote it into a
+      // sibling snapshot at exactly this path, clobbering whatever was there.
+      writeFile(
+        path.join(dir, 'convex', 'todos.ts'),
+        `
+        import { initCRPC } from 'kitcn/server';
+        export const list = { _crpcMeta: { type: 'query' }, c: initCRPC };
+        `.trim()
+      );
+      const collidingFile = path.join(dir, 'convex', 'todos.ts.kitcn-parse.ts');
+      writeFile(collidingFile, 'export const userOwned = 42;');
+
+      await generateMeta(undefined, { silent: true });
+
+      expect(fs.readFileSync(collidingFile, 'utf-8')).toBe(
+        'export const userOwned = 42;'
+      );
+      const { outputFile } = getConvexConfig();
+      expect(fs.readFileSync(outputFile, 'utf-8')).toContain('todos');
       expect(fs.readFileSync(outputFile, 'utf-8')).not.toContain('kitcn-parse');
     } finally {
       process.chdir(oldCwd);

--- a/packages/kitcn/src/cli/codegen.test.ts
+++ b/packages/kitcn/src/cli/codegen.test.ts
@@ -4297,6 +4297,98 @@ export default createHttpRouter({}, router({}));
     }
   });
 
+  test('generateMeta removes its parse snapshot when a module throws at import time', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeScopedFixture(dir);
+      writeFile(
+        path.join(dir, 'convex', 'todos.ts'),
+        `
+        import { initCRPC } from 'kitcn/server';
+        throw new Error('boom');
+        export const list = { _crpcMeta: { type: 'query' }, c: initCRPC };
+        `.trim()
+      );
+
+      await expect(generateMeta(undefined, { silent: true })).rejects.toThrow(
+        'boom'
+      );
+
+      expect(
+        fs
+          .readdirSync(path.join(dir, 'convex'))
+          .filter((entry) => entry.includes('.kitcn-parse.'))
+      ).toEqual([]);
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('generateMeta recovers once the failing module is removed', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeScopedFixture(dir);
+      writeFile(
+        path.join(dir, 'convex', 'todos.ts'),
+        `
+        import { initCRPC } from 'kitcn/server';
+        throw new Error('boom');
+        export const list = { _crpcMeta: { type: 'query' }, c: initCRPC };
+        `.trim()
+      );
+
+      await expect(generateMeta(undefined, { silent: true })).rejects.toThrow(
+        'boom'
+      );
+
+      fs.rmSync(path.join(dir, 'convex', 'todos.ts'));
+      writeFile(
+        path.join(dir, 'convex', 'tasks.ts'),
+        `
+        import { initCRPC } from 'kitcn/server';
+        export const list = { _crpcMeta: { type: 'query' }, c: initCRPC };
+        `.trim()
+      );
+
+      await generateMeta(undefined, { silent: true });
+
+      const { outputFile } = getConvexConfig();
+      expect(fs.readFileSync(outputFile, 'utf-8')).toContain('tasks');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('generateMeta sweeps stale parse snapshots left by older runs', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeScopedFixture(dir);
+      writeFile(
+        path.join(dir, 'convex', 'todos.ts.kitcn-parse.ts'),
+        "throw new Error('stale snapshot');"
+      );
+
+      await generateMeta(undefined, { silent: true });
+
+      expect(
+        fs.existsSync(path.join(dir, 'convex', 'todos.ts.kitcn-parse.ts'))
+      ).toBe(false);
+      const { outputFile } = getConvexConfig();
+      expect(fs.readFileSync(outputFile, 'utf-8')).not.toContain('kitcn-parse');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
   test('codegen no longer contains plugin codegen/lockfile reconciliation paths', () => {
     const source = fs.readFileSync(
       path.join(process.cwd(), 'packages/kitcn/src/cli/codegen.ts'),

--- a/packages/kitcn/src/cli/codegen.ts
+++ b/packages/kitcn/src/cli/codegen.ts
@@ -6,7 +6,6 @@ import { OrmSchemaOptions } from '../orm/symbols';
 import {
   hasPotentialCodegenExports,
   isValidConvexFile,
-  PARSE_SNAPSHOT_SUFFIX,
 } from '../shared/meta-utils';
 import { CRPC_BUILDER_STUB_SOURCE } from './utils/crpc-builder-stub.js';
 import { logger } from './utils/logger.js';
@@ -164,21 +163,6 @@ function listFilesRecursive(cwd: string, relDir = ''): string[] {
     }
   }
   return files;
-}
-
-/**
- * Delete parse snapshots stranded by an earlier crashed run so a project that
- * is already wedged heals itself on the next codegen.
- */
-function sweepStaleParseSnapshots(functionsDir: string): void {
-  if (!fs.existsSync(functionsDir)) {
-    return;
-  }
-  for (const relPath of listFilesRecursive(functionsDir)) {
-    if (relPath.endsWith(PARSE_SNAPSHOT_SUFFIX)) {
-      fs.rmSync(path.join(functionsDir, relPath), { force: true });
-    }
-  }
 }
 
 function ensureRelativeImportPath(value: string): string {
@@ -1741,52 +1725,33 @@ async function parseModuleRuntime(
   procedures: ProcedureMeta[];
 }> {
   const source = fs.readFileSync(filePath, 'utf8');
-  let parseSnapshotPath: string | null = null;
-  try {
-    return await parseModuleRuntimeSource(filePath, source, jitiInstance, {
-      onSnapshot: (snapshotPath) => {
-        parseSnapshotPath = snapshotPath;
-      },
-    });
-  } finally {
-    if (parseSnapshotPath) {
-      fs.rmSync(parseSnapshotPath, { force: true });
-    }
-  }
-}
-
-async function parseModuleRuntimeSource(
-  filePath: string,
-  source: string,
-  jitiInstance: ReturnType<typeof createProjectJiti>,
-  hooks: { onSnapshot: (snapshotPath: string) => void }
-): Promise<{
-  meta: ModuleMeta | null;
-  httpRoutes: HttpRoutes;
-  procedures: ProcedureMeta[];
-}> {
+  // Bun can resolve a bare `kitcn/server` back through its own install cache,
+  // so the specifier is rewritten to the project parser shim before the module
+  // is evaluated. See docs/solutions/integration-issues/
+  // bunx-kitcn-self-resolution-must-not-break-scaffold-codegen-20260407.md.
   const rewrittenSource = source.replaceAll(
     /from\s+(['"])kitcn\/server\1/g,
     `from ${JSON.stringify(
       normalizeImportPath(getProjectServerParserShimPath())
     )}`
   );
-  const importPath =
-    rewrittenSource === source
-      ? filePath
-      : (() => {
-          const tempFilePath = `${filePath}${PARSE_SNAPSHOT_SUFFIX}`;
-          fs.writeFileSync(tempFilePath, rewrittenSource, 'utf8');
-          hooks.onSnapshot(tempFilePath);
-          return tempFilePath;
-        })();
   const result: ModuleMeta = {};
   const httpRoutes: HttpRoutes = {};
   const procedures: ProcedureMeta[] = [];
   const isHttp = filePath.endsWith('http.ts');
 
-  // Use jiti to import TypeScript files
-  const module = await jitiInstance.import(importPath);
+  // Use jiti to evaluate TypeScript files. A rewritten module is evaluated in
+  // memory rather than through a sibling temp file: anchoring it to `filePath`
+  // keeps its relative imports and stack traces pointing at the real module,
+  // and codegen never writes to — or deletes from — the Convex directory.
+  const module =
+    rewrittenSource === source
+      ? await jitiInstance.import(filePath)
+      : await jitiInstance.evalModule(rewrittenSource, {
+          async: true,
+          ext: '.ts',
+          filename: filePath,
+        });
 
   if (!module || typeof module !== 'object') {
     if (isHttp) {
@@ -1876,7 +1841,6 @@ export async function generateMeta(
 ): Promise<void> {
   const startTime = Date.now();
   const { functionsDir, outputFile } = getConvexConfig(sharedDir);
-  sweepStaleParseSnapshots(functionsDir);
   const serverOutputFile = getGeneratedServerOutputFile(functionsDir);
   const ormOutputFile = getGeneratedOrmOutputFile(functionsDir);
   const crpcOutputFile = getGeneratedCrpcOutputFile(functionsDir);

--- a/packages/kitcn/src/cli/codegen.ts
+++ b/packages/kitcn/src/cli/codegen.ts
@@ -6,6 +6,7 @@ import { OrmSchemaOptions } from '../orm/symbols';
 import {
   hasPotentialCodegenExports,
   isValidConvexFile,
+  PARSE_SNAPSHOT_SUFFIX,
 } from '../shared/meta-utils';
 import { CRPC_BUILDER_STUB_SOURCE } from './utils/crpc-builder-stub.js';
 import { logger } from './utils/logger.js';
@@ -163,6 +164,21 @@ function listFilesRecursive(cwd: string, relDir = ''): string[] {
     }
   }
   return files;
+}
+
+/**
+ * Delete parse snapshots stranded by an earlier crashed run so a project that
+ * is already wedged heals itself on the next codegen.
+ */
+function sweepStaleParseSnapshots(functionsDir: string): void {
+  if (!fs.existsSync(functionsDir)) {
+    return;
+  }
+  for (const relPath of listFilesRecursive(functionsDir)) {
+    if (relPath.endsWith(PARSE_SNAPSHOT_SUFFIX)) {
+      fs.rmSync(path.join(functionsDir, relPath), { force: true });
+    }
+  }
 }
 
 function ensureRelativeImportPath(value: string): string {
@@ -1725,6 +1741,30 @@ async function parseModuleRuntime(
   procedures: ProcedureMeta[];
 }> {
   const source = fs.readFileSync(filePath, 'utf8');
+  let parseSnapshotPath: string | null = null;
+  try {
+    return await parseModuleRuntimeSource(filePath, source, jitiInstance, {
+      onSnapshot: (snapshotPath) => {
+        parseSnapshotPath = snapshotPath;
+      },
+    });
+  } finally {
+    if (parseSnapshotPath) {
+      fs.rmSync(parseSnapshotPath, { force: true });
+    }
+  }
+}
+
+async function parseModuleRuntimeSource(
+  filePath: string,
+  source: string,
+  jitiInstance: ReturnType<typeof createProjectJiti>,
+  hooks: { onSnapshot: (snapshotPath: string) => void }
+): Promise<{
+  meta: ModuleMeta | null;
+  httpRoutes: HttpRoutes;
+  procedures: ProcedureMeta[];
+}> {
   const rewrittenSource = source.replaceAll(
     /from\s+(['"])kitcn\/server\1/g,
     `from ${JSON.stringify(
@@ -1735,8 +1775,9 @@ async function parseModuleRuntime(
     rewrittenSource === source
       ? filePath
       : (() => {
-          const tempFilePath = `${filePath}.kitcn-parse.ts`;
+          const tempFilePath = `${filePath}${PARSE_SNAPSHOT_SUFFIX}`;
           fs.writeFileSync(tempFilePath, rewrittenSource, 'utf8');
+          hooks.onSnapshot(tempFilePath);
           return tempFilePath;
         })();
   const result: ModuleMeta = {};
@@ -1750,9 +1791,6 @@ async function parseModuleRuntime(
   if (!module || typeof module !== 'object') {
     if (isHttp) {
       logger.error('  http.ts: module is empty or not an object');
-    }
-    if (importPath !== filePath) {
-      fs.rmSync(importPath, { force: true });
     }
     return { meta: null, httpRoutes: {}, procedures: [] };
   }
@@ -1820,10 +1858,6 @@ async function parseModuleRuntime(
     }
   }
 
-  if (importPath !== filePath) {
-    fs.rmSync(importPath, { force: true });
-  }
-
   return {
     meta: Object.keys(result).length > 0 ? result : null,
     httpRoutes,
@@ -1842,6 +1876,7 @@ export async function generateMeta(
 ): Promise<void> {
   const startTime = Date.now();
   const { functionsDir, outputFile } = getConvexConfig(sharedDir);
+  sweepStaleParseSnapshots(functionsDir);
   const serverOutputFile = getGeneratedServerOutputFile(functionsDir);
   const ormOutputFile = getGeneratedOrmOutputFile(functionsDir);
   const crpcOutputFile = getGeneratedCrpcOutputFile(functionsDir);

--- a/packages/kitcn/src/cli/commands/add.ts
+++ b/packages/kitcn/src/cli/commands/add.ts
@@ -597,14 +597,20 @@ export const handleAddCommand = async (argv: string[], deps: AddDeps = {}) => {
     manualActions: applyResult.manualActions,
     updated: applyResult.updated,
     skipped: applyResult.skipped,
+    refused: applyResult.refused,
+    complete: applyResult.refused.length === 0,
   };
+
+  const resultLine = `${selectedPlugin} scaffold results: ${applyResult.created.length} created, ${applyResult.updated.length} updated, ${applyResult.skipped.length} skipped, ${applyResult.refused.length} refused.`;
 
   if (addArgs.json) {
     console.info(JSON.stringify(payload));
   } else {
-    logger.success(
-      `✔ ${selectedPlugin} scaffold results: ${applyResult.created.length} created, ${applyResult.updated.length} updated, ${applyResult.skipped.length} skipped.`
-    );
+    if (applyResult.refused.length > 0) {
+      logger.error(`✖ ${resultLine}`);
+    } else {
+      logger.success(`✔ ${resultLine}`);
+    }
     if (applyResult.created.length > 0) {
       logger.write(
         `Created files:\n${applyResult.created.map((file) => `  - ${file}`).join('\n')}`
@@ -617,11 +623,17 @@ export const handleAddCommand = async (argv: string[], deps: AddDeps = {}) => {
     }
     if (applyResult.skipped.length > 0) {
       logger.write(
-        `Skipped files:\n${applyResult.skipped.map((file) => `  - ${file}`).join('\n')}`
+        `Skipped files (already up to date):\n${applyResult.skipped.map((file) => `  - ${file}`).join('\n')}`
       );
-      if (!addArgs.schema && !addArgs.overwrite) {
-        logger.info('Re-run with --overwrite to replace changed files.');
-      }
+    }
+    if (applyResult.refused.length > 0) {
+      logger.write(
+        `Refused files (your changes were kept):\n${applyResult.refused.map((file) => `  - ${file}`).join('\n')}`
+      );
+      logger.info(
+        'Re-run with --overwrite to replace these files, or merge the changes yourself.'
+      );
+      logger.error(`${selectedPlugin} is only partially installed.`);
     }
     if (applyResult.manualActions.length > 0) {
       logger.info('Manual actions:');
@@ -738,5 +750,7 @@ export const handleAddCommand = async (argv: string[], deps: AddDeps = {}) => {
     }
   }
 
-  return 0;
+  // A refused file means the plugin is only partially wired, so the run must
+  // not look successful to a script or agent keying on the exit code.
+  return applyResult.refused.length > 0 ? 1 : 0;
 };

--- a/packages/kitcn/src/cli/commands/init.ts
+++ b/packages/kitcn/src/cli/commands/init.ts
@@ -141,6 +141,7 @@ export const handleInitCommand = async (
         created: result.created,
         updated: result.updated,
         skipped: result.skipped,
+        refused: result.refused,
         usedShadcn: result.usedShadcn,
         template: result.template,
         codegen: result.codegen,

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.test.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.test.ts
@@ -1,12 +1,264 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { applyPluginInstallPlanFiles } from '../../../backend-core';
 import { createDefaultConfig } from '../../../test-utils';
 import { getPluginCatalogEntry } from '../../index';
+import { INIT_CRPC_TEMPLATE } from '../../init/init-crpc.template.js';
+import { INIT_HTTP_TEMPLATE } from '../../init/init-http.template.js';
+import { INIT_NEXT_CONVEX_PROVIDER_TEMPLATE } from '../../init/next/init-next-convex-provider.template.js';
+import { INIT_NEXT_SERVER_TEMPLATE } from '../../init/next/init-next-server.template.js';
+import { renderInitTemplateContent } from '../../plan-helpers.js';
 import {
   loadDefaultManagedAuthOptions,
   renderManagedAuthSchemaUnits,
 } from './reconcile-auth-schema.js';
+
+const silentPromptAdapter = {
+  confirm: async () => false,
+  isInteractive: () => false,
+  multiselect: async () => [],
+  select: async () => 'ignored',
+};
+
+const writeNextAuthProject = (dir: string, params: { userEdits: boolean }) => {
+  const functionsDir = path.join(dir, 'convex', 'functions');
+  const libDir = path.join(dir, 'convex', 'lib');
+  const clientDir = path.join(dir, 'src', 'lib', 'convex');
+  const crpcFilePath = path.join(libDir, 'crpc.ts');
+  const httpFilePath = path.join(functionsDir, 'http.ts');
+  fs.mkdirSync(functionsDir, { recursive: true });
+  fs.mkdirSync(libDir, { recursive: true });
+  fs.mkdirSync(clientDir, { recursive: true });
+
+  const userSuffix = params.userEdits
+    ? '\nexport const userOwnedMarker = 42;\n'
+    : '';
+
+  fs.writeFileSync(
+    crpcFilePath,
+    renderInitTemplateContent({
+      template: INIT_CRPC_TEMPLATE,
+      filePath: crpcFilePath,
+      functionsDir,
+      crpcFilePath,
+    }) + userSuffix,
+    'utf8'
+  );
+  fs.writeFileSync(
+    httpFilePath,
+    renderInitTemplateContent({
+      template: INIT_HTTP_TEMPLATE,
+      filePath: httpFilePath,
+      functionsDir,
+      crpcFilePath,
+    }),
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(clientDir, 'convex-provider.tsx'),
+    INIT_NEXT_CONVEX_PROVIDER_TEMPLATE + userSuffix,
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(clientDir, 'server.ts'),
+    INIT_NEXT_SERVER_TEMPLATE + userSuffix,
+    'utf8'
+  );
+
+  return {
+    config: createDefaultConfig(),
+    functionsDir,
+    lockfile: { plugins: {} },
+    overwrite: false,
+    preset: 'default' as const,
+    preview: false,
+    promptAdapter: silentPromptAdapter,
+    roots: {
+      appRootDir: path.join(dir, 'src', 'app'),
+      clientLibRootDir: path.join(dir, 'src', 'lib'),
+      crpcFilePath,
+      envFilePath: path.join(libDir, 'get-env.ts'),
+      functionsRootDir: functionsDir,
+      libRootDir: libDir,
+      projectContext: {
+        appDir: 'src/app',
+        clientEntryFile: null,
+        componentsDir: 'src/components',
+        convexClientDir: 'src/lib/convex',
+        framework: 'next' as const,
+        mode: 'next-app' as const,
+      },
+      sharedApiFilePath: path.join(dir, 'convex', 'shared', 'api.ts'),
+    },
+    yes: true,
+  };
+};
+
+describe('auth registry item overwrite safety', () => {
+  test('does not clobber user-edited crpc.ts, provider, or server without --overwrite', async () => {
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-auth-owner-'))
+    );
+    const oldCwd = process.cwd();
+    process.chdir(dir);
+
+    try {
+      const params = writeNextAuthProject(dir, { userEdits: true });
+      const descriptor = getPluginCatalogEntry('auth');
+      const files = descriptor.integration?.buildPlanFiles?.(params) ?? [];
+
+      const result = await applyPluginInstallPlanFiles(files, {
+        overwrite: false,
+        yes: true,
+        promptAdapter: silentPromptAdapter,
+      });
+
+      expect(result.refused).toEqual(
+        expect.arrayContaining([
+          'convex/lib/crpc.ts',
+          'src/lib/convex/convex-provider.tsx',
+          'src/lib/convex/server.ts',
+        ])
+      );
+      // Refusals are not "already up to date" and must stay distinguishable.
+      expect(result.skipped).toEqual([]);
+      expect(
+        fs.readFileSync(path.join(dir, 'convex', 'lib', 'crpc.ts'), 'utf8')
+      ).toContain('userOwnedMarker');
+      expect(
+        fs.readFileSync(
+          path.join(dir, 'src', 'lib', 'convex', 'convex-provider.tsx'),
+          'utf8'
+        )
+      ).toContain('userOwnedMarker');
+      expect(
+        fs.readFileSync(
+          path.join(dir, 'src', 'lib', 'convex', 'server.ts'),
+          'utf8'
+        )
+      ).toContain('userOwnedMarker');
+      // http.ts is patched in place, so it stays writable without --overwrite.
+      expect(result.updated).toContain('convex/functions/http.ts');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('wires auth into crpc.ts after `add ratelimit` without --overwrite', async () => {
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-auth-owner-'))
+    );
+    const oldCwd = process.cwd();
+    process.chdir(dir);
+
+    try {
+      const params = writeNextAuthProject(dir, { userEdits: false });
+      const ratelimitFiles =
+        getPluginCatalogEntry('ratelimit').integration?.buildPlanFiles?.(
+          params
+        ) ?? [];
+      const ratelimitResult = await applyPluginInstallPlanFiles(
+        ratelimitFiles,
+        { overwrite: false, yes: true, promptAdapter: silentPromptAdapter }
+      );
+      expect(ratelimitResult.updated).toContain('convex/lib/crpc.ts');
+
+      const authFiles =
+        getPluginCatalogEntry('auth').integration?.buildPlanFiles?.(params) ??
+        [];
+      const authResult = await applyPluginInstallPlanFiles(authFiles, {
+        overwrite: false,
+        yes: true,
+        promptAdapter: silentPromptAdapter,
+      });
+
+      expect(authResult.refused).toEqual([]);
+      expect(authResult.updated).toContain('convex/lib/crpc.ts');
+
+      const crpc = fs.readFileSync(
+        path.join(dir, 'convex', 'lib', 'crpc.ts'),
+        'utf8'
+      );
+      expect(crpc).toContain('export const authQuery = c.query');
+      expect(crpc).toContain('export const authMutation = c.mutation');
+      // The ratelimit wiring from the earlier `add` survives.
+      expect(crpc).toContain('ratelimit.middleware()');
+      expect(crpc).toContain('RatelimitBucket');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('upgrades untouched managed baselines without --overwrite', async () => {
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-auth-owner-'))
+    );
+    const oldCwd = process.cwd();
+    process.chdir(dir);
+
+    try {
+      const params = writeNextAuthProject(dir, { userEdits: false });
+      const descriptor = getPluginCatalogEntry('auth');
+      const files = descriptor.integration?.buildPlanFiles?.(params) ?? [];
+
+      const result = await applyPluginInstallPlanFiles(files, {
+        overwrite: false,
+        yes: true,
+        promptAdapter: silentPromptAdapter,
+      });
+
+      expect(result.skipped).toEqual([]);
+      expect(result.updated).toEqual(
+        expect.arrayContaining([
+          'convex/lib/crpc.ts',
+          'src/lib/convex/convex-provider.tsx',
+          'src/lib/convex/server.ts',
+        ])
+      );
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('prompts before replacing user-edited integration files', async () => {
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-auth-owner-'))
+    );
+    const oldCwd = process.cwd();
+    process.chdir(dir);
+
+    try {
+      const params = writeNextAuthProject(dir, { userEdits: true });
+      const descriptor = getPluginCatalogEntry('auth');
+      const files = descriptor.integration?.buildPlanFiles?.(params) ?? [];
+      const prompts: string[] = [];
+
+      await applyPluginInstallPlanFiles(files, {
+        overwrite: false,
+        yes: false,
+        promptAdapter: {
+          ...silentPromptAdapter,
+          isInteractive: () => true,
+          confirm: async (message: string) => {
+            prompts.push(message);
+            return false;
+          },
+        },
+      });
+
+      expect(prompts).toEqual(
+        expect.arrayContaining([
+          'Overwrite convex/lib/crpc.ts?',
+          'Overwrite src/lib/convex/convex-provider.tsx?',
+          'Overwrite src/lib/convex/server.ts?',
+        ])
+      );
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+});
 
 describe('auth registry item', () => {
   test('claims jwks on first managed auth scaffold pass', async () => {

--- a/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-item.ts
@@ -25,6 +25,7 @@ import { renderLocalConvexEnvContent } from '../../planner.js';
 import { reconcileRootSchemaOwnership } from '../../schema-ownership.js';
 import { getSchemaFilePath } from '../../state.js';
 import type { PluginRegistryBuildPlanFilesParams } from '../../types.js';
+import { patchRatelimitCrpcSource } from '../ratelimit/ratelimit-crpc.js';
 import {
   AUTH_CONVEX_TEMPLATE,
   AUTH_EXPO_TEMPLATE,
@@ -232,7 +233,12 @@ function buildAuthCrpcRegistrationPlanFile(
     kind: 'scaffold',
     filePath: crpcPath,
     content: renderAuthCrpcTemplate({ withRatelimit }),
-    managedBaselineContent: baselineCrpcSource,
+    // Every shape another kitcn plugin can leave behind counts as managed, so
+    // `add ratelimit` before `add auth` still upgrades without --overwrite.
+    managedBaselineContent: [
+      baselineCrpcSource,
+      patchRatelimitCrpcSource(baselineCrpcSource),
+    ],
     createReason: 'Create crpc.ts with auth-aware procedures.',
     updateReason: 'Register auth-aware procedures in crpc.ts.',
     skipReason: 'Auth-aware procedures are already registered in crpc.ts.',
@@ -305,6 +311,8 @@ app.use(
     filePath: httpPath,
     content: source,
     managedBaselineContent: baselineHttpSource,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create http.ts with auth middleware.',
     updateReason: 'Register auth middleware in http.ts.',
     skipReason: 'Auth middleware is already registered in http.ts.',
@@ -615,6 +623,8 @@ export default http;
     kind: 'scaffold',
     filePath: httpPath,
     content: source,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create Convex http.ts with auth routes.',
     updateReason: 'Register auth routes in Convex http.ts.',
     skipReason: 'Convex http.ts already registers auth routes.',
@@ -704,6 +714,8 @@ function buildAuthConvexNextProviderPlanFile(
     kind: 'scaffold',
     filePath: providerPath,
     content: source,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create auth-aware Convex client provider.',
     updateReason: 'Update Convex client provider with auth.',
     skipReason: 'Convex client provider already includes auth.',
@@ -750,6 +762,8 @@ function buildAuthConvexStartProviderPlanFile(
     kind: 'scaffold',
     filePath: providerPath,
     content: source,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create auth-aware Start provider.',
     updateReason: 'Update Start provider with auth.',
     skipReason: 'Start provider already includes auth.',
@@ -802,6 +816,8 @@ function buildAuthConvexReactEntryPlanFile(
     kind: 'scaffold',
     filePath: entryPath,
     content: source,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create auth-aware client entry.',
     updateReason: 'Update client entry with auth.',
     skipReason: 'Client entry already includes auth.',

--- a/packages/kitcn/src/cli/registry/items/ratelimit/ratelimit-crpc.ts
+++ b/packages/kitcn/src/cli/registry/items/ratelimit/ratelimit-crpc.ts
@@ -1,0 +1,72 @@
+const CRPC_META_RATELIMIT_RE = /ratelimit\?: string;/;
+const CRPC_RATELIMIT_BUCKET_RE = /ratelimit\?: RatelimitBucket;/;
+const CRPC_CREATE_LINE_RE = /const c = initCRPC\.create\(\);/;
+const CRPC_META_CREATE_RE =
+  /const c = initCRPC\s*\.meta<\{\s*([\s\S]*?)\s*\}>\(\)\s*\.create\(\);/;
+const PUBLIC_MUTATION_LINE_RE =
+  /export const publicMutation = c\.mutation(?:\.use\(ratelimit\.middleware\(\)\))?;/;
+
+/**
+ * Wire ratelimit middleware into an existing `crpc.ts` source.
+ *
+ * Shared so other plugins can reproduce the ratelimit-patched baseline and
+ * recognize it as managed content rather than a user edit.
+ */
+export const patchRatelimitCrpcSource = (input: string): string => {
+  let source = input;
+
+  if (!source.includes("from './plugins/ratelimit/plugin'")) {
+    if (source.includes('import type { ActionCtx, MutationCtx, QueryCtx }')) {
+      source = source.replace(
+        "import type { ActionCtx, MutationCtx, QueryCtx } from '../functions/generated/server';",
+        `import { type RatelimitBucket, ratelimit } from './plugins/ratelimit/plugin';
+import type { ActionCtx, MutationCtx, QueryCtx } from '../functions/generated/server';`
+      );
+    } else {
+      source = `import { type RatelimitBucket, ratelimit } from './plugins/ratelimit/plugin';\n${source}`;
+    }
+  }
+
+  if (CRPC_META_RATELIMIT_RE.test(source)) {
+    source = source.replace(
+      CRPC_META_RATELIMIT_RE,
+      'ratelimit?: RatelimitBucket;'
+    );
+  }
+
+  if (!CRPC_RATELIMIT_BUCKET_RE.test(source)) {
+    if (CRPC_META_CREATE_RE.test(source)) {
+      source = source.replace(CRPC_META_CREATE_RE, (_match, fields: string) => {
+        const nextFields = [
+          ...fields
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean),
+          'ratelimit?: RatelimitBucket;',
+        ]
+          .map((line) => `    ${line}`)
+          .join('\n');
+
+        return `const c = initCRPC\n  .meta<{\n${nextFields}\n  }>()\n  .create();`;
+      });
+    } else if (CRPC_CREATE_LINE_RE.test(source)) {
+      source = source.replace(
+        CRPC_CREATE_LINE_RE,
+        `const c = initCRPC
+  .meta<{
+    ratelimit?: RatelimitBucket;
+  }>()
+  .create();`
+      );
+    }
+  }
+
+  if (PUBLIC_MUTATION_LINE_RE.test(source)) {
+    source = source.replace(
+      PUBLIC_MUTATION_LINE_RE,
+      'export const publicMutation = c.mutation.use(ratelimit.middleware());'
+    );
+  }
+
+  return source;
+};

--- a/packages/kitcn/src/cli/registry/items/ratelimit/ratelimit-item.ts
+++ b/packages/kitcn/src/cli/registry/items/ratelimit/ratelimit-item.ts
@@ -8,16 +8,9 @@ import {
   renderInitTemplateContent,
 } from '../../plan-helpers.js';
 import type { PluginRegistryBuildPlanFilesParams } from '../../types.js';
+import { patchRatelimitCrpcSource } from './ratelimit-crpc.js';
 import { RATELIMIT_PLUGIN_TEMPLATE } from './ratelimit-plugin.template.js';
 import { RATELIMIT_SCHEMA_TEMPLATE } from './ratelimit-schema.template.js';
-
-const CRPC_META_RATELIMIT_RE = /ratelimit\?: string;/;
-const CRPC_RATELIMIT_BUCKET_RE = /ratelimit\?: RatelimitBucket;/;
-const CRPC_CREATE_LINE_RE = /const c = initCRPC\.create\(\);/;
-const CRPC_META_CREATE_RE =
-  /const c = initCRPC\s*\.meta<\{\s*([\s\S]*?)\s*\}>\(\)\s*\.create\(\);/;
-const PUBLIC_MUTATION_LINE_RE =
-  /export const publicMutation = c\.mutation(?:\.use\(ratelimit\.middleware\(\)\))?;/;
 
 const RATELIMIT_FILES = [
   createRegistryFile({
@@ -45,68 +38,19 @@ function buildRatelimitCrpcRegistrationPlanFile(
     functionsDir: params.functionsDir,
     crpcFilePath: crpcPath,
   });
-  let source = fs.existsSync(crpcPath)
-    ? fs.readFileSync(crpcPath, 'utf8')
-    : baselineCrpcSource;
-
-  if (!source.includes("from './plugins/ratelimit/plugin'")) {
-    if (source.includes('import type { ActionCtx, MutationCtx, QueryCtx }')) {
-      source = source.replace(
-        "import type { ActionCtx, MutationCtx, QueryCtx } from '../functions/generated/server';",
-        `import { type RatelimitBucket, ratelimit } from './plugins/ratelimit/plugin';
-import type { ActionCtx, MutationCtx, QueryCtx } from '../functions/generated/server';`
-      );
-    } else {
-      source = `import { type RatelimitBucket, ratelimit } from './plugins/ratelimit/plugin';\n${source}`;
-    }
-  }
-
-  if (CRPC_META_RATELIMIT_RE.test(source)) {
-    source = source.replace(
-      CRPC_META_RATELIMIT_RE,
-      'ratelimit?: RatelimitBucket;'
-    );
-  }
-
-  if (!CRPC_RATELIMIT_BUCKET_RE.test(source)) {
-    if (CRPC_META_CREATE_RE.test(source)) {
-      source = source.replace(CRPC_META_CREATE_RE, (_match, fields: string) => {
-        const nextFields = [
-          ...fields
-            .split('\n')
-            .map((line) => line.trim())
-            .filter(Boolean),
-          'ratelimit?: RatelimitBucket;',
-        ]
-          .map((line) => `    ${line}`)
-          .join('\n');
-
-        return `const c = initCRPC\n  .meta<{\n${nextFields}\n  }>()\n  .create();`;
-      });
-    } else if (CRPC_CREATE_LINE_RE.test(source)) {
-      source = source.replace(
-        CRPC_CREATE_LINE_RE,
-        `const c = initCRPC
-  .meta<{
-    ratelimit?: RatelimitBucket;
-  }>()
-  .create();`
-      );
-    }
-  }
-
-  if (PUBLIC_MUTATION_LINE_RE.test(source)) {
-    source = source.replace(
-      PUBLIC_MUTATION_LINE_RE,
-      'export const publicMutation = c.mutation.use(ratelimit.middleware());'
-    );
-  }
+  const source = patchRatelimitCrpcSource(
+    fs.existsSync(crpcPath)
+      ? fs.readFileSync(crpcPath, 'utf8')
+      : baselineCrpcSource
+  );
 
   return createPlanFile({
     kind: 'scaffold',
     filePath: crpcPath,
     content: source,
     managedBaselineContent: baselineCrpcSource,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create crpc.ts with ratelimit middleware.',
     updateReason: 'Register ratelimit middleware in crpc.ts.',
     skipReason: 'Ratelimit middleware is already registered in crpc.ts.',

--- a/packages/kitcn/src/cli/registry/items/resend/resend-item.ts
+++ b/packages/kitcn/src/cli/registry/items/resend/resend-item.ts
@@ -111,6 +111,8 @@ function buildResendHttpRegistrationPlanFile(
     filePath: httpPath,
     content: source,
     managedBaselineContent: baselineHttpSource,
+    // Patches the existing source in place, so it never clobbers user code.
+    requiresExplicitOverwrite: false,
     createReason: 'Create http.ts with resend webhook route.',
     updateReason: 'Register resend webhook in http.ts.',
     skipReason: 'Resend webhook is already registered in http.ts.',

--- a/packages/kitcn/src/cli/registry/planner.test.ts
+++ b/packages/kitcn/src/cli/registry/planner.test.ts
@@ -543,6 +543,22 @@ export default defineSchema(tables);
     );
   });
 
+  test('registers before a chained call with a sentence comment', () => {
+    const plan = runWithSchema(`import { defineSchema } from 'kitcn/orm';
+
+export const tables = {};
+
+export default defineSchema(tables). /* explanatory sentence. */ relations((r) => ({}));
+`);
+
+    expect(plan.content).toContain(
+      'defineSchema(tables).extend(resendExtension()). /* explanatory sentence. */ relations'
+    );
+    expect(plan.content).not.toContain(
+      'explanatory sentence.extend(resendExtension())'
+    );
+  });
+
   test('ignores a commented-out defineSchema call', () => {
     const plan =
       runWithSchema(`import { convexTable, defineSchema, text } from 'kitcn/orm';

--- a/packages/kitcn/src/cli/registry/planner.test.ts
+++ b/packages/kitcn/src/cli/registry/planner.test.ts
@@ -6,7 +6,11 @@ import {
   writeMinimalSchema,
   writePackageJson,
 } from '../test-utils';
-import { buildPluginInstallPlan, renderEnvHelperContent } from './planner';
+import {
+  buildPluginInstallPlan,
+  buildSchemaRegistrationPlanFile,
+  renderEnvHelperContent,
+} from './planner';
 
 describe('cli registry planner', () => {
   test('defaults SITE_URL to localhost:3000 in the generated env helper', () => {
@@ -473,5 +477,106 @@ export const getEnv = createEnv({
     } finally {
       process.chdir(originalCwd);
     }
+  });
+});
+
+describe('buildSchemaRegistrationPlanFile', () => {
+  const descriptor = {
+    key: 'resend',
+    packageName: '@kitcn/resend',
+    schemaRegistration: {
+      importName: 'resendExtension',
+      path: 'schema.ts',
+      target: 'lib' as const,
+    },
+  };
+
+  const runWithSchema = (schemaSource: string) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kitcn-planner-schema-'));
+    const originalCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const functionsDir = path.join(dir, 'convex');
+      fs.mkdirSync(path.join(dir, 'convex', 'lib'), { recursive: true });
+      fs.writeFileSync(
+        path.join(functionsDir, 'schema.ts'),
+        schemaSource,
+        'utf8'
+      );
+
+      return buildSchemaRegistrationPlanFile(
+        functionsDir,
+        descriptor as never,
+        {
+          appRootDir: null,
+          clientLibRootDir: null,
+          crpcFilePath: path.join(dir, 'convex', 'lib', 'crpc.ts'),
+          envFilePath: path.join(dir, 'convex', 'lib', 'get-env.ts'),
+          functionsRootDir: functionsDir,
+          libRootDir: path.join(dir, 'convex', 'lib'),
+          projectContext: null,
+          sharedApiFilePath: path.join(dir, 'convex', 'shared', 'api.ts'),
+        } as never
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  };
+
+  test('registers the extension on the real defineSchema call, not a comment', () => {
+    const plan =
+      runWithSchema(`import { convexTable, defineSchema, text } from 'kitcn/orm';
+
+export const tables = {};
+
+/**
+ * Chain relations with defineSchema(tables).relations((r) => ({})).
+ */
+export default defineSchema(tables);
+`);
+
+    expect(plan.content).toContain(
+      'export default defineSchema(tables).extend(resendExtension());'
+    );
+    expect(plan.content).toContain(
+      ' * Chain relations with defineSchema(tables).relations((r) => ({})).'
+    );
+  });
+
+  test('ignores a commented-out defineSchema call', () => {
+    const plan =
+      runWithSchema(`import { convexTable, defineSchema, text } from 'kitcn/orm';
+
+export const tables = {};
+
+// export default defineSchema(legacyTables);
+export default defineSchema(tables);
+`);
+
+    expect(plan.content).toContain(
+      'export default defineSchema(tables).extend(resendExtension());'
+    );
+    expect(plan.content).toContain(
+      '// export default defineSchema(legacyTables);'
+    );
+  });
+
+  test('ignores a defineSchema mention inside a string literal', () => {
+    const plan =
+      runWithSchema(`import { convexTable, defineSchema, text } from 'kitcn/orm';
+
+export const docs = 'defineSchema(tables)';
+
+export const tables = {};
+
+export default defineSchema(tables);
+`);
+
+    expect(plan.content).toContain(
+      'export default defineSchema(tables).extend(resendExtension());'
+    );
+    expect(plan.content).toContain(
+      "export const docs = 'defineSchema(tables)';"
+    );
   });
 });

--- a/packages/kitcn/src/cli/registry/planner.ts
+++ b/packages/kitcn/src/cli/registry/planner.ts
@@ -41,6 +41,7 @@ import {
   normalizeRelativePathOrThrow,
 } from './path-utils.js';
 import { createPlanFile, resolveRelativeImportPath } from './plan-helpers.js';
+import { findDefineSchemaChain, hasCallExpression } from './schema-chain.js';
 import {
   assertSchemaFileExists,
   getPluginLockfilePath,
@@ -79,7 +80,6 @@ const READ_OPTIONAL_RUNTIME_ENV_RE =
   /(\s*readOptionalRuntimeEnv\s*:\s*\[)([\s\S]*?)(\]\s*,?)/m;
 const LEADING_WHITESPACE_RE = /^\s*/;
 const STRING_LITERAL_ARRAY_ENTRY_RE = /^(['"])([^'"]+)\1$/;
-const WHITESPACE_RE = /\s/;
 
 const findMatchingObjectBraceIndex = (source: string, openIndex: number) => {
   let depth = 0;
@@ -737,105 +737,33 @@ const getPlannedFileContent = (
   return files?.find((file) => file.path === normalizedPath)?.content;
 };
 
-const skipWhitespace = (source: string, start: number) => {
-  let index = start;
-  while (index < source.length && WHITESPACE_RE.test(source[index] ?? '')) {
-    index += 1;
-  }
-  return index;
-};
-
-const findBalancedParenEnd = (source: string, openParenIndex: number) => {
-  let depth = 0;
-
-  for (let index = openParenIndex; index < source.length; index += 1) {
-    const char = source[index];
-
-    if (char === '(') {
-      depth += 1;
-      continue;
-    }
-
-    if (char !== ')') {
-      continue;
-    }
-
-    depth -= 1;
-    if (depth === 0) {
-      return index;
-    }
-  }
-
-  return -1;
-};
-
 const findSchemaExtensionInsertIndex = (source: string) => {
-  const defineSchemaIndex = source.indexOf('defineSchema(');
-  if (defineSchemaIndex < 0) {
+  const chain = findDefineSchemaChain(source);
+  if (!chain) {
     return { closeParenIndex: -1, hasExtend: false, insertIndex: -1 };
   }
 
-  const defineSchemaOpenParenIndex = source.indexOf('(', defineSchemaIndex);
-  if (defineSchemaOpenParenIndex < 0) {
-    return { closeParenIndex: -1, hasExtend: false, insertIndex: -1 };
-  }
-
-  const defineSchemaCloseParenIndex = findBalancedParenEnd(
-    source,
-    defineSchemaOpenParenIndex
-  );
-  if (defineSchemaCloseParenIndex < 0) {
-    return { closeParenIndex: -1, hasExtend: false, insertIndex: -1 };
-  }
-
-  const cursor = defineSchemaCloseParenIndex + 1;
-
-  while (cursor < source.length) {
-    const nextSegmentIndex = skipWhitespace(source, cursor);
-
-    if (
-      source.startsWith('.relations(', nextSegmentIndex) ||
-      source.startsWith('.triggers(', nextSegmentIndex)
-    ) {
-      return {
-        closeParenIndex: -1,
-        hasExtend: false,
-        insertIndex: nextSegmentIndex,
-      };
-    }
-
-    if (!source.startsWith('.extend(', nextSegmentIndex)) {
-      return {
-        closeParenIndex: -1,
-        hasExtend: false,
-        insertIndex: nextSegmentIndex,
-      };
-    }
-
-    const extendOpenParenIndex = source.indexOf('(', nextSegmentIndex);
-    if (extendOpenParenIndex < 0) {
-      return { closeParenIndex: -1, hasExtend: false, insertIndex: -1 };
-    }
-
-    const extendCloseParenIndex = findBalancedParenEnd(
-      source,
-      extendOpenParenIndex
-    );
-    if (extendCloseParenIndex < 0) {
-      return { closeParenIndex: -1, hasExtend: false, insertIndex: -1 };
-    }
-
+  const firstCall = chain.calls[0];
+  if (!firstCall) {
     return {
-      closeParenIndex: extendCloseParenIndex,
+      closeParenIndex: -1,
+      hasExtend: false,
+      insertIndex: chain.defineSchemaEnd,
+    };
+  }
+
+  if (firstCall.name === 'extend') {
+    return {
+      closeParenIndex: firstCall.closeParenIndex,
       hasExtend: true,
-      insertIndex: extendCloseParenIndex,
+      insertIndex: firstCall.closeParenIndex,
     };
   }
 
   return {
     closeParenIndex: -1,
     hasExtend: false,
-    insertIndex: cursor,
+    insertIndex: firstCall.dotIndex,
   };
 };
 
@@ -865,7 +793,7 @@ export const buildSchemaRegistrationPlanFile = (
   );
 
   let source = bootstrappedSchemaSource ?? fs.readFileSync(schemaPath, 'utf8');
-  if (!source.includes(`${pluginFactory}()`)) {
+  if (!hasCallExpression(source, pluginFactory)) {
     const importRegex = new RegExp(
       `import\\s+\\{[^}]*\\b${pluginFactory}\\b[^}]*\\}\\s+from\\s+['"]${pluginImportPath}['"];?`
     );

--- a/packages/kitcn/src/cli/registry/schema-chain.ts
+++ b/packages/kitcn/src/cli/registry/schema-chain.ts
@@ -1,0 +1,132 @@
+import type * as tsType from 'typescript';
+import { createTypeScriptProxy } from '../utils/typescript-runtime.js';
+
+const ts = createTypeScriptProxy();
+
+export type SchemaChainCall = {
+  /** Index of the matching `)` of this call. */
+  closeParenIndex: number;
+  /** Index of the leading `.` that starts `.name(`. */
+  dotIndex: number;
+  /** Index just past the matching `)` of this call. */
+  end: number;
+  /** Method name, e.g. `extend`, `relations`, `triggers`. */
+  name: string;
+};
+
+export type SchemaChain = {
+  /** Calls chained onto `defineSchema(...)`, in source order. */
+  calls: SchemaChainCall[];
+  /** Index just past the `)` that closes `defineSchema(...)`. */
+  defineSchemaEnd: number;
+};
+
+const parse = (source: string) =>
+  ts.createSourceFile(
+    'schema.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
+const isDefineSchemaCall = (
+  node: tsType.Node
+): node is tsType.CallExpression => {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+  if (ts.isIdentifier(node.expression)) {
+    return node.expression.text === 'defineSchema';
+  }
+  return (
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'defineSchema'
+  );
+};
+
+const findDefineSchemaCall = (
+  sourceFile: tsType.SourceFile
+): tsType.CallExpression | null => {
+  let found: tsType.CallExpression | null = null;
+
+  const visit = (node: tsType.Node) => {
+    if (found) {
+      return;
+    }
+    if (isDefineSchemaCall(node)) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+};
+
+/**
+ * Resolve the real `defineSchema(...)` call and the methods chained onto it.
+ *
+ * Locating the call through the TypeScript AST is what keeps registration out
+ * of comments and string literals that merely mention `defineSchema(`.
+ */
+export const findDefineSchemaChain = (source: string): SchemaChain | null => {
+  const sourceFile = parse(source);
+  const defineSchemaCall = findDefineSchemaCall(sourceFile);
+  if (!defineSchemaCall) {
+    return null;
+  }
+
+  const calls: SchemaChainCall[] = [];
+  let current: tsType.Node = defineSchemaCall;
+
+  while (
+    current.parent &&
+    ts.isPropertyAccessExpression(current.parent) &&
+    current.parent.expression === current &&
+    current.parent.parent &&
+    ts.isCallExpression(current.parent.parent) &&
+    current.parent.parent.expression === current.parent
+  ) {
+    const propertyAccess = current.parent;
+    const call = current.parent.parent;
+    const nameStart = propertyAccess.name.getStart(sourceFile);
+    calls.push({
+      closeParenIndex: call.end - 1,
+      dotIndex: source.lastIndexOf('.', nameStart),
+      end: call.end,
+      name: propertyAccess.name.text,
+    });
+    current = call;
+  }
+
+  return { calls, defineSchemaEnd: defineSchemaCall.end };
+};
+
+/**
+ * Whether `source` really calls `name()` somewhere, ignoring comments and
+ * string literals.
+ */
+export const hasCallExpression = (source: string, name: string): boolean => {
+  const sourceFile = parse(source);
+  let found = false;
+
+  const visit = (node: tsType.Node) => {
+    if (found) {
+      return;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === name
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+};

--- a/packages/kitcn/src/cli/registry/schema-chain.ts
+++ b/packages/kitcn/src/cli/registry/schema-chain.ts
@@ -91,10 +91,15 @@ export const findDefineSchemaChain = (source: string): SchemaChain | null => {
   ) {
     const propertyAccess = current.parent;
     const call = current.parent.parent;
-    const nameStart = propertyAccess.name.getStart(sourceFile);
+    const dotToken = propertyAccess
+      .getChildren(sourceFile)
+      .find((child) => child.kind === ts.SyntaxKind.DotToken);
+    if (!dotToken) {
+      throw new Error('Schema chain property access is missing its dot token.');
+    }
     calls.push({
       closeParenIndex: call.end - 1,
-      dotIndex: source.lastIndexOf('.', nameStart),
+      dotIndex: dotToken.getStart(sourceFile),
       end: call.end,
       name: propertyAccess.name.text,
     });

--- a/packages/kitcn/src/cli/registry/schema-ownership.test.ts
+++ b/packages/kitcn/src/cli/registry/schema-ownership.test.ts
@@ -342,3 +342,202 @@ describe('root schema ownership', () => {
     );
   });
 });
+
+describe('schema ownership source safety', () => {
+  const jwksUnit: RootSchemaTableUnit = {
+    declaration: `export const jwksTable = convexTable("jwks", {
+  publicKey: text().notNull(),
+  privateKey: text().notNull(),
+});`,
+    importNames: ['convexTable', 'text'],
+    key: 'jwks',
+    registration: 'jwks: jwksTable',
+  };
+
+  const reconcile = (source: string, tables: RootSchemaTableUnit[]) =>
+    reconcileRootSchemaOwnership({
+      lock: null,
+      overwrite: true,
+      pluginKey: 'auth',
+      preview: false,
+      promptAdapter: createPromptAdapter(),
+      schemaPath: '/repo/convex/functions/schema.ts',
+      source,
+      tables,
+      yes: true,
+    });
+
+  test('preserves a block-bodied index callback while merging managed fields', async () => {
+    const source = `import { convexTable, defineSchema, index, text } from "kitcn/orm";
+
+export const jwksTable = convexTable(
+  "jwks",
+  {
+    publicKey: text().notNull(),
+  },
+  (jwksTable) => {
+    return [index("publicKey").on(jwksTable.publicKey)];
+  }
+);
+
+export const tables = {
+  jwks: jwksTable,
+};
+
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [jwksUnit]);
+    expect(result.content).toContain(
+      'return [index("publicKey").on(jwksTable.publicKey)];'
+    );
+    expect(result.content).toContain('privateKey: text().notNull(),');
+  });
+
+  test('preserves a hoisted index callback identifier', async () => {
+    const source = `import { convexTable, defineSchema, index, text } from "kitcn/orm";
+
+const jwksIndexes = (t) => [index("publicKey").on(t.publicKey)];
+
+export const jwksTable = convexTable(
+  "jwks",
+  {
+    publicKey: text().notNull(),
+  },
+  jwksIndexes
+);
+
+export const tables = {
+  jwks: jwksTable,
+};
+
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [jwksUnit]);
+    expect(result.content).toContain('  jwksIndexes\n);');
+    expect(result.content).toContain('privateKey: text().notNull(),');
+  });
+
+  test('still refuses to merge managed indexes into an unparsed callback', async () => {
+    const source = `import { convexTable, defineSchema, index, text } from "kitcn/orm";
+
+export const userTable = convexTable(
+  "user",
+  {
+    email: text().notNull(),
+  },
+  (userTable) => {
+    return [index("email").on(userTable.email)];
+  }
+);
+
+export const tables = {
+  user: userTable,
+};
+
+export default defineSchema(tables);
+`;
+
+    await expect(reconcile(source, [usernameUserUnit])).rejects.toThrow(
+      'auth indexes for table "user" could not be merged into the existing schema callback'
+    );
+  });
+
+  test('keeps a concise-body index callback while merging managed fields', async () => {
+    const source = `import { convexTable, defineSchema, index, text } from "kitcn/orm";
+
+export const jwksTable = convexTable(
+  "jwks",
+  {
+    publicKey: text().notNull(),
+  },
+  (jwksTable) => [index("publicKey").on(jwksTable.publicKey)]
+);
+
+export const tables = {
+  jwks: jwksTable,
+};
+
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [jwksUnit]);
+    expect(result.content).toContain(
+      'index("publicKey").on(jwksTable.publicKey)'
+    );
+    expect(result.content).toContain('privateKey: text().notNull(),');
+  });
+
+  test('keeps a type-only kitcn/orm import type-only', async () => {
+    const source = `import type { InferSelectModel } from "kitcn/orm";
+import { convexTable, defineSchema, text } from "kitcn/orm";
+
+export const messagesTable = convexTable("messages", {
+  body: text().notNull(),
+});
+
+export const tables = {
+  messages: messagesTable,
+};
+
+export type Message = InferSelectModel<typeof messagesTable>;
+
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [userUnit]);
+    expect(result.content).toContain(
+      'import type { InferSelectModel } from "kitcn/orm";'
+    );
+    expect(result.content).not.toContain('InferSelectModel,');
+    expect(result.content.match(/from ['"]kitcn\/orm['"]/g)).toHaveLength(2);
+  });
+
+  test('adds a value import when only a namespace kitcn/orm import exists', async () => {
+    const source = `import * as orm from "kitcn/orm";
+
+export const tables = {};
+
+export default orm.defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [userUnit]);
+    expect(result.content).toContain("from 'kitcn/orm';");
+    expect(result.content).toContain('convexTable');
+    expect(result.content).toContain('import * as orm from "kitcn/orm";');
+  });
+
+  test('does not merge a plain name into an existing inline type specifier', async () => {
+    const source = `import { convexTable, defineSchema, type text } from "kitcn/orm";
+
+export const tables = {};
+
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [userUnit]);
+    expect(result.content).not.toContain('type text,');
+    expect(result.content).toContain('text,');
+  });
+
+  test('chains relations onto the real defineSchema call, not a comment', async () => {
+    const source = `import { convexTable, defineSchema, text } from "kitcn/orm";
+
+export const tables = {};
+
+/**
+ * Chain relations with defineSchema(tables).relations((r) => ({})).
+ */
+export default defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [userUnit]);
+    expect(result.content).toContain(
+      'export default defineSchema(tables).relations((r) => ('
+    );
+    expect(result.content).toContain(
+      ' * Chain relations with defineSchema(tables).relations((r) => ({})).'
+    );
+  });
+});

--- a/packages/kitcn/src/cli/registry/schema-ownership.test.ts
+++ b/packages/kitcn/src/cli/registry/schema-ownership.test.ts
@@ -5,6 +5,9 @@ import {
   reconcileRootSchemaOwnership,
 } from './schema-ownership';
 
+const TEXT_VALUE_IMPORT_RE =
+  /import \{[\s\S]*\btext,?[\s\S]*\} from 'kitcn\/orm';/;
+
 const createPromptAdapter = () => ({
   confirm: async () => true,
   isInteractive: () => false,
@@ -492,6 +495,27 @@ export default defineSchema(tables);
     );
     expect(result.content).not.toContain('InferSelectModel,');
     expect(result.content.match(/from ['"]kitcn\/orm['"]/g)).toHaveLength(2);
+  });
+
+  test('moves required bindings out of a whole type-only import', async () => {
+    const source = `import type { InferSelectModel, text } from "kitcn/orm";
+import * as orm from "kitcn/orm";
+
+export const tables = {};
+
+export type Value = InferSelectModel<{ value: ReturnType<typeof text> }>;
+
+export default orm.defineSchema(tables);
+`;
+
+    const result = await reconcile(source, [userUnit]);
+    expect(result.content).toContain(
+      'import type { InferSelectModel } from "kitcn/orm";'
+    );
+    expect(result.content).not.toContain(
+      'import type { InferSelectModel, text } from "kitcn/orm";'
+    );
+    expect(result.content).toMatch(TEXT_VALUE_IMPORT_RE);
   });
 
   test('adds a value import when only a namespace kitcn/orm import exists', async () => {

--- a/packages/kitcn/src/cli/registry/schema-ownership.ts
+++ b/packages/kitcn/src/cli/registry/schema-ownership.ts
@@ -1192,7 +1192,69 @@ const mergeOrmImports = (source: string, importNames: readonly string[]) => {
     return source;
   }
 
-  const sourceFile = parseSource(source);
+  const requiredNames = new Set(importNames);
+  const initialSourceFile = parseSource(source);
+  const typeOnlyReplacements = initialSourceFile.statements.flatMap(
+    (statement) => {
+      if (
+        !ts.isImportDeclaration(statement) ||
+        !isStringLiteralLike(statement.moduleSpecifier) ||
+        statement.moduleSpecifier.text !== 'kitcn/orm' ||
+        !statement.importClause?.isTypeOnly ||
+        !statement.importClause.namedBindings ||
+        !ts.isNamedImports(statement.importClause.namedBindings)
+      ) {
+        return [];
+      }
+
+      const remainingElements =
+        statement.importClause.namedBindings.elements.filter(
+          (element) => !requiredNames.has(element.name.text)
+        );
+      if (
+        remainingElements.length ===
+        statement.importClause.namedBindings.elements.length
+      ) {
+        return [];
+      }
+
+      const namedBindings =
+        remainingElements.length > 0
+          ? `{ ${remainingElements
+              .map((element) => element.getText(initialSourceFile))
+              .join(', ')} }`
+          : null;
+      const bindings = [
+        statement.importClause.name?.text,
+        namedBindings,
+      ].filter((value): value is string => Boolean(value));
+      const replacement =
+        bindings.length > 0
+          ? `import type ${bindings.join(', ')} from ${statement.moduleSpecifier.getText(initialSourceFile)};`
+          : '';
+      return [
+        {
+          end: statement.end,
+          replacement,
+          start: statement.getStart(initialSourceFile),
+        },
+      ];
+    }
+  );
+
+  let workingSource = source;
+  for (const replacement of typeOnlyReplacements.sort(
+    (a, b) => b.start - a.start
+  )) {
+    workingSource = replaceRange(
+      workingSource,
+      replacement.start,
+      replacement.end,
+      replacement.replacement
+    );
+  }
+
+  const sourceFile = parseSource(workingSource);
   // Only a named *value* import can host the generated declarations' bindings.
   // Rewriting `import type {...}` would drop the `type` modifier and duplicate
   // identifiers; rewriting `import * as orm` would drop the namespace.
@@ -1209,7 +1271,7 @@ const mergeOrmImports = (source: string, importNames: readonly string[]) => {
 
   if (!ormImport) {
     const importText = `import {\n  ${[...new Set(importNames)].sort().join(',\n  ')},\n} from 'kitcn/orm';\n\n`;
-    return `${importText}${source}`;
+    return `${importText}${workingSource}`;
   }
 
   const namedBindings = ormImport.importClause
@@ -1229,7 +1291,7 @@ const mergeOrmImports = (source: string, importNames: readonly string[]) => {
   );
   const nextImport = `import {\n  ${mergedImports.join(',\n  ')},\n} from 'kitcn/orm';`;
   return replaceRange(
-    source,
+    workingSource,
     ormImport.getStart(sourceFile),
     ormImport.end,
     nextImport

--- a/packages/kitcn/src/cli/registry/schema-ownership.ts
+++ b/packages/kitcn/src/cli/registry/schema-ownership.ts
@@ -7,6 +7,7 @@ import type {
   PromptAdapter,
 } from '../types.js';
 import { createTypeScriptProxy } from '../utils/typescript-runtime.js';
+import { findDefineSchemaChain } from './schema-chain.js';
 
 export type RootSchemaTableUnit = {
   declaration: string;
@@ -55,7 +56,6 @@ type MergeNamedEntriesResult = {
 const OBJECT_ENTRY_INDENT = '  ';
 const LEADING_INDENT_RE = /^[ \t]*/;
 const LEGACY_MANAGED_COMMENT_RE = /^[ \t]*\/\* kitcn-managed [^*]+ \*\/\n?/gm;
-const WHITESPACE_RE = /\s/;
 const ts = createTypeScriptProxy();
 let printer: tsType.Printer | null = null;
 
@@ -640,6 +640,11 @@ const mergeIndexEntries = (params: {
   const desiredParamName =
     params.desiredInfo.indexParamName ?? params.desiredInfo.varName;
   const desiredEntries = params.desiredInfo.indexEntries;
+  const unparsedThirdArgText =
+    params.existingInfo.thirdArgText && !params.existingInfo.indexEntries
+      ? params.existingInfo.thirdArgText
+      : null;
+
   if (!desiredEntries || desiredEntries.length === 0) {
     return {
       changed: false,
@@ -648,10 +653,13 @@ const mergeIndexEntries = (params: {
       ),
       indexParamName: targetParamName,
       requiresIndexArg: Boolean(params.existingInfo.thirdArgText),
+      // Nothing to merge, so keep whatever the user wrote verbatim instead of
+      // re-rendering (and dropping) an argument we cannot represent as entries.
+      verbatimIndexArgText: unparsedThirdArgText,
     };
   }
 
-  if (params.existingInfo.thirdArgText && !params.existingInfo.indexEntries) {
+  if (unparsedThirdArgText) {
     throw new Error(
       `Schema patch conflict in ${params.displayPath}: ${params.pluginKey} indexes for table "${params.tableKey}" could not be merged into the existing schema callback.`
     );
@@ -720,6 +728,7 @@ const mergeIndexEntries = (params: {
     requiresIndexArg: Boolean(
       params.existingInfo.thirdArgText ?? nextEntries.length > 0
     ),
+    verbatimIndexArgText: null as string | null,
   };
 };
 
@@ -729,14 +738,16 @@ const renderTableStatement = (params: {
   indexParamName?: string | null;
   tableNameText: string;
   varName: string;
+  verbatimIndexArgText?: string | null;
 }) => {
   const fieldsText = renderObjectLiteral(
     '  ',
     params.fieldEntries.map(ensureTrailingComma)
   );
   const indexEntries = params.indexEntries ?? [];
-  const indexBlock =
-    indexEntries.length > 0
+  const indexBlock = params.verbatimIndexArgText
+    ? `,\n  ${params.verbatimIndexArgText}`
+    : indexEntries.length > 0
       ? `,\n  (${params.indexParamName ?? params.varName}) => ${renderArrayLiteral(
           '  ',
           indexEntries
@@ -803,6 +814,7 @@ const mergeTableDeclaration = (params: {
     indexParamName: indexMerge.indexParamName,
     tableNameText: existingInfo.tableNameText,
     varName: existingInfo.varName,
+    verbatimIndexArgText: indexMerge.verbatimIndexArgText,
   });
 
   return {
@@ -864,80 +876,21 @@ const updateTablesObject = (
   );
 };
 
-const skipWhitespace = (source: string, start: number) => {
-  let cursor = start;
-  while (cursor < source.length && WHITESPACE_RE.test(source[cursor]!)) {
-    cursor += 1;
-  }
-  return cursor;
-};
-
-const findBalancedParenEnd = (source: string, openParenIndex: number) => {
-  let depth = 0;
-  for (let index = openParenIndex; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === '(') {
-      depth += 1;
-    } else if (char === ')') {
-      depth -= 1;
-      if (depth === 0) {
-        return index;
-      }
-    }
-  }
-  return -1;
-};
-
 const findRelationsInsertIndex = (source: string) => {
-  const defineSchemaIndex = source.indexOf('defineSchema(');
-  if (defineSchemaIndex < 0) {
+  const chain = findDefineSchemaChain(source);
+  if (!chain) {
     return -1;
   }
 
-  const defineSchemaOpenParenIndex = source.indexOf('(', defineSchemaIndex);
-  if (defineSchemaOpenParenIndex < 0) {
-    return -1;
+  let insertIndex = chain.defineSchemaEnd;
+  for (const call of chain.calls) {
+    if (call.name !== 'extend') {
+      return call.dotIndex;
+    }
+    insertIndex = call.end;
   }
 
-  const defineSchemaCloseParenIndex = findBalancedParenEnd(
-    source,
-    defineSchemaOpenParenIndex
-  );
-  if (defineSchemaCloseParenIndex < 0) {
-    return -1;
-  }
-
-  let cursor = defineSchemaCloseParenIndex + 1;
-  while (cursor < source.length) {
-    const nextSegmentIndex = skipWhitespace(source, cursor);
-
-    if (source.startsWith('.relations(', nextSegmentIndex)) {
-      return nextSegmentIndex;
-    }
-    if (source.startsWith('.triggers(', nextSegmentIndex)) {
-      return nextSegmentIndex;
-    }
-    if (!source.startsWith('.extend(', nextSegmentIndex)) {
-      return nextSegmentIndex;
-    }
-
-    const extendOpenParenIndex = source.indexOf('(', nextSegmentIndex);
-    if (extendOpenParenIndex < 0) {
-      return -1;
-    }
-
-    const extendCloseParenIndex = findBalancedParenEnd(
-      source,
-      extendOpenParenIndex
-    );
-    if (extendCloseParenIndex < 0) {
-      return -1;
-    }
-
-    cursor = extendCloseParenIndex + 1;
-  }
-
-  return cursor;
+  return insertIndex;
 };
 
 const mergeRelationProperty = (params: {
@@ -1240,11 +1193,18 @@ const mergeOrmImports = (source: string, importNames: readonly string[]) => {
   }
 
   const sourceFile = parseSource(source);
+  // Only a named *value* import can host the generated declarations' bindings.
+  // Rewriting `import type {...}` would drop the `type` modifier and duplicate
+  // identifiers; rewriting `import * as orm` would drop the namespace.
   const ormImport = sourceFile.statements.find(
     (statement): statement is tsType.ImportDeclaration =>
       ts.isImportDeclaration(statement) &&
       isStringLiteralLike(statement.moduleSpecifier) &&
-      statement.moduleSpecifier.text === 'kitcn/orm'
+      statement.moduleSpecifier.text === 'kitcn/orm' &&
+      statement.importClause !== undefined &&
+      !statement.importClause.isTypeOnly &&
+      statement.importClause.namedBindings !== undefined &&
+      ts.isNamedImports(statement.importClause.namedBindings)
   );
 
   if (!ormImport) {
@@ -1252,18 +1212,20 @@ const mergeOrmImports = (source: string, importNames: readonly string[]) => {
     return `${importText}${source}`;
   }
 
-  if (
-    !ormImport.importClause?.namedBindings ||
-    !ts.isNamedImports(ormImport.importClause.namedBindings)
-  ) {
-    return source;
+  const namedBindings = ormImport.importClause
+    ?.namedBindings as tsType.NamedImports;
+  const specifiersByLocalName = new Map<string, string>();
+  for (const element of namedBindings.elements) {
+    specifiersByLocalName.set(element.name.text, element.getText(sourceFile));
+  }
+  // A generated declaration needs the value binding, so an inline `type X`
+  // specifier has to collapse into the plain name rather than coexist with it.
+  for (const name of importNames) {
+    specifiersByLocalName.set(name, name);
   }
 
-  const existingImports = ormImport.importClause.namedBindings.elements.map(
-    (element) => element.getText(sourceFile)
-  );
-  const mergedImports = [...new Set([...existingImports, ...importNames])].sort(
-    (a, b) => a.localeCompare(b)
+  const mergedImports = [...specifiersByLocalName.values()].sort((a, b) =>
+    a.localeCompare(b)
   );
   const nextImport = `import {\n  ${mergedImports.join(',\n  ')},\n} from 'kitcn/orm';`;
   return replaceRange(

--- a/packages/kitcn/src/cli/watcher.ts
+++ b/packages/kitcn/src/cli/watcher.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PARSE_SNAPSHOT_SUFFIX } from '../shared/meta-utils.js';
 import {
   resolveConfiguredBackend,
   resolveRunDeps,
@@ -134,7 +135,7 @@ export function shouldIgnoreWatchPath(
 
   return (
     normalizedPath.endsWith('.runtime.ts') ||
-    normalizedPath.endsWith('.kitcn-parse.ts')
+    normalizedPath.endsWith(PARSE_SNAPSHOT_SUFFIX)
   );
 }
 

--- a/packages/kitcn/src/package-intent.test.ts
+++ b/packages/kitcn/src/package-intent.test.ts
@@ -303,7 +303,7 @@ describe('package intent metadata', () => {
       const backendCoreSource = new TextDecoder().decode(extract.stdout);
 
       expect(backendCoreSource).toContain('getProjectServerParserShimPath');
-      expect(backendCoreSource).toContain('kitcn-parse.ts');
+      expect(backendCoreSource).toContain('evalModule');
       expect(backendCoreSource).toContain('kitcn/server');
       expect(backendCoreSource).toContain('tryNative: false');
     } finally {

--- a/packages/kitcn/src/shared/meta-utils.ts
+++ b/packages/kitcn/src/shared/meta-utils.ts
@@ -127,6 +127,13 @@ export function buildMetaIndex(api: Record<string, unknown>): Meta {
   return meta;
 }
 
+/**
+ * Suffix codegen appends to its throwaway parse snapshots. Snapshots live next
+ * to the module they mirror so relative imports still resolve, so every reader
+ * of the Convex functions directory must ignore them.
+ */
+export const PARSE_SNAPSHOT_SUFFIX = '.kitcn-parse.ts';
+
 /** Files to exclude from meta generation */
 const EXCLUDED_FILES = new Set([
   'schema.ts',
@@ -148,6 +155,7 @@ const DIRECT_CODEGEN_META_CAPTURE_REGEX = /\b_crpc(?:Meta|HttpRoute)\b/;
  * Filters out private files/directories (prefixed with _) and config files.
  */
 export function isValidConvexFile(file: string): boolean {
+  if (file.endsWith(PARSE_SNAPSHOT_SUFFIX)) return false;
   if (file.endsWith('.runtime.ts')) return false;
   if (file.endsWith('.test.ts')) return false;
   if (file.endsWith('.spec.ts')) return false;

--- a/packages/kitcn/src/shared/meta-utils.ts
+++ b/packages/kitcn/src/shared/meta-utils.ts
@@ -128,9 +128,11 @@ export function buildMetaIndex(api: Record<string, unknown>): Meta {
 }
 
 /**
- * Suffix codegen appends to its throwaway parse snapshots. Snapshots live next
- * to the module they mirror so relative imports still resolve, so every reader
- * of the Convex functions directory must ignore them.
+ * Suffix of a parse snapshot — a mirror of a Convex module that kitcn builds
+ * predating in-memory evaluation could strand in a project. Codegen writes no
+ * snapshot, so this exists only so readers of the Convex functions directory
+ * skip a stranded file rather than parse it as a real module. Nothing deletes
+ * one: kitcn cannot prove it owns a file it did not write.
  */
 export const PARSE_SNAPSHOT_SUFFIX = '.kitcn-parse.ts';
 

--- a/www/content/docs/cli/registry.mdx
+++ b/www/content/docs/cli/registry.mdx
@@ -227,6 +227,17 @@ patches the supported frontend shell in place, but it stays conservative:
 | `--no-codegen` | Skip automatic codegen after add |
 | `--preset <name>` | Plugin preset override |
 
+### Files you edited
+
+`add` never replaces a scaffold file whose contents differ from the scaffold it
+wrote. Such a file is kept and listed under `Refused files`, and the command
+exits `1` because the plugin is only partially installed. Re-run with
+`--overwrite` to replace it, or merge the change yourself.
+
+With `--json`, `skipped` lists files that were already up to date, `refused`
+lists files kept because they were edited, and `complete` is `false` whenever
+anything was refused.
+
 ## view
 
 Use `view` when you want the resolved plugin plan without writing files.


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

`kitcn add` now fails closed for user-owned scaffold files. It writes silently only when the on-disk content matches a managed baseline; `--overwrite` remains the explicit escape hatch. Refusals are separate from skipped files, appear in `--json`, and make `add` exit 1. `init` deliberately keeps exit 0 when it leaves existing project files alone.

The same source-owned planner repairs schema editing with TypeScript AST positions: comment text cannot divert `defineSchema` registration, block-bodied index callbacks keep their indexes, and required runtime bindings move out of whole type-only `kitcn/orm` imports without duplicating identifiers. Codegen parsing is in memory, so a failed parse cannot leave a snapshot that wedges later runs.

Review fixes:

- Anchor chained schema insertion to the AST `DotToken`, including sentence comments containing periods.
- Preserve unrelated type bindings while moving required runtime bindings out of whole type-only imports.

Proof:

- 31 focused planner/schema-ownership tests pass.
- 124 CLI tests pass with 865 assertions.
- Package build, root typecheck, fixture sync/check, package-skill mirror comparison, Intent validation/staleness, deslop, agent-native review, and final autoreview pass.
- Exact final-tree `bun check` passes, including all generated fixtures and runtime scenarios.
- `.changeset/cli-safe-file-edits.md` records a minor `kitcn` release.
