### PR TITLE
docs: fix ORM release migration index

### DIFF
--- a/.changeset/orm-index-pushdown.md
+++ b/.changeset/orm-index-pushdown.md
@@ -22,8 +22,8 @@ await ctx.orm.query.posts.findMany({
   limit: 2,
 });
 
-// Add the sort column to the index to keep it a two-document read
-index('by_type_created').on(t.type, t.createdAt);
+// Pinning the narrower index leaves creation time as the implicit next key
+index('by_type').on(t.type);
 ```
 
 - Change which rows a `.through()` relation returns for a given `limit`. Each

--- a/docs/plans/2026-08-17-pr-335-autoclosure.md
+++ b/docs/plans/2026-08-17-pr-335-autoclosure.md
@@ -99,6 +99,7 @@ Error attempts:
 | Configured compound index was treated as native creation order | 1 | add a real configured-index ordering regression and require proven pushdown | fixed; `[90, 70]` became `[70, 20]` |
 | P1 review claimed through relations skipped offset/limit | 1 | trace the final relation assignment and add ordered/bounded offset+limit tests | rejected; `applyOffsetAndLimit` owns the final slice and both tests pass |
 | First configured-index repair rejected every ranged creation-order cursor | 1 | observe the real range builder and distinguish full equality prefixes from partial/range prefixes | fixed; full `by_name` equality cursor works while compound partial pin still sorts after fetch |
+| Release migration snippet tried to index system `createdAt` | 1 | replace it at the changeset source with the narrower declared index whose implicit suffix is creation time | correction PR required before release #349 |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
@@ -175,6 +176,10 @@ Verification evidence:
 - Final committed-head P1 autoreview is clean: no accepted/actionable finding,
   `patch is correct` at 0.82 confidence. The accepted cursor finding converged
   in the second review-triggered repair cycle.
+- Release PR #349 exposed stale migration advice that indexed system
+  `createdAt`, which the ORM forbids. The source changeset now recommends
+  `index('by_type').on(t.type)`, whose fully pinned partition is natively ordered
+  by the implicit creation-time suffix.
 
 Timeline:
 - 2026-08-17 PR #335 merged released v0.17.5 main; confirmed third P1.


### PR DESCRIPTION
<!-- auto-release:start -->
- [ ] Auto release
<!-- auto-release:end -->

Fixes the #335 changeset migration snippet before v0.18.0. System `createdAt` cannot be indexed directly; a narrower `(type)` index leaves Convex creation time as the implicit next key and preserves the requested bounded order.\n\nVerification: `bun lint:fix`, full `bun check`, and autoreview pass.
