### PR TITLE
fix(crpc): stop overwriting err.stack, which dropped error payloads

### DIFF
--- a/.changeset/crpc-error-payload-to-client.md
+++ b/.changeset/crpc-error-payload-to-client.md
@@ -1,0 +1,35 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `CRPCError` reaching the client as a bare `Error` with the message
+  redacted to `Server Error` and `error.data` undefined. Errors converted by
+  cRPC — a procedure calling another procedure through a caller, an ORM
+  not-found, a Better Auth `APIError`, or any error wrapped by
+  `getCRPCErrorFromUnknown` — now arrive as a `ConvexError` carrying the
+  original `code`, `message`, and custom `data`.
+
+  ```ts
+  // convex/functions/payment.ts — internal procedure
+  throw new CRPCError({
+    code: 'BAD_REQUEST',
+    message: 'Declined: INSUFFICIENT_FUNDS',
+    data: { processorCode },
+  });
+
+  // Before — the public procedure delegating to it lost the reason
+  onError: (error) => {
+    error.data; // undefined
+  };
+
+  // After
+  onError: (error) => {
+    error.data; // { code: 'BAD_REQUEST', message: 'Declined: …', processorCode }
+  };
+  ```
+
+- Fix converted errors losing every source-mapped frame in Convex dashboard
+  logs. Traces carry frames again; the original throw site stays on
+  `error.cause`.

--- a/docs/plans/2026-08-15-pr-324-autoclosure.md
+++ b/docs/plans/2026-08-15-pr-324-autoclosure.md
@@ -77,7 +77,7 @@ Closure matrix:
 | agent workflow | no | N/A: no agent surface changes | complete |
 | cleanup/review | yes | slop delta 0; autoreview clean at 0.99 | complete |
 | repository check | yes | `bun check`: pass | complete |
-| GitHub delivery | yes | update/push/read back/merge #324 | pending |
+| GitHub delivery | yes | #324 merged at `0536f17b`; CI `31903574332` and Vercel green | complete |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
@@ -85,7 +85,7 @@ Work Checklist:
 - [x] Generated output was changed through its owner and regenerated.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
 - [x] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
+- [x] PR body and check state match the final evidence: merged head `90d61db6`, all required checks green.
 - [x] Residual blocker/waiver has exact evidence and next owner: none.
 - [x] Agent-native pack: N/A, no agent rule or generated skill mirror changed.
 - [x] Agent-native pack: N/A, no changed agent action.
@@ -110,9 +110,9 @@ Completion Gates:
 | Agent-native reviewer | no | Run for workflow changes or N/A | N/A: no agent workflow change |
 | Final lint | yes | Run `bun lint:fix` | 882 files checked; no fixes |
 | Repository check | yes | Run `bun check` | Pass: CI, verify, and runtime lanes |
-| GitHub delivery | yes | Commit/push/open or update PR and read back | pending push/checks/merge |
+| GitHub delivery | yes | Commit/push/open or update PR and read back | #324 merged 2026-08-15T19:27:28Z at `0536f17b` |
 | Autoreview | yes | Resolve every accepted actionable finding | Codex Sol: clean, 0 actionable findings, 0.99 |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-324-autoclosure.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-324-autoclosure.md` | pass recorded after final receipt |
 | Agent source / generated sync | no | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | N/A: no agent rule change |
 | Installed lock audit | no | Verify expected lock entries and removed skills through CLI-managed state | N/A: no installed skill change |
 | Agent action discoverability | no | Source-audit the skill/rule path an agent will read | N/A: no agent action change |
@@ -125,8 +125,8 @@ Phase / pass table:
 | Inventory | complete | PR body/files/head/checks reconstructed | checkout/rebase |
 | Repair | complete | No repairs required after source audit/feedback triage | review |
 | Review/checks | complete | focused proof, build, fixtures, deslop, lint, autoreview, `bun check` pass | delivery |
-| Delivery | in_progress | local closure ready | push/checks/merge |
-| Closeout | pending | | final |
+| Delivery | complete | pushed `90d61db6`; CI/Vercel green; merged `0536f17b` | final audit |
+| Closeout | complete | remote read-back recorded; checker pass required below | done |
 
 Verification evidence:
 - `get-pr-comments 324`: 0 threads, 0 review bodies, only changeset bot metadata.
@@ -139,6 +139,8 @@ Verification evidence:
 - Autoreview Codex Sol/high: clean, 0 actionable findings, 0.99.
 - `bun lint:fix`: 882 files checked, no fixes.
 - `bun check`: pass through check:ci, test:verify, and test:runtime.
+- GitHub read-back: #324 `MERGED`; head `90d61db6`; merge `0536f17b`;
+  CI run `31903574332` success in 7m50s; Vercel success.
 
 Review fixes:
 - No actionable GitHub or autoreview findings; no code repair required.
@@ -147,16 +149,16 @@ Timeline:
 - 2026-08-15T19:04:01.990Z Autoclosure plan created.
 - 2026-08-15 Source/issue/feedback reconstructed; zero actionable feedback.
 - 2026-08-15 Targeted, generated, fixture, review, lint, and full check gates passed.
+- 2026-08-15T19:27:28Z PR #324 merged at `0536f17b` with remote checks green.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Delivery |
-| Where am I going? | Push, remote checks, merge, final audit |
+| Where am I? | Complete |
+| Where am I going? | Parent batch continues with PR #326 |
 | What is the goal? | Merge PR #324 with complete codegen proof. |
 | What have I learned? | Source implementation and 15 generated runtimes match the issue invariant. |
-| What have I done? | Closed every local proof/review gate without code repairs. |
+| What have I done? | Closed every local/remote gate and merged #324. |
 
 Open risks:
-- Remote checks must rerun after adding closeout plans; merge receipt will be
-  recorded on the following #326 branch.
+- None.

--- a/docs/plans/2026-08-15-pr-326-autoclosure.md
+++ b/docs/plans/2026-08-15-pr-326-autoclosure.md
@@ -69,33 +69,32 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | V8 regression tests and error unit tests | pending |
-| package/API/build | yes | `bun --cwd packages/kitcn build` | pending |
+| source behavior | yes | V8: 7 pass; Bun error unit: 16 pass | complete |
+| package/API/build | yes | `bun --cwd packages/kitcn build`: pass | complete |
 | generated output | no | N/A: no generated output | complete |
 | fixtures/scenarios | no | N/A: no fixture/scenario change | complete |
 | docs/package skill | no | N/A: no docs or published skill change | complete |
-| changeset | yes | `.changeset/crpc-error-payload-to-client.md` | pending |
+| changeset | yes | Patch changeset matches client payload/stack behavior | complete |
 | agent workflow | no | N/A: no agent surface changes | complete |
 | cleanup/review | yes | deslop + autoreview | pending |
 | repository check | yes | `bun check` | pending |
 | GitHub delivery | yes | update/push/read back/merge/release #326 | pending |
 
 Work Checklist:
-- [ ] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
-- [ ] Generated output was changed through its owner and regenerated.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [x] Each lane is classified with concrete owner or N/A reason.
+- [x] Generated output: N/A, no generated file changed.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized for current local state.
 - [ ] Accepted cleanup and review findings are closed.
 - [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
-- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
-- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
-- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
-- [ ] Agent-native pack: installed skills are changed only through
+- [x] Residual blocker/waiver has exact evidence and next owner: none.
+- [x] Agent-native pack: N/A, no agent rule or generated skill mirror changed.
+- [x] Agent-native pack: N/A, no changed agent action.
+- [x] Agent-native pack: N/A, no `.agents/rules/**` change.
+- [x] Agent-native pack: N/A, no installed skill changed; installed skills are changed only through
       `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
-- [ ] Agent-native pack: routing, required receipts, placeholder failure,
-      completion representability, and forbidden behavior have eval/smoke rows.
-- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+- [x] Agent-native pack: N/A, no agent workflow behavior to evaluate.
+- [x] Agent-native pack: N/A, no agent-native review findings.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
@@ -105,45 +104,57 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
-| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
-| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
-| Deslop | pending | Run bounded cleanup or N/A | pending |
-| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
+| Targeted behavior proof | yes | Run smallest missing owning proof | V8 7/7 and Bun error 16/16 pass |
+| Source/generated audit | no | Prove correct source and regenerated mirrors | N/A: no generated output; four stack assignments removed in owner |
+| Package/docs/scenario closure | yes | Run every applicable local contract | Package build pass; changeset audited; scenarios owned by final `bun check` |
+| Deslop | yes | Run bounded cleanup or N/A | 0 added occurrences; fan-out heuristic ignored because V8 requires its own `.vitest.ts` lane |
+| Agent-native reviewer | no | Run for workflow changes or N/A | N/A: no agent workflow change |
+| Final lint | yes | Run `bun lint:fix` | 883 files checked; no fixes |
 | Repository check | yes | Run `bun check` | pending |
-| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
+| GitHub delivery | yes | Commit/push/open or update PR and read back | pending |
 | Autoreview | yes | Resolve every accepted actionable finding | pending |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-326-autoclosure.md` | pending |
-| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
-| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
-| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
-| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
-| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+| Agent source / generated sync | no | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | N/A: no agent rule change |
+| Installed lock audit | no | Verify expected lock entries and removed skills through CLI-managed state | N/A: no installed skill change |
+| Agent action discoverability | no | Source-audit the skill/rule path an agent will read | N/A: no agent action change |
+| Helper and template smoke | no | Syntax-check helpers and prove incomplete failure/completed representation when applicable | N/A: no helper/template change |
+| Agent-native review | no | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | N/A: no agent-native delta |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
 | Inventory | complete | PR body/files/head/checks reconstructed | checkout/rebase |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
+| Repair | complete | Replaced two new `any` casts with `Value`; V8 test remains 7/7 | review |
+| Review/checks | in_progress | focused tests, build, deslop, lint pass | autoreview and `bun check` |
 | Delivery | pending | | final audit |
 | Closeout | pending | | final |
 
 Verification evidence:
-- Pending.
+- `get-pr-comments 326`: 0 threads, 0 review bodies, only changeset bot metadata.
+- `bunx vitest run packages/kitcn/src/server/error.vitest.ts`: 7 pass, 0 fail, no type errors.
+- `bun test packages/kitcn/src/server/error.test.ts`: 16 pass, 0 fail.
+- `bun --cwd packages/kitcn build`: pass.
+- `bun run lint:slop:delta`: 0 added occurrences; one directory fan-out
+  heuristic ignored because the separate V8 test lane is required.
+- `bun lint:fix`: 883 files checked; no fixes.
+
+Review fixes:
+- Local standards audit found two new `any` uses in `error.vitest.ts`; accepted
+  and replaced with Convex `Value`; focused V8 proof stayed 7/7.
 
 Timeline:
 - 2026-08-15T19:04:02.015Z Autoclosure plan created.
+- 2026-08-15 Rebased onto #324 merge; source/issue/feedback reconstructed.
+- 2026-08-15 Focused tests/build/lint passed; two test-only `any` uses removed.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Review/checks |
+| Where am I going? | Autoreview, `bun check`, push, remote checks, merge, release |
 | What is the goal? | Merge PR #326 and verify one release. |
-| What have I learned? | See closure matrix |
-| What have I done? | See timeline |
+| What have I learned? | V8 lazy stack materialization is the payload-loss trigger; no GitHub feedback exists. |
+| What have I done? | Rebased, tightened types, and passed focused/package/deslop/lint gates. |
 
 Open risks:
-- V8-only regression proof must remain in the Vitest lane after rebase.
+- Remote release automation must publish exactly once after the final merge.

--- a/docs/plans/2026-08-15-pr-326-autoclosure.md
+++ b/docs/plans/2026-08-15-pr-326-autoclosure.md
@@ -76,8 +76,8 @@ Closure matrix:
 | docs/package skill | no | N/A: no docs or published skill change | complete |
 | changeset | yes | Patch changeset matches client payload/stack behavior | complete |
 | agent workflow | no | N/A: no agent surface changes | complete |
-| cleanup/review | yes | deslop + autoreview | pending |
-| repository check | yes | `bun check` | pending |
+| cleanup/review | yes | deslop bounded; autoreview clean at 0.99 | complete |
+| repository check | yes | `bun check`: pass | complete |
 | GitHub delivery | yes | update/push/read back/merge/release #326 | pending |
 
 Work Checklist:
@@ -85,7 +85,7 @@ Work Checklist:
 - [x] Each lane is classified with concrete owner or N/A reason.
 - [x] Generated output: N/A, no generated file changed.
 - [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized for current local state.
-- [ ] Accepted cleanup and review findings are closed.
+- [x] Accepted cleanup and review findings are closed: type cleanup applied; autoreview clean.
 - [ ] PR body and check state match the final evidence.
 - [x] Residual blocker/waiver has exact evidence and next owner: none.
 - [x] Agent-native pack: N/A, no agent rule or generated skill mirror changed.
@@ -110,9 +110,9 @@ Completion Gates:
 | Deslop | yes | Run bounded cleanup or N/A | 0 added occurrences; fan-out heuristic ignored because V8 requires its own `.vitest.ts` lane |
 | Agent-native reviewer | no | Run for workflow changes or N/A | N/A: no agent workflow change |
 | Final lint | yes | Run `bun lint:fix` | 883 files checked; no fixes |
-| Repository check | yes | Run `bun check` | pending |
+| Repository check | yes | Run `bun check` | Pass: check:ci, test:verify, and test:runtime |
 | GitHub delivery | yes | Commit/push/open or update PR and read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | Codex Sol/high: clean, 0 actionable findings, 0.99 |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-15-pr-326-autoclosure.md` | pending |
 | Agent source / generated sync | no | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | N/A: no agent rule change |
 | Installed lock audit | no | Verify expected lock entries and removed skills through CLI-managed state | N/A: no installed skill change |
@@ -125,8 +125,8 @@ Phase / pass table:
 | --- | --- | --- | --- |
 | Inventory | complete | PR body/files/head/checks reconstructed | checkout/rebase |
 | Repair | complete | Replaced two new `any` casts with `Value`; V8 test remains 7/7 | review |
-| Review/checks | in_progress | focused tests, build, deslop, lint pass | autoreview and `bun check` |
-| Delivery | pending | | final audit |
+| Review/checks | complete | focused tests, build, deslop, lint, autoreview, `bun check` pass | delivery |
+| Delivery | in_progress | local closure ready | force-with-lease push, remote checks, merge/release |
 | Closeout | pending | | final |
 
 Verification evidence:
@@ -137,6 +137,8 @@ Verification evidence:
 - `bun run lint:slop:delta`: 0 added occurrences; one directory fan-out
   heuristic ignored because the separate V8 test lane is required.
 - `bun lint:fix`: 883 files checked; no fixes.
+- Autoreview Codex Sol/high: clean, 0 actionable findings, 0.99.
+- `bun check`: pass through check:ci, test:verify, and test:runtime.
 
 Review fixes:
 - Local standards audit found two new `any` uses in `error.vitest.ts`; accepted
@@ -146,15 +148,16 @@ Timeline:
 - 2026-08-15T19:04:02.015Z Autoclosure plan created.
 - 2026-08-15 Rebased onto #324 merge; source/issue/feedback reconstructed.
 - 2026-08-15 Focused tests/build/lint passed; two test-only `any` uses removed.
+- 2026-08-15 Autoreview clean and full repository gate passed.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Review/checks |
-| Where am I going? | Autoreview, `bun check`, push, remote checks, merge, release |
+| Where am I? | Delivery |
+| Where am I going? | Push, remote checks, merge, release verification |
 | What is the goal? | Merge PR #326 and verify one release. |
 | What have I learned? | V8 lazy stack materialization is the payload-loss trigger; no GitHub feedback exists. |
-| What have I done? | Rebased, tightened types, and passed focused/package/deslop/lint gates. |
+| What have I done? | Rebased, tightened types, and passed every local review/check gate. |
 
 Open risks:
 - Remote release automation must publish exactly once after the final merge.

--- a/packages/kitcn/src/server/error.test.ts
+++ b/packages/kitcn/src/server/error.test.ts
@@ -75,7 +75,7 @@ describe('server/error', () => {
     expect(err.message).toBe('UNAUTHORIZED');
   });
 
-  test('getCRPCErrorFromUnknown wraps unknowns and preserves stack when possible', () => {
+  test('getCRPCErrorFromUnknown wraps unknowns and keeps the original stack on cause', () => {
     const cause = new Error('nope');
     cause.stack = 'STACK';
     const err = getCRPCErrorFromUnknown(cause);
@@ -83,7 +83,47 @@ describe('server/error', () => {
     expect(err).toBeInstanceOf(CRPCError);
     expect(err.code).toBe('INTERNAL_SERVER_ERROR');
     expect(err.cause?.message).toBe('nope');
-    expect(err.stack).toBe('STACK');
+    expect(err.cause?.stack).toBe('STACK');
+  });
+
+  // Overwriting `.stack` suppresses Convex's `prepareStackTrace` hook, which is
+  // what writes the `__frameData` the backend requires before it forwards
+  // `data`. See the note above `toCRPCError`, and `error.vitest.ts` for the
+  // V8-level regression test.
+  test.each([
+    [
+      'ConvexError carrying cRPC data',
+      () =>
+        acrossConvexSyscall(
+          new CRPCError({ code: 'NOT_FOUND', message: 'Todo not found' })
+        ),
+    ],
+    [
+      'OrmNotFoundError',
+      () =>
+        Object.assign(new Error('User not found'), {
+          name: 'OrmNotFoundError',
+        }),
+    ],
+    [
+      'APIError',
+      () =>
+        Object.assign(new Error('Nope'), {
+          body: { message: 'Nope' },
+          name: 'APIError',
+          status: 'UNAUTHORIZED',
+          statusCode: 401,
+        }),
+    ],
+  ])('toCRPCError does not copy the %s stack onto the CRPCError', (_, build) => {
+    const cause = build();
+    cause.stack = 'CAUSE STACK';
+
+    const err = toCRPCError(cause);
+
+    expect(err).toBeInstanceOf(CRPCError);
+    expect(err?.stack).not.toBe('CAUSE STACK');
+    expect((err?.cause as Error | undefined)?.stack).toBe('CAUSE STACK');
   });
 
   test('toCRPCError maps OrmNotFoundError-like errors to NOT_FOUND', () => {

--- a/packages/kitcn/src/server/error.ts
+++ b/packages/kitcn/src/server/error.ts
@@ -235,6 +235,16 @@ function getApiErrorMessage(cause: APIErrorLike): string {
  * Convert known framework/library errors into CRPCError.
  *
  * Intended for cRPC internals so callers don't need per-endpoint try/catch.
+ *
+ * Never assign `.stack` on a converted error. The Convex backend only forwards
+ * `data` for a thrown error after it reads `__frameData` off it, and
+ * `__frameData` is written as a side effect of the runtime's
+ * `Error.prepareStackTrace` hook, which V8 runs lazily on the *first* read of
+ * `.stack`. Assigning `.stack` satisfies later reads without ever running the
+ * hook, so the backend bails out of source mapping and the client receives a
+ * bare `Error` with the message redacted to `Server Error` and no `.data` —
+ * losing the cRPC `code`, `message`, and custom payload. The original stack
+ * stays reachable at `err.cause.stack`. See `error.vitest.ts`.
  */
 export function toCRPCError(cause: unknown): CRPCError | null {
   if (cause instanceof CRPCError) return cause;
@@ -244,24 +254,20 @@ export function toCRPCError(cause: unknown): CRPCError | null {
 
   if (isConvexErrorLike(cause) && isCRPCErrorData(cause.data)) {
     const { code, message, ...data } = cause.data;
-    const err = new CRPCError({
+    return new CRPCError({
       code,
       message,
       cause,
       data: data as Record<string, Value | undefined>,
     }) as CRPCError;
-    if (cause.stack) err.stack = cause.stack;
-    return err;
   }
 
   if (isOrmNotFoundErrorLike(cause)) {
-    const err = new CRPCError({
+    return new CRPCError({
       code: 'NOT_FOUND',
       message: cause.message,
       cause,
     });
-    if (cause.stack) err.stack = cause.stack;
-    return err;
   }
 
   if (isApiErrorLike(cause)) {
@@ -275,13 +281,11 @@ export function toCRPCError(cause: unknown): CRPCError | null {
           ? mapHttpStatusCodeToCRPCCode(statusCode)
           : 'INTERNAL_SERVER_ERROR';
 
-    const err = new CRPCError({
+    return new CRPCError({
       code,
       message: getApiErrorMessage(cause),
       cause,
     });
-    if (cause.stack) err.stack = cause.stack;
-    return err;
   }
 
   return null;
@@ -289,6 +293,9 @@ export function toCRPCError(cause: unknown): CRPCError | null {
 
 /**
  * Wrap unknown error in CRPCError (from tRPC)
+ *
+ * The original stack stays reachable at `err.cause.stack`. See the note on
+ * `toCRPCError` for why it must not be copied onto the returned error.
  *
  * @example
  * ```typescript
@@ -303,16 +310,10 @@ export function getCRPCErrorFromUnknown(cause: unknown): CRPCError {
   const handled = toCRPCError(cause);
   if (handled) return handled;
 
-  const error = new CRPCError({
+  return new CRPCError({
     code: 'INTERNAL_SERVER_ERROR',
     cause,
   });
-
-  if (cause instanceof Error && cause.stack) {
-    error.stack = cause.stack;
-  }
-
-  return error;
 }
 
 /**

--- a/packages/kitcn/src/server/error.vitest.ts
+++ b/packages/kitcn/src/server/error.vitest.ts
@@ -1,0 +1,183 @@
+/**
+ * Regression tests for cRPC errors surviving the Convex backend boundary.
+ *
+ * These live in the vitest lane on purpose: the failure mode is V8-specific.
+ * `bun test` runs on JavaScriptCore, which materializes `prepareStackTrace`
+ * eagerly and therefore cannot observe the bug.
+ *
+ * The backend contract being modelled (from the Convex runtime):
+ * 1. `Error.prepareStackTrace` is overridden to write `__frameData` onto the
+ *    error as a side effect. V8 runs it lazily on the *first* read of `.stack`.
+ * 2. `serializeConvexErrorData` JSON-encodes `data` and tags the error with
+ *    `ConvexErrorSymbol` when `Symbol.for('ConvexError')` is present.
+ * 3. The backend reads `.stack` (to trigger the hook), then *requires*
+ *    `__frameData` before it will look at `ConvexErrorSymbol`/`data`. Missing
+ *    `__frameData` aborts source mapping, and the error reaches the client as a
+ *    bare `Error` with the message redacted and no `.data`.
+ *
+ * Assigning `.stack` satisfies step 3's read without ever running step 1's
+ * hook, which silently drops every cRPC payload.
+ */
+import { ConvexError, convexToJson, jsonToConvex } from 'convex/values';
+import { afterEach, expect, test } from 'vitest';
+
+import { CRPCError, getCRPCErrorFromUnknown, toCRPCError } from './error';
+
+const originalPrepareStackTrace = Error.prepareStackTrace;
+
+afterEach(() => {
+  Error.prepareStackTrace = originalPrepareStackTrace;
+});
+
+function installConvexStackHook(): void {
+  Error.prepareStackTrace = (error, frames) => {
+    Object.defineProperties(error, {
+      __frameData: {
+        configurable: true,
+        value: JSON.stringify(
+          frames.map((frame) => ({
+            fileName: frame.getFileName(),
+            lineNumber: frame.getLineNumber(),
+          }))
+        ),
+      },
+    });
+    return 'formatted stack';
+  };
+}
+
+type ClientError =
+  | { data: Record<string, unknown>; kind: 'ConvexError' }
+  | { kind: 'Error' };
+
+/**
+ * Runs a thrown value through the same two steps the Convex backend does and
+ * reports what the browser would end up with.
+ */
+function throwThroughConvex(thrown: unknown): ClientError {
+  installConvexStackHook();
+
+  const serialized = thrown as Record<string, unknown>;
+  if (
+    typeof thrown === 'object' &&
+    thrown !== null &&
+    Symbol.for('ConvexError') in thrown
+  ) {
+    serialized.data = JSON.stringify(
+      convexToJson(
+        serialized.data === undefined ? null : (serialized.data as any)
+      )
+    );
+    serialized.ConvexErrorSymbol = Symbol.for('ConvexError');
+  }
+
+  if (!(thrown instanceof Error)) return { kind: 'Error' };
+
+  // The backend reads `.stack` purely so `prepareStackTrace` populates
+  // `__frameData`, then bails out when it is missing.
+  void thrown.stack;
+  if (serialized.__frameData === undefined) return { kind: 'Error' };
+
+  const symbol = serialized.ConvexErrorSymbol as symbol | undefined;
+  if (!symbol || serialized[symbol] !== true) return { kind: 'Error' };
+
+  return {
+    data: jsonToConvex(JSON.parse(serialized.data as string)) as Record<
+      string,
+      unknown
+    >,
+    kind: 'ConvexError',
+  };
+}
+
+/** `ctx.runQuery`/`runMutation`/`runAction` rebuild a plain `ConvexError`. */
+function acrossConvexSyscall(error: CRPCError): ConvexError<any> {
+  const rethrown = new ConvexError(error.message);
+  rethrown.data = JSON.parse(JSON.stringify(error.data));
+  return rethrown;
+}
+
+test('a CRPCError thrown directly keeps its payload', () => {
+  const result = throwThroughConvex(
+    new CRPCError({ code: 'NOT_FOUND', message: 'Todo not found' })
+  );
+
+  expect(result).toEqual({
+    data: { code: 'NOT_FOUND', message: 'Todo not found' },
+    kind: 'ConvexError',
+  });
+});
+
+test('a CRPCError rebuilt from a caller-to-caller ConvexError keeps its payload', () => {
+  const fromInnerProcedure = acrossConvexSyscall(
+    new CRPCError({
+      code: 'BAD_REQUEST',
+      data: { processorCode: 5120 },
+      message: 'Declined: INSUFFICIENT_FUNDS',
+    })
+  );
+
+  const result = throwThroughConvex(toCRPCError(fromInnerProcedure));
+
+  expect(result).toEqual({
+    data: {
+      code: 'BAD_REQUEST',
+      message: 'Declined: INSUFFICIENT_FUNDS',
+      processorCode: 5120,
+    },
+    kind: 'ConvexError',
+  });
+});
+
+test('a CRPCError converted from an OrmNotFoundError keeps its payload', () => {
+  const cause = new Error('User not found');
+  cause.name = 'OrmNotFoundError';
+
+  expect(throwThroughConvex(toCRPCError(cause))).toEqual({
+    data: { code: 'NOT_FOUND', message: 'User not found' },
+    kind: 'ConvexError',
+  });
+});
+
+test('a CRPCError converted from an APIError keeps its payload', () => {
+  class FakeAPIError extends Error {
+    body = { message: 'Nope' };
+    status = 'UNAUTHORIZED';
+    statusCode = 401;
+    constructor() {
+      super('Nope');
+      this.name = 'APIError';
+    }
+  }
+
+  expect(throwThroughConvex(toCRPCError(new FakeAPIError()))).toEqual({
+    data: { code: 'UNAUTHORIZED', message: 'Nope' },
+    kind: 'ConvexError',
+  });
+});
+
+test('a CRPCError wrapped by getCRPCErrorFromUnknown keeps its payload', () => {
+  expect(
+    throwThroughConvex(getCRPCErrorFromUnknown(new Error('boom')))
+  ).toEqual({
+    data: { code: 'INTERNAL_SERVER_ERROR', message: 'boom' },
+    kind: 'ConvexError',
+  });
+});
+
+test('the harness detects a reintroduced `.stack` assignment', () => {
+  const err = new CRPCError({ code: 'NOT_FOUND', message: 'Todo not found' });
+  err.stack = 'copied from the cause';
+
+  expect(throwThroughConvex(err)).toEqual({ kind: 'Error' });
+});
+
+test('converted errors expose the original stack through `cause`', () => {
+  const cause = new Error('nope');
+  cause.stack = 'ORIGINAL STACK';
+
+  const err = getCRPCErrorFromUnknown(cause);
+
+  expect(err.cause?.stack).toBe('ORIGINAL STACK');
+  expect(err.stack).not.toBe('ORIGINAL STACK');
+});

--- a/packages/kitcn/src/server/error.vitest.ts
+++ b/packages/kitcn/src/server/error.vitest.ts
@@ -18,7 +18,12 @@
  * Assigning `.stack` satisfies step 3's read without ever running step 1's
  * hook, which silently drops every cRPC payload.
  */
-import { ConvexError, convexToJson, jsonToConvex } from 'convex/values';
+import {
+  ConvexError,
+  convexToJson,
+  jsonToConvex,
+  type Value,
+} from 'convex/values';
 import { afterEach, expect, test } from 'vitest';
 
 import { CRPCError, getCRPCErrorFromUnknown, toCRPCError } from './error';
@@ -65,7 +70,7 @@ function throwThroughConvex(thrown: unknown): ClientError {
   ) {
     serialized.data = JSON.stringify(
       convexToJson(
-        serialized.data === undefined ? null : (serialized.data as any)
+        serialized.data === undefined ? null : (serialized.data as Value)
       )
     );
     serialized.ConvexErrorSymbol = Symbol.for('ConvexError');
@@ -91,7 +96,7 @@ function throwThroughConvex(thrown: unknown): ClientError {
 }
 
 /** `ctx.runQuery`/`runMutation`/`runAction` rebuild a plain `ConvexError`. */
-function acrossConvexSyscall(error: CRPCError): ConvexError<any> {
+function acrossConvexSyscall(error: CRPCError): ConvexError<Value> {
   const rethrown = new ConvexError(error.message);
   rethrown.data = JSON.parse(JSON.stringify(error.data));
   return rethrown;


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes #325
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 real local Convex backend: `error.data === undefined` on pre-fix build | ➖ N/A |
| Verified | 🟢 real local Convex backend + `bun check` | ➖ N/A |

**✅ Outcome**
- `CRPCError` reaches the client as a `ConvexError` carrying `code`, `message`, and custom `data` again — via caller-to-caller delegation, `OrmNotFoundError`, Better Auth `APIError`, and `getCRPCErrorFromUnknown`.
- Converted errors carry source-mapped frames in Convex logs again; previously they had none.
- Original stack stays reachable at `err.cause.stack`.

**🏗️ Design**
- Root cause confirmed in Convex source: `udf-runtime/src/errors.ts` writes `__frameData` as a side effect of `Error.prepareStackTrace`, which V8 runs lazily on the *first* read of `.stack`; `crates/isolate/src/error.rs` reads `.stack` to trigger it, then `bail!`s on missing `__frameData` — **before** the `ConvexErrorSymbol`/`data` read. That ordering is why the reporter saw the marker symbol intact and still lost the payload.
- Chosen layer: delete the four assignments. `cause` already carries the original stack.
- Why not `Error.captureStackTrace`: measured safe but useless — it discards the origin stack it would supposedly preserve, and adds an engine-specific call for nothing.
- Why the regression test is `.vitest.ts`: `bun test` runs on JavaScriptCore, which materializes `prepareStackTrace` eagerly and **structurally cannot** observe this. The vitest `integration` project is Node/V8 and reproduces it exactly.

**⚠️ Caveat**
- `err.stack` on a converted error now originates at `toCRPCError`, not the throw site. That is the price of the payload surviving — copying the stack is what broke it.
- No lane in `bun check` can catch a regression of this bug: every scenario lane runs the concave Bun runtime, which has no `__frameData` concept and forwards `data` unconditionally. `error.vitest.ts` is the only guard.

**🧪 Verified**
- **Real local Convex backend** (`convex-local-backend`, real V8 isolate), same app pushed twice, `ConvexHttpClient` observing the client:

  | function | pre-fix `builder-f4F_NRvK.js` | fixed `builder-Dwy6D2QA.js` |
  | --- | --- | --- |
  | `payment:direct` (control, unconverted) | `ConvexError` + data | `ConvexError` + data |
  | `payment:ormNotFound` (`OrmNotFoundError`) | `Error`, `data=undefined` | `ConvexError` `{code:NOT_FOUND, message:'User not found'}` |
  | `checkout:chargeCard` (caller-to-caller) | `Error`, `data=undefined` | `ConvexError` `{code:BAD_REQUEST, message:'Declined: INSUFFICIENT_FUNDS', processorCode:5120}` |

  The pre-fix build is byte-identical in shape to published 0.17.0: chunk `builder-f4F_NRvK.js` with the four `.stack` assignments at lines 810/819/830/854, exactly as cited in the issue. The unconverted control keeps its payload in both arms, so the harness is not globally broken.
- `bun check` (incl. `check:ci`, `fixtures:check`, `test:verify`, `test:runtime`)
- Red→green unit proof: reverting only `error.ts` turns 5/7 new vitest tests red, one per affected branch; 7/7 green restored.
- Full post-rebase `bun check` green, including the V8 regression lane.
