### PR TITLE
fix(cli): codegen emits only the api type imports a runtime uses

### DIFF
--- a/.changeset/codegen-unused-api-imports.md
+++ b/.changeset/codegen-unused-api-imports.md
@@ -1,0 +1,12 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `kitcn codegen` emitting both the `api` and `internal` type imports into
+  generated runtime files that only reference one of them. A module whose
+  procedures are all internal, or all public, no longer carries an unused import
+  that editors grey out and that `tsc` rejects with `TS6196` when
+  `noUnusedLocals` is enabled. Each generated runtime now imports only the api
+  roots its procedures reference.

--- a/convex/generated/server.runtime.ts
+++ b/convex/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/docs/plans/2026-08-15-pr-324-326-autoclosure-batch.md
+++ b/docs/plans/2026-08-15-pr-324-326-autoclosure-batch.md
@@ -1,0 +1,153 @@
+# PR 324 326 autoclosure batch
+
+Objective:
+Merge PRs #324 and #326 in that order; done when both are merged, #326 triggers
+one release, and GitHub/npm/post-release checks are green.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-08-15-pr-324-326-autoclosure-batch.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- [PR #324 autoclosure](docs/plans/2026-08-15-pr-324-autoclosure.md) - owns codegen fix closeout.
+- [PR #326 autoclosure](docs/plans/2026-08-15-pr-326-autoclosure.md) - owns CRPC error fix and release closeout.
+
+Completion threshold:
+- PRs #324 and #326 merged from reviewed head commits with all required checks green.
+- Exactly one release is triggered from final PR #326; GitHub release, npm latest
+  for affected packages, and post-release CI are verified.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Each linked child plan owns targeted proof, source/generated audit, reviews,
+  `bun check`, PR read-back, and merge receipt.
+- Root proof is live GitHub PR/release state plus npm latest and post-release CI.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: existing PR #324 codegen import fix and PR #326 CRPC error fix
+- allowed repairs: only actionable review/check/rebase findings inside either PR scope
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new product behavior, unrelated cleanup, extra release triggers
+
+Output budget strategy:
+- Query exact PRs/files/threads; cap logs and command output; save large check
+  output rather than streaming it.
+
+Blocked condition:
+- Stop only for an unresolvable protected-branch/release permission failure,
+  repeated CI infrastructure failure, or a scope-changing repair.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | Live PR bodies, files, commits, checks, and prior batch receipts read. |
+| Intended delta and exclusions recorded | yes | Boundaries above. |
+| Closure matrix classified | yes | Matrix below; child plans own lane detail. |
+| GitHub delivery expectation recorded | yes | Merge both; release only from final #326. |
+| Active goal checked or created | yes | `get_goal`: no active goal; this shell is ready for creation. |
+| Agent-native pack selected | yes | Materialized because autoclosure requires the pack. |
+| Agent-facing action surface identified | no | N/A: neither PR changes agent behavior. |
+| Source rule versus generated mirror boundary identified | no | N/A: neither PR changes agent rules/skills. |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no installed skill changes. |
+| `agent-native-reviewer` loaded or waiver recorded | no | N/A: no agent-native delta; child plans record the same waiver. |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Child #324 and #326 focused proofs | pending |
+| package/API/build | yes | Both touch `packages/kitcn`; build/check in children | pending |
+| generated output | yes | #324 owns generated runtime audit; #326 N/A | pending |
+| fixtures/scenarios | yes | #324 owns fixture generation/check; #326 N/A | pending |
+| docs/package skill | yes | #324 docs touched; package skill N/A unless audit finds drift | pending |
+| changeset | yes | Both PRs contain patch changesets | pending |
+| agent workflow | no | N/A: no agent surface changes | complete |
+| cleanup/review | yes | deslop + autoreview per child | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | merge #324 then #326; one release | pending |
+
+Work Checklist:
+- [ ] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [ ] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
+| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
+| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
+| Deslop | pending | Run bounded cleanup or N/A | pending |
+| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-324-326-autoclosure-batch.md` | pending |
+| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
+| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
+| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
+| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
+| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | complete | two open PRs; order #324 then #326 | child #324 |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- Pending.
+
+Timeline:
+- 2026-08-15T19:03:53.708Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge #324 then #326 and publish one verified release. |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- #324 may need regeneration/rebase after current main; #326 release remains
+  disabled until it is the final ready merge.

--- a/docs/plans/2026-08-15-pr-324-autoclosure.md
+++ b/docs/plans/2026-08-15-pr-324-autoclosure.md
@@ -1,0 +1,162 @@
+# PR 324 autoclosure
+
+Objective:
+Autoclose PR #324; done when the codegen import fix is source-backed,
+regenerated, reviewed, checked, merged, and remotely read back.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-08-15-pr-324-autoclosure.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- PR #324 merged from the reviewed head with targeted codegen tests, fixture
+  generation checks, package build, lint, `bun check`, and GitHub checks green.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- `packages/kitcn` codegen tests/build, fixture sync/check, source/generated
+  import audit, deslop, autoreview, `bun check`, PR checks and merge receipt.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: emit only used `api`/`internal` generated type imports
+- allowed repairs: source/template/generated/docs/test/changeset fixes required by review
+- unrelated files: preserve; do not treat as blockers
+- non-goals: unrelated CLI/codegen features or release trigger
+
+Output budget strategy:
+- Read exact changed files and focused tests; cap full-check output to saved logs.
+
+Blocked condition:
+- Stop only for repeated infrastructure failure, missing merge authority, or a
+  repair that changes the accepted issue scope.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR #324 body/files/head/checks read at `d42e7246`. |
+| Intended delta and exclusions recorded | yes | Boundaries above. |
+| Closure matrix classified | yes | Matrix below. |
+| GitHub delivery expectation recorded | yes | Merge after all local/remote gates; no release. |
+| Active goal checked or created | yes | Root batch goal owns this linked plan. |
+| Agent-native pack selected | yes | Materialized by autoclosure requirement. |
+| Agent-facing action surface identified | no | N/A: no agent action changes. |
+| Source rule versus generated mirror boundary identified | no | N/A: generated runtimes are product output, not agent mirrors. |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill install changes. |
+| `agent-native-reviewer` loaded or waiver recorded | no | N/A: no agent-native delta. |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | Focused public/internal/mixed codegen test: 1 pass, 0 fail | complete |
+| package/API/build | yes | `bun --cwd packages/kitcn build`: pass | complete |
+| generated output | yes | 15 runtimes audited; 0 missing or unused roots | complete |
+| fixtures/scenarios | yes | `fixtures:sync` and `fixtures:check`: all 8 variants pass | complete |
+| docs/package skill | yes | Internal solution doc aligned; N/A published skill because no user workflow changed | complete |
+| changeset | yes | Patch changeset matches the CLI behavior | complete |
+| agent workflow | no | N/A: no agent surface changes | complete |
+| cleanup/review | yes | slop delta 0; autoreview clean at 0.99 | complete |
+| repository check | yes | `bun check`: pass | complete |
+| GitHub delivery | yes | update/push/read back/merge #324 | pending |
+
+Work Checklist:
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [x] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output was changed through its owner and regenerated.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner: none.
+- [x] Agent-native pack: N/A, no agent rule or generated skill mirror changed.
+- [x] Agent-native pack: N/A, no changed agent action.
+- [x] Agent-native pack: N/A, no `.agents/rules/**` change.
+- [x] Agent-native pack: N/A, no installed skill changed; installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [x] Agent-native pack: N/A, no agent workflow behavior to evaluate.
+- [x] Agent-native pack: N/A, no agent-native review findings.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | yes | Run smallest missing owning proof | Focused codegen test: 1 pass, 0 fail |
+| Source/generated audit | yes | Prove correct source and regenerated mirrors | `fixtures:sync`; 15 runtime audit with 0 bad files |
+| Package/docs/scenario closure | yes | Run every applicable local contract | Package build and all fixture sync/check variants pass |
+| Deslop | yes | Run bounded cleanup or N/A | `bun run lint:slop:delta`: 0 occurrence changes |
+| Agent-native reviewer | no | Run for workflow changes or N/A | N/A: no agent workflow change |
+| Final lint | yes | Run `bun lint:fix` | 882 files checked; no fixes |
+| Repository check | yes | Run `bun check` | Pass: CI, verify, and runtime lanes |
+| GitHub delivery | yes | Commit/push/open or update PR and read back | pending push/checks/merge |
+| Autoreview | yes | Resolve every accepted actionable finding | Codex Sol: clean, 0 actionable findings, 0.99 |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-324-autoclosure.md` | pending |
+| Agent source / generated sync | no | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | N/A: no agent rule change |
+| Installed lock audit | no | Verify expected lock entries and removed skills through CLI-managed state | N/A: no installed skill change |
+| Agent action discoverability | no | Source-audit the skill/rule path an agent will read | N/A: no agent action change |
+| Helper and template smoke | no | Syntax-check helpers and prove incomplete failure/completed representation when applicable | N/A: no helper/template change |
+| Agent-native review | no | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | N/A: no agent-native delta |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | complete | PR body/files/head/checks reconstructed | checkout/rebase |
+| Repair | complete | No repairs required after source audit/feedback triage | review |
+| Review/checks | complete | focused proof, build, fixtures, deslop, lint, autoreview, `bun check` pass | delivery |
+| Delivery | in_progress | local closure ready | push/checks/merge |
+| Closeout | pending | | final |
+
+Verification evidence:
+- `get-pr-comments 324`: 0 threads, 0 review bodies, only changeset bot metadata.
+- Focused codegen behavior test: 1 pass, 62 filtered, 0 fail.
+- `bun --cwd packages/kitcn build`: pass.
+- `fixtures:sync`: pass with no new tracked drift.
+- `fixtures:check`: all 8 variants match fresh output.
+- Generated API root audit: 15 runtime files, 0 bad imports/usages.
+- `bun run lint:slop:delta`: 0 added/worsened occurrences.
+- Autoreview Codex Sol/high: clean, 0 actionable findings, 0.99.
+- `bun lint:fix`: 882 files checked, no fixes.
+- `bun check`: pass through check:ci, test:verify, and test:runtime.
+
+Review fixes:
+- No actionable GitHub or autoreview findings; no code repair required.
+
+Timeline:
+- 2026-08-15T19:04:01.990Z Autoclosure plan created.
+- 2026-08-15 Source/issue/feedback reconstructed; zero actionable feedback.
+- 2026-08-15 Targeted, generated, fixture, review, lint, and full check gates passed.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Delivery |
+| Where am I going? | Push, remote checks, merge, final audit |
+| What is the goal? | Merge PR #324 with complete codegen proof. |
+| What have I learned? | Source implementation and 15 generated runtimes match the issue invariant. |
+| What have I done? | Closed every local proof/review gate without code repairs. |
+
+Open risks:
+- Remote checks must rerun after adding closeout plans; merge receipt will be
+  recorded on the following #326 branch.

--- a/docs/plans/2026-08-15-pr-326-autoclosure.md
+++ b/docs/plans/2026-08-15-pr-326-autoclosure.md
@@ -1,0 +1,149 @@
+# PR 326 autoclosure
+
+Objective:
+Autoclose PR #326; done when CRPC error payload preservation is reviewed,
+checked, merged, and its single release is verified through npm and CI.
+
+Flow mode:
+one-shot execution
+
+Goal plan:
+docs/plans/2026-08-15-pr-326-autoclosure.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Linked plans:
+- None.
+
+Completion threshold:
+- PR #326 merged from the reviewed head with V8 regression proof, package
+  build, lint, `bun check`, remote checks green, then one release published and
+  post-release CI green.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- Node/V8 error tests, package build, deslop, autoreview, `bun check`, PR checks,
+  GitHub release/npm latest/post-release CI.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: preserve Convex error payloads by not overwriting converted stacks
+- allowed repairs: error conversion tests/source/changeset fixes required by review
+- unrelated files: preserve; do not treat as blockers
+- non-goals: unrelated error API changes or additional release triggers
+
+Output budget strategy:
+- Read exact error files and focused tests; cap full-check/release output.
+
+Blocked condition:
+- Stop only for repeated infrastructure failure, missing merge/release authority,
+  or a repair that changes the accepted issue scope.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Active source/plan reconstructed | yes | PR #326 body/files/head/checks read at `43e1694d`. |
+| Intended delta and exclusions recorded | yes | Boundaries above. |
+| Closure matrix classified | yes | Matrix below. |
+| GitHub delivery expectation recorded | yes | Final merge owns the one batch release. |
+| Active goal checked or created | yes | Root batch goal owns this linked plan. |
+| Agent-native pack selected | yes | Materialized by autoclosure requirement. |
+| Agent-facing action surface identified | no | N/A: no agent action changes. |
+| Source rule versus generated mirror boundary identified | no | N/A: no agent mirrors. |
+| Installed-skill lock versus local-rule owner identified | no | N/A: no skill install changes. |
+| `agent-native-reviewer` loaded or waiver recorded | no | N/A: no agent-native delta. |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| source behavior | yes | V8 regression tests and error unit tests | pending |
+| package/API/build | yes | `bun --cwd packages/kitcn build` | pending |
+| generated output | no | N/A: no generated output | complete |
+| fixtures/scenarios | no | N/A: no fixture/scenario change | complete |
+| docs/package skill | no | N/A: no docs or published skill change | complete |
+| changeset | yes | `.changeset/crpc-error-payload-to-client.md` | pending |
+| agent workflow | no | N/A: no agent surface changes | complete |
+| cleanup/review | yes | deslop + autoreview | pending |
+| repository check | yes | `bun check` | pending |
+| GitHub delivery | yes | update/push/read back/merge/release #326 | pending |
+
+Work Checklist:
+- [ ] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [ ] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| None yet | 0 | | |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
+| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
+| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
+| Deslop | pending | Run bounded cleanup or N/A | pending |
+| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-326-autoclosure.md` | pending |
+| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
+| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
+| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
+| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
+| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | complete | PR body/files/head/checks reconstructed | checkout/rebase |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- Pending.
+
+Timeline:
+- 2026-08-15T19:04:02.015Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Merge PR #326 and verify one release. |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- V8-only regression proof must remain in the Vitest lane after rebase.

--- a/docs/solutions/build-errors/generated-runtime-must-type-from-generated-api-contracts-20260325.md
+++ b/docs/solutions/build-errors/generated-runtime-must-type-from-generated-api-contracts-20260325.md
@@ -63,10 +63,7 @@ Type runtime refs from the app's generated Convex API surface instead of the
 source module export:
 
 ```ts
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from "../_generated/api";
+import type { api as generatedApi } from "../_generated/api";
 
 createGeneratedFunctionReference<
   "query",

--- a/example/convex/functions/generated/plugins/resend.runtime.ts
+++ b/example/convex/functions/generated/plugins/resend.runtime.ts
@@ -10,10 +10,7 @@ import {
   type GeneratedRegistryCallerForContext,
   type GeneratedRegistryHandlerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../../_generated/api';
+import type { internal as generatedInternal } from '../../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from '../server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/example/convex/functions/generated/server.runtime.ts
+++ b/example/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/example/convex/functions/generated/todoInternal.runtime.ts
+++ b/example/convex/functions/generated/todoInternal.runtime.ts
@@ -10,10 +10,7 @@ import {
   type GeneratedRegistryCallerForContext,
   type GeneratedRegistryHandlerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/expo-auth/convex/functions/generated/server.runtime.ts
+++ b/fixtures/expo-auth/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/expo/convex/functions/generated/server.runtime.ts
+++ b/fixtures/expo/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/next-auth/convex/functions/generated/server.runtime.ts
+++ b/fixtures/next-auth/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/next/convex/functions/generated/server.runtime.ts
+++ b/fixtures/next/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/start-auth/convex/functions/generated/server.runtime.ts
+++ b/fixtures/start-auth/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/start/convex/functions/generated/server.runtime.ts
+++ b/fixtures/start/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/vite-auth/convex/functions/generated/server.runtime.ts
+++ b/fixtures/vite-auth/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/fixtures/vite/convex/functions/generated/server.runtime.ts
+++ b/fixtures/vite/convex/functions/generated/server.runtime.ts
@@ -9,10 +9,7 @@ import {
   typedProcedureResolver,
   type GeneratedRegistryCallerForContext,
 } from 'kitcn/server';
-import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '../_generated/api';
+import type { internal as generatedInternal } from '../_generated/api';
 import type { ActionCtx, MutationCtx, QueryCtx } from './server';
 import type { OrmTriggerContext } from 'kitcn/orm';
 

--- a/packages/kitcn/src/cli/codegen.test.ts
+++ b/packages/kitcn/src/cli/codegen.test.ts
@@ -295,9 +295,8 @@ describe('cli/codegen', () => {
       expect(moduleRuntime).toContain('createGeneratedFunctionReference,');
       expect(moduleRuntime).not.toContain('getGeneratedFunctionReference(');
       expect(moduleRuntime).not.toContain('_generated/api.js');
-      expect(moduleRuntime).not.toContain(
-        "import type {\n  api as generatedApi,\n  internal as generatedInternal,\n} from '../_generated/api';"
-      );
+      expect(moduleRuntime).not.toContain('generatedApi');
+      expect(moduleRuntime).not.toContain('generatedInternal');
       expect(moduleRuntime).toContain(
         'createGeneratedFunctionReference<"query", "public", typeof import("../../items/queries").list>("items/queries:list")'
       );
@@ -1229,7 +1228,7 @@ describe('cli/codegen', () => {
       const runtimeGenerated = fs.readFileSync(runtimeFile, 'utf-8');
 
       expect(runtimeGenerated).toContain(
-        "import type {\n  api as generatedApi,\n  internal as generatedInternal,\n} from '../_generated/api';"
+        "import type { api as generatedApi } from '../_generated/api';"
       );
       expect(runtimeGenerated).toContain(
         'createGeneratedFunctionReference<"query", "public", typeof generatedApi["foo"]["detail"]>("foo:detail")'
@@ -1239,6 +1238,73 @@ describe('cli/codegen', () => {
       );
       expect(runtimeGenerated).not.toContain('typeof import("../foo").detail');
       expect(runtimeGenerated).not.toContain('typeof import("../foo").list');
+    } finally {
+      process.chdir(oldCwd);
+    }
+  });
+
+  test('generateMeta only imports the generated api roots a module actually uses', async () => {
+    const dir = mkTempDir();
+    const oldCwd = process.cwd();
+
+    process.chdir(dir);
+    try {
+      writeScopedFixture(dir);
+      writeFile(
+        path.join(dir, 'convex', 'pub.ts'),
+        `
+        import { createPubHandler } from './generated/pub.runtime';
+        void createPubHandler;
+
+        export const list = { _crpcMeta: { type: 'query' } };
+        export const detail = { _crpcMeta: { type: 'query' } };
+        `.trim()
+      );
+      writeFile(
+        path.join(dir, 'convex', 'priv.ts'),
+        `
+        import { createPrivHandler } from './generated/priv.runtime';
+        void createPrivHandler;
+
+        export const sweep = { _crpcMeta: { type: 'mutation', internal: true } };
+        export const purge = { _crpcMeta: { type: 'mutation', internal: true } };
+        `.trim()
+      );
+      writeFile(
+        path.join(dir, 'convex', 'mixed.ts'),
+        `
+        import { createMixedHandler } from './generated/mixed.runtime';
+        void createMixedHandler;
+
+        export const list = { _crpcMeta: { type: 'query' } };
+        export const sweep = { _crpcMeta: { type: 'mutation', internal: true } };
+        `.trim()
+      );
+
+      await generateMeta(undefined, { silent: true });
+
+      const readRuntime = (moduleName: string) =>
+        fs.readFileSync(
+          path.join(dir, 'convex', 'generated', `${moduleName}.runtime.ts`),
+          'utf-8'
+        );
+
+      const pubRuntime = readRuntime('pub');
+      expect(pubRuntime).toContain(
+        "import type { api as generatedApi } from '../_generated/api';"
+      );
+      expect(pubRuntime).not.toContain('generatedInternal');
+
+      const privRuntime = readRuntime('priv');
+      expect(privRuntime).toContain(
+        "import type { internal as generatedInternal } from '../_generated/api';"
+      );
+      expect(privRuntime).not.toContain('generatedApi');
+
+      const mixedRuntime = readRuntime('mixed');
+      expect(mixedRuntime).toContain(
+        "import type {\n  api as generatedApi,\n  internal as generatedInternal,\n} from '../_generated/api';"
+      );
     } finally {
       process.chdir(oldCwd);
     }

--- a/packages/kitcn/src/cli/codegen.ts
+++ b/packages/kitcn/src/cli/codegen.ts
@@ -1215,6 +1215,31 @@ export function defineMigration(
 `;
 }
 
+function renderRuntimeApiTypesImport(
+  entries: ProcedureRegistryEntry[],
+  importPath: string
+): string {
+  const specifiers: string[] = [];
+
+  if (entries.some((entry) => !entry.internal)) {
+    specifiers.push('api as generatedApi');
+  }
+  if (entries.some((entry) => entry.internal)) {
+    specifiers.push('internal as generatedInternal');
+  }
+
+  if (specifiers.length === 0) {
+    return '';
+  }
+  if (specifiers.length === 1) {
+    return `import type { ${specifiers[0]} } from '${importPath}';\n`;
+  }
+
+  return `import type {\n${specifiers
+    .map((specifier) => `  ${specifier},\n`)
+    .join('')}} from '${importPath}';\n`;
+}
+
 function emitGeneratedModuleRuntimeFile(
   outputFile: string,
   functionsDir: string,
@@ -1244,6 +1269,11 @@ function emitGeneratedModuleRuntimeFile(
   );
   const { callerEntries, handlerEntries } =
     partitionRuntimeEntriesForEmission(procedureEntries);
+  // Handler entries are a subset of caller entries, so caller entries alone
+  // decide which generated api roots the emitted registries reference.
+  const runtimeApiTypesImport = runtimeApiTypesImportPath
+    ? renderRuntimeApiTypesImport(callerEntries, runtimeApiTypesImportPath)
+    : '';
   const callerRegistryLines = emitProcedureRegistryEntries(
     callerEntries,
     outputFile,
@@ -1326,15 +1356,7 @@ import {
     hasHandlerRegistry ? '\n  type GeneratedRegistryHandlerForContext,' : ''
   }
 } from 'kitcn/server';
-${
-  runtimeApiTypesImportPath
-    ? `import type {
-  api as generatedApi,
-  internal as generatedInternal,
-} from '${runtimeApiTypesImportPath}';
-`
-    : ''
-}import type { ActionCtx, MutationCtx, QueryCtx } from '${generatedServerImportPath}';
+${runtimeApiTypesImport}import type { ActionCtx, MutationCtx, QueryCtx } from '${generatedServerImportPath}';
 import type { OrmTriggerContext } from 'kitcn/orm';
 
 const procedureRegistry = {${callerRegistryBody}} as const;


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

Fixes #295

`kitcn codegen` emitted both the `api` and `internal` type imports into every generated runtime that types from the Convex generated API, so an all-internal or all-public module carried an unused import — greyed out in editors, and a `TS6196` error under `noUnusedLocals`. A new `renderRuntimeApiTypesImport` helper emits only the specifiers a module's procedure entries reference, and the diff also carries a codegen test (all-public / all-internal / mixed), 12 regenerated runtime artifacts across `convex/`, `example/`, and `fixtures/`, a docs snippet trim, and a patch changeset.

Proof:

- Full `bun check` green: lint, forced `turbo typecheck` (0 cached), 1095 bun + 718 vitest tests, 124 CLI tests, concave smoke, `fixtures:check`, `test:verify`, `test:runtime`.
- All 15 tracked runtimes that type from the generated API verified consistent — emitted specifiers match usage exactly, with no use-without-import or import-without-use; the three genuinely mixed `example` modules (`organization`, `ratelimitDemo`, `seed`) still need both roots and are correctly untouched.
