### PR TITLE
docs: close contributor PR batch

### DIFF
--- a/docs/plans/2026-08-16-pr-330-autoclosure.md
+++ b/docs/plans/2026-08-16-pr-330-autoclosure.md
@@ -17,9 +17,6 @@ docs/plans/templates/autoclosure.md
 Applied packs:
 - agent-native (docs/plans/templates/packs/agent-native.md)
 
-Linked plans:
-- [Batch plan](docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md)
-
 Completion threshold:
 - The two watcher review threads are source-backed and closed; lazy imports,
   codegen parsing/content comparison, config/env behavior, package build,

--- a/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
+++ b/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
@@ -41,6 +41,10 @@ Linked plans:
   Solid/React auth and query parity.
 - [PR #340 autoclosure](docs/plans/2026-08-17-pr-340-autoclosure.md) -
   Single-pass cRPC validation and definition-time schema plans.
+- [PR #341 autoclosure](docs/plans/2026-08-17-pr-341-autoclosure.md) -
+  Request-keyed anonymous rate limits with manual cleanup only.
+- [PR #342 autoclosure](docs/plans/2026-08-17-pr-342-autoclosure.md) -
+  Explicit ORM capabilities and isolated optional runtime graphs.
 
 Completion threshold:
 - All 14 frozen PRs (#329-#342) have a recorded intent, overlap/dependency map,
@@ -105,16 +109,16 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| source behavior | yes | exact invariant plus focused tests/runtime per PR | inventory pending |
-| package/API/build | conditional | public exports/types/build per touched package | inventory pending |
-| generated output | conditional | owner plus regeneration/diff | inventory pending |
-| fixtures/scenarios | conditional | sync/check/runtime proof | inventory pending |
-| docs/package skill | conditional | paired owner audit | inventory pending |
-| changeset | conditional | package delta coverage | inventory pending |
-| agent workflow | conditional | source/mirror/lock/helper proof | inventory pending |
-| cleanup/review | yes | deslop, agent-native reviewer, autoreview | inventory pending |
-| repository check | yes | `bun check` | pending |
-| GitHub delivery | yes | source-backed merge or close plus remote read-back | pending |
+| source behavior | yes | exact invariant plus focused tests/runtime per PR | pass |
+| package/API/build | conditional | public exports/types/build per touched package | pass where applicable |
+| generated output | conditional | owner plus regeneration/diff | pass where applicable |
+| fixtures/scenarios | conditional | sync/check/runtime proof | pass where applicable |
+| docs/package skill | conditional | paired owner audit | pass where applicable |
+| changeset | conditional | package delta coverage | pass where applicable |
+| agent workflow | conditional | source/mirror/lock/helper proof | pass where applicable |
+| cleanup/review | yes | deslop, agent-native reviewer, autoreview | pass |
+| repository check | yes | `bun check` | pass |
+| GitHub delivery | yes | source-backed merge or close plus remote read-back | pass |
 
 PR disposition ledger:
 | PR | Intended invariant | Initial slop verdict | Feedback | Dependency / order | Status |
@@ -132,7 +136,7 @@ PR disposition ledger:
 | #339 | restore Solid/React parity | credible but broad; stale changeset story was slop and removed | 4 outdated threads plus accepted local privacy findings | after #329/#332 | closed: merged `ed72944a`, corrected and released v0.22.1, post-release CI green |
 | #340 | validate cRPC output once | credible; not slop, but handler/client output typing was wrong | 2 upstream repairs plus 1 accepted local P1 | after released #339 | closed: merged `13fbae32`, released v0.23.0, post-release CI green |
 | #341 | key anonymous rate limits per request | mixed but substantive; deny-list safety and recurring cleanup proposal were slop | 2 upstream fixes plus 2 accepted P1s | after released #340 | closed: merged `c255ae2a`, released v0.24.0, post-release gates green; manual cleanup only |
-| #342 | inject ORM capabilities to cut bundle graphs | potentially valuable architecture change, far too large for trust-by-CI | 4 threads | last; depends on #330/#331/#333/#335/#337/#341 | deep review pending |
+| #342 | inject ORM capabilities to cut bundle graphs | substantive, not wholesale slop; release claims and two unbounded/cleanup edge cases required repair | 4 threads resolved plus 1 accepted local P1 | last; depends on #330/#331/#333/#335/#337/#341 | closed: merged `3aff976a`, released v0.25.0, post-release gates green |
 
 Dependency-safe order:
 - Release 0.17.2: #329.
@@ -140,26 +144,25 @@ Dependency-safe order:
 - Released 0.17.5: #332.
 - Release 0.19.x: #335 then #336.
 - Released 0.20.0: #337.
-- Next isolated package release: #338.
-- Subsequent candidates: #339 then #340, each rebased on released main.
-- Later isolated candidates: #341, then #342 only after explicit high-risk proof.
+- Released in order after #337: #338, #339, #340, #341, then #342 after the
+  explicit high-risk proof recorded below.
 
 Work Checklist:
-- [ ] Intended behavior and exclusions are reconstructed from real sources.
-- [ ] Each lane is proven or N/A with a concrete reason.
-- [ ] Generated output was changed through its owner and regenerated.
-- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
-- [ ] Accepted cleanup and review findings are closed.
-- [ ] PR body and check state match the final evidence.
-- [ ] Residual blocker/waiver has exact evidence and next owner.
-- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
-- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
-- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
-- [ ] Agent-native pack: installed skills are changed only through
+- [x] Intended behavior and exclusions are reconstructed from real sources.
+- [x] Each lane is proven or N/A with a concrete reason.
+- [x] Generated output was changed through its owner and regenerated.
+- [x] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [x] Accepted cleanup and review findings are closed.
+- [x] PR body and check state match the final evidence.
+- [x] Residual blocker/waiver has exact evidence and next owner: none.
+- [x] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [x] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [x] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [x] Agent-native pack: installed skills are changed only through
       `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
-- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+- [x] Agent-native pack: routing, required receipts, placeholder failure,
       completion representability, and forbidden behavior have eval/smoke rows.
-- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
@@ -170,30 +173,30 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
-| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
-| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
-| Deslop | pending | Run bounded cleanup or N/A | pending |
-| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
-| Repository check | yes | Run `bun check` | pending |
-| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md` | pending |
-| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
-| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
-| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
-| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
-| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+| Targeted behavior proof | yes | Run smallest missing owning proof | pass per linked PR plans |
+| Source/generated audit | yes | Prove correct source and regenerated mirrors | pass per applicable PR plans |
+| Package/docs/scenario closure | yes | Run every applicable local contract | pass |
+| Deslop | yes | Run bounded cleanup or N/A | pass per PR |
+| Agent-native reviewer | yes | Run for workflow changes or N/A | pass for applicable CLI/workflow changes |
+| Final lint | yes | Run `bun lint:fix` | pass per delivered PR |
+| Repository check | yes | Run `bun check` | pass; post-release CI `32006568741` green |
+| GitHub delivery | yes | Merge/release and read back every PR | pass |
+| Autoreview | yes | Resolve every accepted actionable finding | pass per PR |
+| Goal plan complete | yes | Run completion checker | pass after final receipt update |
+| Agent source / generated sync | no | No source-rule change in final delta | N/A |
+| Installed lock audit | no | No installed-skill lock change | N/A |
+| Agent action discoverability | yes | Audit CLI/source/generated/skill route | pass for #342 |
+| Helper and template smoke | no | No helper/template delta in closeout | N/A |
+| Agent-native review | yes | Close applicable agent-native findings | pass |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Inventory | complete | all 14 exact heads, owners, overlaps, and threads recorded | repair |
+| Repair | complete | accepted correctness, ownership, and proof defects fixed | review |
+| Review/checks | complete | focused/full gates and final reviews pass | delivery |
+| Delivery | complete | every PR merged and applicable releases published | final audit |
+| Closeout | complete | exact #342/release/npm/workflow read-back | done |
 
 Verification evidence:
 - GitHub snapshot: 14 contributor PRs #329-#342; every head had green CI and
@@ -310,21 +313,29 @@ Verification evidence:
   arbitrary update. The mutation now continues inside the same transaction
   until terminal or two matches; 101 focused auth tests pass. Final whole-
   branch P1 review is clean at 0.87 and the exact full-gate retry passes.
+- #342 exact head `cb3322c8` passed CI `32006113457`, Vercel, and the
+  auto-release gate, then squash-merged as `3aff976a`. Release PR #360 merged
+  as `f3a602b8` and published GitHub plus npm `v0.25.0` for `kitcn` and
+  `@kitcn/resend`, both with exact `gitHead` `f3a602b8`. Post-release CI
+  `32006568741`, skill audit `32006530625`, and Convex Matrix
+  `32006560638` all passed; the latter includes the full version matrix and
+  runtime scenarios. No cron or recurring workflow was added.
 
 Timeline:
 - 2026-08-16T18:31:28.829Z Autoclosure plan created.
 - 2026-08-16 Froze #329-#342, fetched local refs, audited PR bodies/files/checks,
   mapped overlaps, and retrieved every unresolved feedback thread.
+- 2026-08-17 Closed all 14 PRs in dependency-safe order and verified the final
+  v0.25.0 release, npm provenance, post-release CI, and Convex matrix.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
-| Where am I going? | Repair, review/checks, delivery, final audit |
+| Where am I? | Complete |
+| Where am I going? | Done; PR #352 remains outside this frozen batch |
 | What is the goal? | Give every PR #329-#342 an honest slop verdict and final disposition, then autoclose each viable PR. |
-| What have I learned? | Thirteen contributor PRs are green but blocked on review; overlap and intent remain unproven. |
-| What have I done? | Frozen the batch, excluded #343, recorded authority, constraints, proof standards, and delivery rules. |
+| What have I learned? | The batch was mostly substantive but repeatedly mixed real work with stale claims, unsafe bounds, and incomplete ownership. |
+| What have I done? | Repaired, reviewed, merged, released, and remotely verified all 14 frozen PRs without adding recurring automation. |
 
 Open risks:
-- The batch is highly overlapping across ORM/Solid/runtime/performance surfaces;
-  green heads may become stale or redundant as earlier PRs merge.
+- None inside the frozen #329-#342 batch. PR #352 is explicitly outside scope.

--- a/docs/plans/2026-08-17-pr-339-autoclosure.md
+++ b/docs/plans/2026-08-17-pr-339-autoclosure.md
@@ -65,14 +65,14 @@ Closure matrix:
 | agent workflow | no | no agent workflow changes | N/A |
 | cleanup/review | yes | deslop and autoreview | clean |
 | repository check | yes | `bun check` | complete |
-| GitHub delivery | yes | feedback, exact checks, merge/release | pending |
+| GitHub delivery | yes | feedback, exact checks, merge/release | complete |
 
 Work Checklist:
 - [x] Intended behavior and exclusions are reconstructed from real sources.
 - [x] Each focused local lane is proven or N/A with a concrete reason.
 - [x] Package/changeset ownership is closed.
 - [x] Accepted cleanup and review findings are closed locally.
-- [ ] PR body and check state match the final evidence.
+- [x] PR body and check state match the final evidence.
 
 Error attempts:
 | Failure signature | Count | Next different move | Resolution |
@@ -106,9 +106,9 @@ Completion Gates:
 | Agent-native reviewer | no | no workflow changes | N/A |
 | Final lint | yes | run `bun lint:fix` | 910 files clean |
 | Repository check | yes | run `bun check` | passed on `f2445ea1` |
-| GitHub delivery | pending | push, feedback, exact checks, merge/release | pending |
+| GitHub delivery | yes | push, feedback, exact checks, merge/release | pass |
 | Autoreview | yes | final whole-branch review | clean at `ebbbedcf`; patch correct (0.86) |
-| Goal plan complete | yes | run checker | pending |
+| Goal plan complete | yes | run checker | pass from batch closeout |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
@@ -116,8 +116,8 @@ Phase / pass table:
 | Inventory | complete | exact diff, owners, feedback | repair |
 | Repair | complete | released-main merge plus provider identity owner | focused proof |
 | Review/checks | complete | focused/package/deslop, final autoreview, full check green | delivery |
-| Delivery | in_progress | local branch ready | push, checks, merge/release |
-| Closeout | pending | | final |
+| Delivery | complete | exact head merged and released | closeout |
+| Closeout | complete | v0.22.1 correction and post-release CI read back | done |
 
 Verification evidence:
 - The branch is broad but substantive, not disposable slop. Its four P1 review
@@ -194,13 +194,13 @@ Verification evidence:
   findings and reports the patch correct at 0.86 confidence.
 
 Open risks:
-- Exact-head remote checks, merge, release, and read-back remain.
+- None remaining inside PR #339 scope.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Exact-head GitHub delivery |
-| Where am I going? | Exact-head delivery and release |
+| Where am I? | Complete |
+| Where am I going? | Done |
 | What is the goal? | Ship only proven Solid/React parity. |
 | What have I learned? | Mutation-only resets miss provider transitions, and resets need the provider's auth-store owner. |
-| What have I done? | Merged released owners, removed changeset slop, and closed all reviewed identity/cache privacy gaps. |
+| What have I done? | Repaired, merged, corrected, released v0.22.1, and read back exact remote gates. |

--- a/docs/plans/2026-08-17-pr-340-autoclosure.md
+++ b/docs/plans/2026-08-17-pr-340-autoclosure.md
@@ -19,11 +19,26 @@ Completion threshold:
 - Focused tests, package typecheck/build, full check, final review, exact remote
   gates, merge, release, npm/tag, and post-release CI all pass.
 
+Verification surface:
+- Released-main diff, cRPC transformer/builders, Zod transform and default
+  regressions, package typecheck/build, changeset, docs/skill audit, deslop,
+  lint, full check, autoreview, exact-head CI/Vercel, release matrix, and npm.
+
+Constraints:
+- Parse output once without weakening custom codec validation or changing the
+  handler-input/client-output contract.
+- Keep auth, rate-limit, and ORM capability work outside this PR.
+
 Boundaries:
 - intended delta: PR #340 cRPC validation and memoization work
 - allowed repairs: output contract, review feedback, docs/skill/changeset sync,
   proof, and mergeability
 - non-goals: auth parity (#339), rate limits (#341), ORM capabilities (#342)
+
+Blocked condition:
+- Stop only if the owning transformed-output contract cannot be proven by the
+  focused type/runtime tests or maintainer delivery remains unavailable after
+  the documented retry path.
 
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
@@ -39,7 +54,7 @@ Closure matrix:
 | repository check | yes | `bun check` | complete |
 | GitHub delivery | yes | exact head, merge, release, read-back | complete |
 
-Work checklist:
+Work Checklist:
 - [x] Exact released-main diff and three review threads reconstructed.
 - [x] Two upstream threads verified fixed by source and tests.
 - [x] Handler/client transformed-output mismatch reproduced and repaired.
@@ -47,6 +62,15 @@ Work checklist:
 - [x] Focused and package proof passes.
 - [x] Deslop, lint, full check, and final whole-branch review pass.
 - [x] Feedback is resolved and exact remote delivery completes.
+
+Completion Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Targeted/package proof | yes | focused tests, typecheck, and build pass |
+| Cleanup/review | yes | zero-net deslop and clean P1 reviews |
+| Repository check | yes | `bun check` passes |
+| GitHub delivery | yes | exact merge, release, matrix, npm, and CI read-back |
+| Goal plan complete | yes | batch completion audit passes |
 
 Verification evidence:
 - The branch is broad but substantive, not generated slop. It removes repeated
@@ -81,3 +105,15 @@ Phase / pass table:
 | Review/checks | complete | focused/package/full gates; whole-branch review clean | delivery |
 | Delivery | complete | exact head merged and released | closeout |
 | Closeout | complete | npm/tag/post-release CI read back | done |
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Complete |
+| Where am I going? | Done |
+| What is the goal? | Ship proven single-pass cRPC validation and typing. |
+| What have I learned? | Performance work was real; transformed/defaulted output contracts required repair. |
+| What have I done? | Repaired, proved, merged, released v0.23.0, and read back all gates. |
+
+Open risks:
+- None remaining inside PR #340 scope.

--- a/docs/plans/2026-08-17-pr-341-autoclosure.md
+++ b/docs/plans/2026-08-17-pr-341-autoclosure.md
@@ -22,11 +22,27 @@ Completion threshold:
   full check, final review, exact remote gates, merge, release, and remote
   read-back all pass.
 
+Verification surface:
+- Released-main diff, HTTP/RSC keys, anonymous identifiers, deny-list store,
+  manual cleanup mutation, scaffold regeneration, fixtures, docs/skill sync,
+  package typecheck/build, focused tests, deslop, full check, autoreview,
+  exact-head gates, release matrix, npm, and post-release CI.
+
+Constraints:
+- Keep retained state bounded and preserve database enforcement if the local
+  optimization evicts a cold block.
+- No cron, recurring workflow, or schedule may be introduced.
+
 Boundaries:
 - intended delta: PR #341 rate-limit identifiers/options and HTTP/RSC cache keys
 - allowed repairs: deny-list safety, manual cleanup, review feedback,
   docs/skill/changeset sync, proof, and mergeability
 - non-goals: recurring cleanup, auth redesign, ORM capability injection (#342)
+
+Blocked condition:
+- Stop only if the deny-list bound or manual cleanup owner cannot be proven by
+  focused runtime/scaffold tests, or maintainer delivery remains unavailable
+  after the documented retry path.
 
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
@@ -42,7 +58,7 @@ Closure matrix:
 | repository check | yes | `bun check`; explicit `bun run test:runtime` rerun | complete |
 | GitHub delivery | yes | exact head, gates, merge, release, read-back | complete |
 
-Work checklist:
+Work Checklist:
 - [x] Exact released-main diff and four review threads reconstructed.
 - [x] Two upstream threads verified fixed in the submitted source.
 - [x] Rolling-window, bounded blocked-state, and long-key regressions reproduced.
@@ -51,6 +67,16 @@ Work checklist:
 - [x] Scaffold, docs, skill, generated output, and changeset are synchronized.
 - [x] Focused, package, full-check, and final-review proof passes.
 - [x] Feedback is resolved and exact remote delivery completes.
+
+Completion Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Targeted/package proof | yes | 99 focused tests, typechecks, and build pass |
+| Generated/docs/skill proof | yes | scaffold, fixtures, intent, and mirrors pass |
+| Cleanup/review | yes | zero-net deslop and clean P1 review at 0.92 |
+| Repository check | yes | `bun check` and explicit runtime scenarios pass |
+| GitHub delivery | yes | exact merge, v0.24.0, matrix, npm, and CI read-back |
+| Goal plan complete | yes | batch completion audit passes |
 
 Verification evidence:
 - The PR is mixed but substantive, not wholesale slop. Exact HTTP keys, shared
@@ -94,3 +120,15 @@ Phase / pass table:
 | Review/checks | complete | focused/package/fixture/full gates; P1 review clean | delivery |
 | Delivery | complete | exact head merged and released | closeout |
 | Closeout | complete | npm/tag/matrix/post-release CI read back | done |
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Complete |
+| Where am I going? | Done |
+| What is the goal? | Ship bounded rate limits with manual cleanup only. |
+| What have I learned? | The request-key work was real; recurring cleanup and the original deny-list bounds were unsafe. |
+| What have I done? | Repaired, proved, merged, released v0.24.0, and read back all gates without a cron. |
+
+Open risks:
+- None remaining inside PR #341 scope.

--- a/docs/plans/2026-08-17-pr-342-autoclosure.md
+++ b/docs/plans/2026-08-17-pr-342-autoclosure.md
@@ -67,7 +67,7 @@ State capsule:
 - active candidate: merged capability graph plus isolated aggregate maintenance
 - last proven fact: focused tests, package build, regenerated fixtures, intent,
   and example typecheck pass
-- next proof: exact remote gates, merge, and release read-back
+- next proof: none; exact remote gates, merge, release, and npm read-back pass
 - open blocker: none
 
 Start Gates:
@@ -90,7 +90,7 @@ Work Checklist:
 - [x] Live review defects pass bounded red/green tests.
 - [x] Old runtime exports/routes and stale generated output are absent.
 - [x] Package, fixture, docs/skill, changeset, review, and repository gates pass.
-- [ ] Exact GitHub merge/release/read-back completes.
+- [x] Exact GitHub merge/release/read-back completes.
 
 Owner / candidate map:
 | Candidate | Current owner | Target owner | Public impact | Bundle impact | Generated impact | Decision |
@@ -107,7 +107,7 @@ Implementation packets:
 | graph | ORM capabilities, subpath entries, lifecycle/query | root graph excludes optional runtimes and all write barriers remain | root value imports/types | package build | graph/capability/ORM tests | complete |
 | maintenance | codegen and aggregate CLI | prune runs after final index removal from isolated entry | conditional prune skip/shared route | codegen + fixture sync | red/green CLI/codegen tests | complete |
 | fingerprint | CLI backend owner | partition order changes fingerprint | sorted rank partitions | N/A | red/green fingerprint test | complete |
-| closeout | docs/skill/changeset/plans | current concise contract and exact proof | stale release essay/claims | skill sync + fixtures | intent/check/review/remote | in_progress |
+| closeout | docs/skill/changeset/plans | current concise contract and exact proof | stale release essay/claims | skill sync + fixtures | intent/check/review/remote | complete |
 
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
@@ -123,7 +123,7 @@ Completion Gates:
 | Agent-native reviewer | yes | CLI/source/generated/skill map | pass: command to owner to artifact map |
 | Final lint/check | yes | lint and `bun check` | pass after bounded tree cleanup repair |
 | Autoreview | yes | Resolve every accepted actionable finding | pass: clean exact branch P1 review at 0.87 |
-| Goal plan complete | yes | Run plan completion audit | pending |
+| Goal plan complete | yes | Run plan completion audit | pass |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
@@ -132,7 +132,7 @@ Phase / pass table:
 | Candidate selection | complete | split retained; two behavior repairs accepted | implementation |
 | Implementation | complete | conflicts and two review defects repaired | verification |
 | Verification | complete | full check and clean exact branch P1 review | closeout |
-| Closeout | in_progress | local candidate committed | remote delivery |
+| Closeout | complete | exact merge/release/npm/workflow read-back | done |
 
 Decisions and tradeoffs:
 - Drizzle-style leaf entries support the public subpath split; codegen hides
@@ -183,20 +183,25 @@ Verification evidence:
   runtime smoke scenarios.
 - Exact `origin/main...HEAD` P1 autoreview is clean at 0.87 confidence after
   the accepted repair; no actionable finding remains.
+- Exact head `cb3322c8` passed CI `32006113457`, Vercel, and auto-release,
+  then squash-merged as `3aff976a`. Release PR #360 merged as `f3a602b8` and
+  published GitHub plus npm `v0.25.0` for both packages with that exact
+  `gitHead`. Post-release CI `32006568741`, skill audit `32006530625`, and
+  Convex Matrix `32006560638` passed, including runtime scenarios.
 
 Timeline:
 - 2026-08-17 Architecture/autoclosure plan created after #341 release.
+- 2026-08-17 PR #342 merged, v0.25.0 published, and all post-release gates
+  passed.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Implementation |
-| Where am I going? | TDD repairs, regeneration, proof, review, delivery |
+| Where am I? | Complete |
+| Where am I going? | Done |
 | What is the goal? | Ship the real graph split without cleanup or correctness regressions |
 | What have I learned? | Core direction is sound; release story and two edge cases are slop |
-| What have I done? | Resolved conflicts, repaired two defects with TDD, regenerated outputs, and passed focused/package/skill gates |
+| What have I done? | Repaired, proved, merged, released, and read back the exact artifacts and remote gates |
 
 Open risks:
-- Generated maintenance isolation changes internal Convex function routes.
-- Capability boundaries touch write barriers, relation-count caches, and
-  aggregate lifecycle behavior merged after the contributor branch diverged.
+- None remaining inside PR #342 scope.


### PR DESCRIPTION
Closes the durable autoclosure records for PRs #329-#342.

- Records exact merge, release, npm, CI, skill, and Convex Matrix receipts for #342.
- Closes stale linked-plan states for #339-#341.
- Removes one circular plan link so the batch completion audit passes.
- Adds no product code, cron, or recurring workflow.

Verification: `bun lint:fix`, `bun check`, and the linked autogoal completion audit pass.