### PR TITLE
fix(react): refresh prefetched pagination after auth settles

### DIFF
--- a/.changeset/calm-pandas-settle.md
+++ b/.changeset/calm-pandas-settle.md
@@ -1,0 +1,6 @@
+---
+"kitcn": patch
+---
+
+Fix prefetched optional React pagination remaining disabled after authentication
+settles.

--- a/packages/kitcn/src/react/use-infinite-query.test.tsx
+++ b/packages/kitcn/src/react/use-infinite-query.test.tsx
@@ -239,6 +239,43 @@ describe('useInfiniteQuery', () => {
     expect((useQueriesCalls.at(-1)!.queries[0] as any).enabled).toBe(false);
   });
 
+  test('enables a prefetched optional first page after auth settles', () => {
+    let isLoading = true;
+    useSafeConvexAuthSpy.mockImplementation(() => ({
+      isLoading,
+      isAuthenticated: !isLoading,
+    }));
+    const optionalMeta = {
+      posts: { list: { auth: 'optional' } },
+    } as any;
+    const options = convexInfiniteQueryOptions(
+      fn,
+      { tag: 'x' },
+      { limit: 2 },
+      optionalMeta
+    ) as any;
+    options[FUNC_REF_SYMBOL] = fn;
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(options.queryKey, {
+      page: [{ _id: 'u1' }],
+      isDone: false,
+      continueCursor: 'c1',
+    });
+
+    const { rerender } = renderHook(() => useInfiniteQuery(options), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    expect((useQueriesCalls.at(-1)!.queries[0] as any).enabled).toBe(false);
+
+    act(() => {
+      isLoading = false;
+      rerender();
+    });
+
+    expect((useQueriesCalls.at(-1)!.queries[0] as any).enabled).toBe(true);
+  });
+
   test('rebuilds an auth-bound list from its first page after an account transition', () => {
     let authEpoch = 0;
     useAuthValueSpy.mockImplementation((key: any) => {

--- a/packages/kitcn/src/react/use-infinite-query.ts
+++ b/packages/kitcn/src/react/use-infinite-query.ts
@@ -505,6 +505,8 @@ const useInfiniteQueryInternal = <Query extends PaginatedQueryReference>(
       meta,
       queryOptions,
       placeholderData,
+      authType,
+      isAuthLoading,
     ]
   );
 


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

## Why

Post-release CI for #339 reported missing `authType` and `isAuthLoading` dependencies in the React pagination query-options memo. With a prefetched optional first page, `skip` stays false while auth changes, so the memo could retain `enabled: false` after authentication settled.

## Fix

- Recompute page query options when auth type or loading state changes.
- Add a regression covering loading-to-settled auth with a prefetched optional page.
- Add a patch changeset.

## Proof

- `bun test packages/kitcn/src/react/use-infinite-query.test.tsx` (14 pass)
- `bun --cwd packages/kitcn typecheck`
- `bun --cwd packages/kitcn build`
- `bun lint:fix`
- `bun run lint:slop:delta` (0 net)
- final whole-branch P1 review clean; patch correct (0.97)
- `bun check`
