### PR TITLE
docs: require task per PR

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -16,6 +16,11 @@
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
 - **Task PR default:** The `task` and `major-task` skills explicitly require verified code-changing work to be committed, pushed, and opened/updated as a PR unless the user explicitly says not to, the work has no local patch, or a real blocker is recorded. Do not treat the lack of a separate "open a PR" user sentence as a blocker.
+- **One PR, one task:** Every PR an agent authors, reviews, repairs, or merges
+  requires its own `task` invocation and dedicated task plan. A batch plan may
+  order PRs, but one batch-level `task`, `auto`, or `autoclosure` run never
+  substitutes for the per-PR task. Use `autoclosure` only inside or after that
+  PR's task contract is established.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.
@@ -69,7 +74,8 @@ Use those skills when relevant:
   `milestone`, `prd`, timed, or review-until work. `auto full` continues through
   local task packets, implementation, proof, sync, review, checks, and GitHub
   PR delivery.
-- `task` for normal repo task execution.
+- `task` for normal repo task execution. It is mandatory once per PR an agent
+  authors, reviews, repairs, or merges, including every PR inside a batch.
 - `walkthrough` after final proof whenever a task, major task, or auto run
   changes UI or rendered output. Show the annotated images in the final
   handoff.
@@ -81,7 +87,8 @@ Use those skills when relevant:
 - `to-prd` for an implementation-ready local capability source.
 - `architecture-cleanup` for public exports, package boundaries, Convex import
   graphs, plugins, CLI/scaffolds, generated ownership, and navigation cost.
-- `autoclosure` to finish the current tree without creating new product scope.
+- `autoclosure` to finish the current tree without creating new product scope,
+  after the current PR has its own `task` invocation and task plan.
 - `design` for live `www`/`example` UI decisions and Browser proof.
 - `react-query` for cRPC query/mutation options, live subscription ownership,
   RSC preloading, and bounded invalidation.

--- a/.agents/rules/autoclosure.mdc
+++ b/.agents/rules/autoclosure.mdc
@@ -6,6 +6,8 @@ argument-hint: '[current tree | plan path | PR]'
 # Autoclosure
 
 Autoclosure finishes already-started work. It does not invent the next feature.
+It also does not replace `task`: every PR must enter through its own `task`
+invocation and dedicated task plan before autoclosure can finish it.
 
 ## Use When
 
@@ -17,16 +19,25 @@ Autoclosure finishes already-started work. It does not invent the next feature.
 Use `auto full` when substantial implementation remains. Use `task` for a named
 ordinary task and `major-task` for unresolved architecture.
 
+For a PR batch, use the batch plan only to choose order. Invoke `task` for each
+exact PR, then run autoclosure for that PR. Never autoclose several PRs from one
+aggregate task or plan.
+
 ## Goal Contract
 
 Create or resume a goal plan from the `autoclosure` template with the
 `agent-native` pack. Inventory the current intended delta from the active plan,
 source owners, and actual files. Do not absorb unrelated product scope.
 
+When the source is a PR, record the dedicated task invocation and task-plan
+path before any closure work. If only a batch-level plan exists, route back to
+`task`; missing per-PR task ownership is not an autoclosure waiver.
+
 ## Closure Matrix
 
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
+| per-PR task ownership | yes/no | exact PR + dedicated task plan | pending |
 | source behavior | yes/no | focused tests/runtime | pending |
 | package API/build | yes/no | exports/build/types | pending |
 | generated output | yes/no | source + regenerate + diff | pending |
@@ -42,21 +53,23 @@ Mark N/A only with a concrete reason.
 
 ## Closure Loop
 
-1. Reconstruct intended behavior and exclusions from the active source.
-2. Run the smallest missing proof first; classify failures before editing.
-3. Repair accepted defects within the existing contract.
-4. When package behavior changed, ensure changeset, package build, focused tests,
+1. Verify the exact PR already has its own `task` invocation and dedicated task
+   plan. Route to `task` first when it does not.
+2. Reconstruct intended behavior and exclusions from the active source.
+3. Run the smallest missing proof first; classify failures before editing.
+4. Repair accepted defects within the existing contract.
+5. When package behavior changed, ensure changeset, package build, focused tests,
    docs, and published kitcn skill all match.
-5. When scaffold/template behavior changed, edit the owner, regenerate fixtures
+6. When scaffold/template behavior changed, edit the owner, regenerate fixtures
    or examples, and run the required checks.
-6. When agent files changed, reconcile `skills-lock.json` through the CLI, run
+7. When agent files changed, reconcile `skills-lock.json` through the CLI, run
    `bun install`, and prove `.agents`/`.claude`/root generated mirrors.
-7. Run `deslop` once behavior works.
-8. Run `agent-native-reviewer`, resolve accepted findings, then `autoreview`.
-9. Run `bun lint:fix` and `bun check`; repeat only with a different repair when
+8. Run `deslop` once behavior works.
+9. Run `agent-native-reviewer`, resolve accepted findings, then `autoreview`.
+10. Run `bun lint:fix` and `bun check`; repeat only with a different repair when
    the prior move failed.
-10. Complete the GitHub commit/push/PR path when authorized by the active skill.
-11. Audit the goal plan and mark it complete only when every applicable row has
+11. Complete the GitHub commit/push/PR path when authorized by the active skill.
+12. Audit the goal plan and mark it complete only when every applicable row has
     evidence.
 
 ## Clean Definition
@@ -64,6 +77,8 @@ Mark N/A only with a concrete reason.
 Clean means:
 
 - requested behavior exists with regression proof;
+- when a PR is in scope, its exact slice has a dedicated `task` invocation and
+  task plan;
 - source/generated ownership is correct;
 - public exports, docs, package skill, examples, fixtures, and scenarios agree;
 - no stale alias, placeholder, skipped required gate, or accepted review finding

--- a/.agents/rules/task.mdc
+++ b/.agents/rules/task.mdc
@@ -23,6 +23,9 @@ they earn their keep, and verify before calling the task done.
 - Verify the actual result before claiming done.
 - Do not default to research swarms, review swarms, browser proof, GitHub
   comments, or compounding.
+- Every GitHub PR an agent authors, reviews, repairs, or merges requires a
+  dedicated `task` invocation and task plan for that exact PR. A batch-level
+  task, plan, `auto`, or `autoclosure` run does not satisfy this requirement.
 - For verified code-changing work, commit, push, and create or update a PR by
   default. The `task` skill is the explicit git permission. Only skip that path
   when the user explicitly says not to, the work has no local patch, the task is
@@ -84,7 +87,9 @@ they earn their keep, and verify before calling the task done.
 10. If testing or coverage work, load `testing` before `tdd` and choose the
     smallest honest slice.
 11. If program or batch work, restate the ordered scope and finish one slice at
-    a time unless the user asked for a broader sweep.
+    a time unless the user asked for a broader sweep. For a PR batch, invoke or
+    resume `task` separately for every exact PR and create or resume its
+    dedicated task plan before review, repair, merge, or `autoclosure`.
 12. For any GitHub source, record source type/id/title, task type, acceptance
     criteria, caveats, likely files/routes/packages, browser surface, and likely
     root-cause layer in the plan when a plan exists.
@@ -313,8 +318,12 @@ real closeout pressure.
 ### Program Or Batch Work
 
 1. Respect explicit order.
-2. Define done for the current slice before implementation.
-3. Complete one slice cleanly unless the user asks for a broader sweep.
+2. For every GitHub PR, invoke `task` with that exact PR and use a dedicated
+   per-PR task plan. A coordinating batch plan may link those plans but cannot
+   replace them.
+3. Define done for the current slice before implementation.
+4. Complete one `task` -> optional `autoclosure` slice cleanly before moving to
+   the next PR unless the user explicitly requested parallel work.
 
 ### Refactor Or Chore
 
@@ -451,6 +460,8 @@ with `gh pr view --json body` before final handoff.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.
+- Every agent-processed PR in a batch has its own `task` invocation and task
+  plan; no aggregate `autoclosure` was used as a substitute.
 - Verification matched change scope.
 - Verified code-changing work was committed and PR'd, or the user explicitly
   declined that path, the work had no local patch, or a real blocker was

--- a/.agents/skills/autoclosure/SKILL.md
+++ b/.agents/skills/autoclosure/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 # Autoclosure
 
 Autoclosure finishes already-started work. It does not invent the next feature.
+It also does not replace `task`: every PR must enter through its own `task`
+invocation and dedicated task plan before autoclosure can finish it.
 
 ## Use When
 
@@ -21,16 +23,25 @@ Autoclosure finishes already-started work. It does not invent the next feature.
 Use `auto full` when substantial implementation remains. Use `task` for a named
 ordinary task and `major-task` for unresolved architecture.
 
+For a PR batch, use the batch plan only to choose order. Invoke `task` for each
+exact PR, then run autoclosure for that PR. Never autoclose several PRs from one
+aggregate task or plan.
+
 ## Goal Contract
 
 Create or resume a goal plan from the `autoclosure` template with the
 `agent-native` pack. Inventory the current intended delta from the active plan,
 source owners, and actual files. Do not absorb unrelated product scope.
 
+When the source is a PR, record the dedicated task invocation and task-plan
+path before any closure work. If only a batch-level plan exists, route back to
+`task`; missing per-PR task ownership is not an autoclosure waiver.
+
 ## Closure Matrix
 
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
+| per-PR task ownership | yes/no | exact PR + dedicated task plan | pending |
 | source behavior | yes/no | focused tests/runtime | pending |
 | package API/build | yes/no | exports/build/types | pending |
 | generated output | yes/no | source + regenerate + diff | pending |
@@ -46,21 +57,23 @@ Mark N/A only with a concrete reason.
 
 ## Closure Loop
 
-1. Reconstruct intended behavior and exclusions from the active source.
-2. Run the smallest missing proof first; classify failures before editing.
-3. Repair accepted defects within the existing contract.
-4. When package behavior changed, ensure changeset, package build, focused tests,
+1. Verify the exact PR already has its own `task` invocation and dedicated task
+   plan. Route to `task` first when it does not.
+2. Reconstruct intended behavior and exclusions from the active source.
+3. Run the smallest missing proof first; classify failures before editing.
+4. Repair accepted defects within the existing contract.
+5. When package behavior changed, ensure changeset, package build, focused tests,
    docs, and published kitcn skill all match.
-5. When scaffold/template behavior changed, edit the owner, regenerate fixtures
+6. When scaffold/template behavior changed, edit the owner, regenerate fixtures
    or examples, and run the required checks.
-6. When agent files changed, reconcile `skills-lock.json` through the CLI, run
+7. When agent files changed, reconcile `skills-lock.json` through the CLI, run
    `bun install`, and prove `.agents`/`.claude`/root generated mirrors.
-7. Run `deslop` once behavior works.
-8. Run `agent-native-reviewer`, resolve accepted findings, then `autoreview`.
-9. Run `bun lint:fix` and `bun check`; repeat only with a different repair when
+8. Run `deslop` once behavior works.
+9. Run `agent-native-reviewer`, resolve accepted findings, then `autoreview`.
+10. Run `bun lint:fix` and `bun check`; repeat only with a different repair when
    the prior move failed.
-10. Complete the GitHub commit/push/PR path when authorized by the active skill.
-11. Audit the goal plan and mark it complete only when every applicable row has
+11. Complete the GitHub commit/push/PR path when authorized by the active skill.
+12. Audit the goal plan and mark it complete only when every applicable row has
     evidence.
 
 ## Clean Definition
@@ -68,6 +81,8 @@ Mark N/A only with a concrete reason.
 Clean means:
 
 - requested behavior exists with regression proof;
+- when a PR is in scope, its exact slice has a dedicated `task` invocation and
+  task plan;
 - source/generated ownership is correct;
 - public exports, docs, package skill, examples, fixtures, and scenarios agree;
 - no stale alias, placeholder, skipped required gate, or accepted review finding

--- a/.agents/skills/task/SKILL.md
+++ b/.agents/skills/task/SKILL.md
@@ -27,6 +27,9 @@ they earn their keep, and verify before calling the task done.
 - Verify the actual result before claiming done.
 - Do not default to research swarms, review swarms, browser proof, GitHub
   comments, or compounding.
+- Every GitHub PR an agent authors, reviews, repairs, or merges requires a
+  dedicated `task` invocation and task plan for that exact PR. A batch-level
+  task, plan, `auto`, or `autoclosure` run does not satisfy this requirement.
 - For verified code-changing work, commit, push, and create or update a PR by
   default. The `task` skill is the explicit git permission. Only skip that path
   when the user explicitly says not to, the work has no local patch, the task is
@@ -88,7 +91,9 @@ they earn their keep, and verify before calling the task done.
 10. If testing or coverage work, load `testing` before `tdd` and choose the
     smallest honest slice.
 11. If program or batch work, restate the ordered scope and finish one slice at
-    a time unless the user asked for a broader sweep.
+    a time unless the user asked for a broader sweep. For a PR batch, invoke or
+    resume `task` separately for every exact PR and create or resume its
+    dedicated task plan before review, repair, merge, or `autoclosure`.
 12. For any GitHub source, record source type/id/title, task type, acceptance
     criteria, caveats, likely files/routes/packages, browser surface, and likely
     root-cause layer in the plan when a plan exists.
@@ -317,8 +322,12 @@ real closeout pressure.
 ### Program Or Batch Work
 
 1. Respect explicit order.
-2. Define done for the current slice before implementation.
-3. Complete one slice cleanly unless the user asks for a broader sweep.
+2. For every GitHub PR, invoke `task` with that exact PR and use a dedicated
+   per-PR task plan. A coordinating batch plan may link those plans but cannot
+   replace them.
+3. Define done for the current slice before implementation.
+4. Complete one `task` -> optional `autoclosure` slice cleanly before moving to
+   the next PR unless the user explicitly requested parallel work.
 
 ### Refactor Or Chore
 
@@ -455,6 +464,8 @@ with `gh pr view --json body` before final handoff.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.
+- Every agent-processed PR in a batch has its own `task` invocation and task
+  plan; no aggregate `autoclosure` was used as a substitute.
 - Verification matched change scope.
 - Verified code-changing work was committed and PR'd, or the user explicitly
   declined that path, the work had no local patch, or a real blocker was

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
 - **Task PR default:** The `task` and `major-task` skills explicitly require verified code-changing work to be committed, pushed, and opened/updated as a PR unless the user explicitly says not to, the work has no local patch, or a real blocker is recorded. Do not treat the lack of a separate "open a PR" user sentence as a blocker.
+- **One PR, one task:** Every PR an agent authors, reviews, repairs, or merges
+  requires its own `task` invocation and dedicated task plan. A batch plan may
+  order PRs, but one batch-level `task`, `auto`, or `autoclosure` run never
+  substitutes for the per-PR task. Use `autoclosure` only inside or after that
+  PR's task contract is established.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.
@@ -74,7 +79,8 @@ Use those skills when relevant:
   `milestone`, `prd`, timed, or review-until work. `auto full` continues through
   local task packets, implementation, proof, sync, review, checks, and GitHub
   PR delivery.
-- `task` for normal repo task execution.
+- `task` for normal repo task execution. It is mandatory once per PR an agent
+  authors, reviews, repairs, or merges, including every PR inside a batch.
 - `walkthrough` after final proof whenever a task, major task, or auto run
   changes UI or rendered output. Show the annotated images in the final
   handoff.
@@ -86,7 +92,8 @@ Use those skills when relevant:
 - `to-prd` for an implementation-ready local capability source.
 - `architecture-cleanup` for public exports, package boundaries, Convex import
   graphs, plugins, CLI/scaffolds, generated ownership, and navigation cost.
-- `autoclosure` to finish the current tree without creating new product scope.
+- `autoclosure` to finish the current tree without creating new product scope,
+  after the current PR has its own `task` invocation and task plan.
 - `design` for live `www`/`example` UI decisions and Browser proof.
 - `react-query` for cRPC query/mutation options, live subscription ownership,
   RSC preloading, and bounded invalidation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## One PR, one task
+
+Human contributors can open PRs normally. Whenever an agent authors, reviews,
+repairs, or merges a PR, invoke `task` for that exact PR and keep a dedicated
+task plan under `docs/plans/**`.
+
+Invoke `$kitcn:task <PR URL or #>` for an existing PR. For a new PR, invoke
+`$kitcn:task <issue, spec, or single-PR task>` before editing.
+
+- A batch plan can choose dependency order, but it cannot replace per-PR task
+  plans.
+- Run `autoclosure` only after the exact PR has entered through `task`.
+- Finish one `task` -> optional `autoclosure` PR slice before moving to the next
+  PR unless parallel work was explicitly requested.
+- Use the task-style PR body and record exact checks, merge, release, and
+  read-back receipts when they apply.
+
+## Verification
+
+Run the owning focused checks while iterating, then run the repository gate
+before opening or updating a PR:
+
+```bash
+bun install
+bun check
+```
+
+Edits to `.agents/AGENTS.md` or `.agents/rules/**` must be regenerated with
+`bun install`; never edit generated skill or root-agent mirrors directly.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ bun run test
 bun run lint
 ```
 
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the PR workflow.
+
 ## Example App
 
 The canonical reference app lives in [example](./example). It demonstrates current best-practice usage across auth, cRPC, ORM, HTTP routes, and TanStack Query.

--- a/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
+++ b/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
@@ -17,6 +17,8 @@ Applied packs:
 - agent-native (docs/plans/templates/packs/agent-native.md)
 
 Linked plans:
+- [Per-PR task workflow repair](docs/plans/2026-08-17-require-task-per-pr.md) -
+  Make one dedicated `task` run and plan mandatory for every future PR slice.
 - [PR #329 autoclosure](docs/plans/2026-08-16-pr-329-autoclosure.md) -
   Solid infinite-query mount crash and first release root.
 - [PR #330 autoclosure](docs/plans/2026-08-16-pr-330-autoclosure.md) -
@@ -196,7 +198,7 @@ Phase / pass table:
 | Repair | complete | accepted correctness, ownership, and proof defects fixed | review |
 | Review/checks | complete | focused/full gates and final reviews pass | delivery |
 | Delivery | complete | every PR merged and applicable releases published | final audit |
-| Closeout | complete | exact #342/release/npm/workflow read-back | done |
+| Closeout | in_progress | batch receipts complete; per-PR task workflow repair pending | workflow repair |
 
 Verification evidence:
 - GitHub snapshot: 14 contributor PRs #329-#342; every head had green CI and
@@ -338,4 +340,5 @@ Reboot status:
 | What have I done? | Repaired, reviewed, merged, released, and remotely verified all 14 frozen PRs without adding recurring automation. |
 
 Open risks:
-- None inside the frozen #329-#342 batch. PR #352 is explicitly outside scope.
+- The original batch cannot retroactively prove per-PR task runs. The linked
+  workflow repair prevents recurrence; PR #352 remains outside scope.

--- a/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
+++ b/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
@@ -198,7 +198,7 @@ Phase / pass table:
 | Repair | complete | accepted correctness, ownership, and proof defects fixed | review |
 | Review/checks | complete | focused/full gates and final reviews pass | delivery |
 | Delivery | complete | every PR merged and applicable releases published | final audit |
-| Closeout | in_progress | batch receipts complete; per-PR task workflow repair pending | workflow repair |
+| Closeout | complete | batch receipts plus per-PR task workflow repair PR #363 | done |
 
 Verification evidence:
 - GitHub snapshot: 14 contributor PRs #329-#342; every head had green CI and

--- a/docs/plans/2026-08-17-require-task-per-pr.md
+++ b/docs/plans/2026-08-17-require-task-per-pr.md
@@ -1,0 +1,408 @@
+# require task per pr
+
+Objective:
+Require one dedicated `task` run and task plan for every agent-processed PR,
+including PRs inside a batch, and keep autoclosure as a per-PR closeout step.
+
+Goal plan:
+docs/plans/2026-08-17-require-task-per-pr.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- docs (docs/plans/templates/packs/docs.md)
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Task source:
+- type: user workflow correction after PR #362
+- id / link: https://github.com/udecode/kitcn/pull/362
+- title: Require task for each PR
+- acceptance criteria: enforce the requirement in AGENTS, task, autoclosure,
+  plan templates, generated mirrors, and contributor guidance; ship through a
+  task-style follow-up PR because #362 was already sealed by GitHub
+
+Timed checkpoint:
+- requested duration: N/A
+- semantics: N/A
+- initial confidence score: 85%
+- improvement loop: source/generated/contributor audit, agent-native review,
+  autoreview, full gate, exact PR read-back
+- final score / loop closure: 99%; source, mirrors, templates, contributor
+  discovery, intent checks, agent-native review, and autoreview agree
+
+Completion threshold:
+- Canonical rules require one `task` invocation and dedicated task plan for
+  every PR an agent authors, reviews, repairs, or merges; batch and autoclosure
+  paths cannot substitute; generated mirrors and contributor guidance agree.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` passes.
+
+Verification surface:
+- Source/generated parity after `bun install`; exact policy searches across
+  AGENTS/task/autoclosure/template/contributor surfaces; agent-native reviewer;
+  final branch autoreview; `bun lint:fix`; `bun check`; task-style PR body and
+  exact remote gate/merge read-back.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: user correction plus `.agents/AGENTS.md`, `task`, and
+  `autoclosure` source rules.
+- Allowed edit scope: workflow sources, generated mirrors, plan templates,
+  contributor docs, README link, and active proof plans.
+- Browser surface: N/A; no rendered product output.
+- GitHub issue sync: N/A; follow-up PR links the sealed #362 context.
+- Non-goals: product/package behavior, forcing human-only contributors to run
+  an agent skill, or retroactively claiming the original batch used `task`.
+
+Output budget strategy:
+- Scope searches to workflow sources/mirrors/docs and cap command output; use
+  exact parity diffs rather than streaming generated trees.
+
+Blocked condition:
+- Stop only if mirror generation cannot reproduce source rules after a clean
+  install, required review finds a contradictory owner, or GitHub authority
+  prevents the follow-up PR after three verified attempts.
+
+Task state:
+- task_type: agent workflow and contributor-doc repair
+- task_complexity: non-trivial
+- current_phase: verification
+- current_phase_status: in_progress
+- next_phase: commit and PR
+- goal_status: active
+
+Current verdict:
+- verdict: valid
+- confidence: 85%
+- next owner: task
+- reason: the batch-level autoclosure plan did not establish per-PR task owners
+
+Implementation readiness:
+- verdict: ready
+- exact owner: `.agents/AGENTS.md`, `.agents/rules/task.mdc`, and
+  `.agents/rules/autoclosure.mdc`
+- contradiction status: none; current rules recommend task but do not require
+  one invocation and plan per PR inside a batch
+- source-listed cases complete: yes
+
+Pre-solution issue challenge:
+- reporter claim: the agent processed the PR batch without `task` per PR
+- suggested diagnosis or fix: make per-PR task use mandatory in AGENTS and
+  contributor/workflow surfaces
+- repro ladder:
+  - tests / source-level repro: current task and autoclosure rules allow one
+    aggregate batch plan without an explicit per-PR task gate
+  - repo-owned automated browser or integration proof: N/A
+  - Browser plugin: N/A
+  - screenshot / visual proof: N/A
+- reproduction verdict: reproduced from canonical workflow text and batch plan
+- validity verdict: valid
+- best long-term fix boundary: canonical rules plus autoclosure template and
+  contributor discovery, then generated mirrors
+- harsh honest feedback: aggregate autoclosure is not task ownership; the old
+  wording was too weak to prevent exactly this failure
+- hard-stop decision: proceed
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration |
+| Walkthrough baseline for possible UI change | no | N/A: workflow Markdown only |
+| Skill analysis before edits | yes | `task`; agent-native review and autoreview required |
+| Active goal checked or created | yes | active #329-#342 batch goal; this repair is a linked closeout requirement |
+| Source of truth read before edits | yes | user correction, PR #362 state, canonical rules, templates, README |
+| Exact per-PR task ownership | yes | this plan owns the single workflow-repair PR created after sealed #362 |
+| GitHub comments and attachments read | no | N/A: source is the user's correction; PR #362 state/body were read |
+| Video transcript evidence required | no | N/A: no video |
+| Pre-solution issue challenge required | yes | valid workflow failure reproduced in canonical text |
+| Reproduction verdict before implementation | yes | reproduced: no per-PR task gate existed |
+| Repro escalation ladder selected | yes | source audit owns this documentation/rule failure |
+| Suggested fix reviewed against durable boundary | yes | fix sources, template, contributor discovery, then regenerate |
+| `docs/solutions` checked for non-trivial existing-code work | yes | no workflow solution owner; canonical rules/templates own the fix |
+| TDD decision before behavior change or bug fix | no | N/A: rule/docs hard cut, no runtime behavior |
+| Branch decision for code-changing task | yes | `codex/require-task-per-pr` from sealed #362 main |
+| Release artifact decision | no | N/A: no package delta |
+| Browser tool decision for browser surface | no | N/A: no browser surface |
+| Commit / PR expectation decision | yes | task requires commit/push/follow-up PR |
+| Task-style PR body decision | yes | required PR #270 emoji shape |
+| GitHub issue sync expectation decision | no | N/A: no issue |
+| Output budget strategy recorded | yes | scoped/capped source and parity reads |
+| Docs pack selected | yes | supporting contributor docs and README |
+| Docs guidance loaded | yes | root README and docs ownership map |
+| Docs lane selected | yes | repository contributor workflow, not www user docs |
+| Target docs and nearest sibling docs read | yes | README, AGENTS, task/autoclosure/template owners |
+| Docs style doctrine read | no | N/A: no `www/**` docs |
+| Documented source owner identified | yes | `.agents` sources; CONTRIBUTING is human discovery owner |
+| Agent-native pack selected | yes | applied at plan creation |
+| Agent-facing action surface identified | yes | exact PR enters through `task`, then optional autoclosure |
+| Source rule versus generated mirror boundary identified | yes | edit `.agents/AGENTS.md` and `.agents/rules/**`; run `bun install` |
+| Installed-skill lock versus local-rule owner identified | yes | no installed-skill change; lock N/A |
+| `agent-native-reviewer` loaded or waiver recorded | yes | loaded; capability map passes with no findings |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Every agent-processed GitHub PR has its own task plan. This plan owns one
+      exact PR, owns a not-yet-created PR slice, or records N/A because no PR is
+      in scope; a batch plan is not used as a substitute.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+- [x] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [x] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [x] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [x] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [x] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Source/mirror/template/doc audit plus repository gate | source audit, intent gates, reviews, and `bun check` pass |
+| Exact per-PR task ownership | yes | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | this plan owns the one follow-up workflow-repair PR |
+| Pre-solution issue challenge verdict | yes | Record claim, repro, verdict, boundary | valid; aggregate workflow lacked per-PR gate |
+| Repro escalation ladder | yes | Source-level proof; higher layers N/A | canonical text proved the gap; no UI/runtime surface |
+| Bug reproduced before fix | yes | Record source repro | task/autoclosure had no mandatory per-PR gate |
+| Targeted behavior verification | yes | Source/generated/template audit | exact fixed-string audit passes |
+| TypeScript or typed config changed | no | N/A | Markdown only |
+| Package exports or file layout changed | no | N/A | no package delta |
+| Package manifests, lockfile, or install graph changed | no | N/A | install changed no manifest or lock content |
+| Agent rules or skills changed | yes | Run `bun install` and verify generated skill sync | pass; root/Codex/Claude mirrors agree |
+| Workspace authority proof | yes | Verify in `/Users/zbeyens/git/better-convex` | source, mirrors, templates, and repo scripts audited here |
+| Browser surface changed | no | N/A | no browser surface |
+| Browser final proof | no | N/A | no rendered product output |
+| UI walkthrough | no | N/A | no UI/rendered output |
+| Scaffold or fixture output changed | no | N/A | no scaffold delta |
+| Package behavior or public API changed | no | N/A | no changeset required |
+| Docs and kitcn skill sync changed | no | N/A | no `www/**` or published kitcn skill change |
+| Docs or content changed | yes | Verify source-backed claims and link | CONTRIBUTING claims map to canonical rules; README link resolves |
+| High-risk mini gate | yes | Record workflow failure mode and proof | aggregate autoclosure skip; fixed at canonical routes and mandatory plan gates |
+| Agent-native review for agent/tooling changes | yes | Run capability review | PASS; no findings after task-template gate repair |
+| Local install corruption suspected | no | N/A | no corruption signal |
+| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR proof image hosting | no | N/A | no browser proof images |
+| GitHub issue sync-back | no | N/A | no issue source |
+| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final lint | yes | Run `bun lint:fix` | pass; 929 files, no fixes |
+| Output budget discipline | yes | Verify scoped/capped output | pass; one broad full-check stream belongs to prior #362 task, not this run |
+| Timed checkpoint | no | N/A | no duration |
+| Autoreview for non-trivial implementation changes | yes | Run dirty local review | clean, correct 0.99, no actionable findings |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` | pending |
+| Docs source-backed claim audit | yes | Verify contributor claims against rules | pass |
+| Docs links / routes / previews | yes | Verify README leaf link | `CONTRIBUTING.md` exists at linked path |
+| Docs MDX/content parser | no | N/A | no MDX/www change |
+| Kitcn docs sync | no | N/A | no www/published skill change |
+| Agent source / generated sync | yes | Run install and verify mirrors | pass |
+| Installed lock audit | no | N/A | no installed-skill changes |
+| Agent action discoverability | yes | Audit AGENTS/task/autoclosure/CONTRIBUTING | pass |
+| Helper and template smoke | yes | Verify mandatory task/autoclosure plan gates | both templates expose pending gate and represent exact completion evidence |
+| Agent-native review | yes | Close accepted findings | PASS; task-template enforcement gap accepted and fixed |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | user source, PR state, rules/templates/docs read | implementation |
+| Implementation | complete | canonical rules, templates, mirrors, contributor docs | verification |
+| Verification | complete | intent, source/mirror audit, reviews, and `bun check` pass | commit/PR |
+| Commit / PR / GitHub sync | pending | | final response |
+| Closeout | pending | | final response |
+
+Findings:
+- The old workflow recommended `task` but did not require one invocation and
+  plan per PR inside a batch.
+- Agent-native review found the first repair still lacked a mandatory gate in
+  the task-plan template; accepted and fixed.
+
+Decisions and tradeoffs:
+- Apply the mandate to agent-processed PRs; human-only contributors can submit
+  normally.
+- Keep batch plans as ordering owners and autoclosure as closeout only.
+
+Implementation notes:
+- Canonical owners are `.agents/AGENTS.md`, task/autoclosure rule sources, and
+  repo plan templates. `bun install` regenerated root and skill mirrors.
+
+Review fixes:
+- Added the exact per-PR ownership gate to the task template after the
+  agent-native review identified that completion was not machine-represented.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| Literal-safe source audit used shell backticks in a double-quoted command | 1 | use single-quoted patterns or fixed-string searches | harmless `task: command not found`; rerun safely |
+| Used `bunx intent` instead of repo-owned scripts | 1 | run package scripts named in package.json | `bun run intent:validate` and `intent:stale` pass |
+
+Verification evidence:
+- `bun install` regenerated root and skill mirrors twice after source edits.
+- Fixed-string routing audit and Codex/Claude mirror comparisons pass.
+- `bun run intent:validate` and `bun run intent:stale` pass.
+- Agent-native review passes after one accepted template-gate fix.
+- Local autoreview is clean at 0.99 with no actionable findings.
+- `bun check` passes on the final workflow source, mirrors, templates, plans,
+  and contributor docs, including all fixtures and runtime scenarios.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| existing PR | agent must use task before review/repair/merge | exact PR + dedicated plan rule audit | batch rule allowed aggregate ownership | one task and plan per exact PR | task/AGENTS/autoclosure sources and mirrors | pass |
+| new PR | agent task begins before PR number exists | task template ownership gate | no exact single-PR slice gate | one not-yet-created PR slice per task plan | task template constraint/start/completion gates | pass |
+| PR batch | batch plan may order but not replace tasks | program/batch and contributor audits | one batch autoclosure could cover all PRs | linked per-PR task plans, sequential task to autoclosure slices | task/autoclosure/AGENTS/CONTRIBUTING | pass |
+| autoclosure without task | route back before closeout | autoclosure source/template audit | no prerequisite | missing per-PR task is forbidden, not waived | source, mirror, closure matrix, checklist, completion gate | pass |
+| human-only author | submitting without Codex remains allowed | CONTRIBUTING audit | ambiguous scope could burden external contributors | agent mandate only | CONTRIBUTING opening paragraph | pass |
+
+Final handoff contract:
+- Commit line: pending until delivery
+- PR line: follow-up required because #362 sealed during interrupted merge
+- Issue line: N/A
+- Confidence line: 99%
+- Flow table:
+  - Reproduced: source audit red, browser N/A
+  - Verified: source/mirror/template/check/review green, browser N/A
+- Browser check: N/A
+- Outcome: one agent-processed PR requires one task invocation and plan
+- Caveat: #362 was already merged and cannot accept another commit
+- Design:
+  - Chosen boundary: canonical rules + required plan gates + contributor discovery
+  - Why not quick patch: AGENTS-only wording would not constrain task/autoclosure plans
+  - Why not broader change: no runtime/CI can reliably prove a skill invocation occurred
+- Verified: install parity, intent gates, source audit, agent-native review,
+  autoreview, and full repository check
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  an emoji confidence line like `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: pending
+- PR: pending
+- Issue: pending
+- Browser proof: pending
+- Caveats: pending
+
+Timeline:
+- 2026-08-17T08:25:05.242Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
+| What is the goal? | TODO: Fill from Objective |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Pending.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/2026-08-17-require-task-per-pr.md
+++ b/docs/plans/2026-08-17-require-task-per-pr.md
@@ -86,10 +86,10 @@ Blocked condition:
 Task state:
 - task_type: agent workflow and contributor-doc repair
 - task_complexity: non-trivial
-- current_phase: verification
-- current_phase_status: in_progress
-- next_phase: commit and PR
-- goal_status: active
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: done
+- goal_status: complete after exact merge read-back
 
 Current verdict:
 - verdict: valid
@@ -269,7 +269,7 @@ Completion Gates:
 | Agent-native review for agent/tooling changes | yes | Run capability review | PASS; no findings after task-template gate repair |
 | Local install corruption suspected | no | N/A | no corruption signal |
 | Commit created | yes | Stage whole checkout and commit | `c72bbfd5` initial workflow commit; final plan receipt commit follows |
-| PR create or update | yes | Push and create/update PR | PR #363 open from dedicated branch after full check |
+| PR create or update | yes | Push and create/update PR | PR #363 exact head `f6c9549b` passed CI `32011406464`, Vercel, and auto-release |
 | Task-style PR body verified | yes | Read back exact PR #270 emoji body | `gh pr view 363 --json body` matches all required fields and has no self-link |
 | PR proof image hosting | no | N/A | no browser proof images |
 | GitHub issue sync-back | no | N/A | no issue source |
@@ -278,7 +278,7 @@ Completion Gates:
 | Output budget discipline | yes | Verify scoped/capped output | pass; one broad full-check stream belongs to prior #362 task, not this run |
 | Timed checkpoint | no | N/A | no duration |
 | Autoreview for non-trivial implementation changes | yes | Run dirty local review | clean, correct 0.99, no actionable findings |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` | final audit pending after this receipt update |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` | pass after final receipt update |
 | Docs source-backed claim audit | yes | Verify contributor claims against rules | pass |
 | Docs links / routes / previews | yes | Verify README leaf link | `CONTRIBUTING.md` exists at linked path |
 | Docs MDX/content parser | no | N/A | no MDX/www change |
@@ -296,7 +296,7 @@ Phase / pass table:
 | Implementation | complete | canonical rules, templates, mirrors, contributor docs | verification |
 | Verification | complete | intent, source/mirror audit, reviews, and `bun check` pass | commit/PR |
 | Commit / PR / GitHub sync | complete | commit pushed; PR #363 task body read back | remote gates/merge |
-| Closeout | in_progress | local proof complete | exact remote gates and merge |
+| Closeout | complete | exact source head gates green; final receipt-only head will be merged | done |
 
 Findings:
 - The old workflow recommended `task` but did not require one invocation and
@@ -331,6 +331,8 @@ Verification evidence:
 - Local autoreview is clean at 0.99 with no actionable findings.
 - `bun check` passes on the final workflow source, mirrors, templates, plans,
   and contributor docs, including all fixtures and runtime scenarios.
+- PR #363 head `f6c9549b` passed CI run `32011406464` in 6m03s,
+  Vercel, and auto-release run `32011406411` with no release requested.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |
@@ -342,8 +344,8 @@ Source-listed case matrix:
 | human-only author | submitting without Codex remains allowed | CONTRIBUTING audit | ambiguous scope could burden external contributors | agent mandate only | CONTRIBUTING opening paragraph | pass |
 
 Final handoff contract:
-- Commit line: `c72bbfd5 docs: require task per PR`
-- PR line: #363 opened from dedicated task branch; final plan receipt follows
+- Commit line: `c72bbfd5 docs: require task per PR`; `f6c9549b` records PR
+- PR line: #363 exact source head gates green; final receipt-only head follows
 - Issue line: N/A
 - Confidence line: 99%
 - Flow table:
@@ -382,8 +384,8 @@ Task-style PR body contract:
 
 Final handoff / sync:
 - Commit: `c72bbfd5`
-- PR: https://github.com/udecode/kitcn/pull/363
-- Issue: pending
+- PR: https://github.com/udecode/kitcn/pull/363; exact source gates green
+- Issue: N/A
 - Browser proof: N/A
 - Caveats: #362 was already sealed; #363 is the technically necessary follow-up
 
@@ -394,13 +396,14 @@ Reboot status:
 | Question | Answer |
 |----------|--------|
 | Where am I? | Remote closeout |
-| Where am I going? | Exact #363 gates and merge |
+| Where am I going? | Final receipt-only head gates and exact merge |
 | What is the goal? | Require one task invocation and plan per agent-processed PR |
 | What have I learned? | Rules need plan gates; prose alone did not prevent aggregate autoclosure |
 | What have I done? | Patched sources/templates/docs, regenerated mirrors, proved locally, opened #363 |
 
 Open risks:
-- Required remote gates and merge remain for PR #363.
+- None in the workflow repair. Final merge read-back is an external GitHub
+  receipt and cannot be committed inside the PR after it merges.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/2026-08-17-require-task-per-pr.md
+++ b/docs/plans/2026-08-17-require-task-per-pr.md
@@ -210,10 +210,10 @@ Work Checklist:
       N/A with reason.
 - [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
       requirements, PR body sync, and issue sync when applicable.
-- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
       completed, no local patch, user explicitly declined, or blocker recorded.
       "User did not separately ask for a PR" is not a valid blocker.
-- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
       recorded, or blocker recorded.
 - [x] Branch handling recorded for code-changing work: dedicated branch used,
       new branch needed, or N/A with reason.
@@ -268,17 +268,17 @@ Completion Gates:
 | High-risk mini gate | yes | Record workflow failure mode and proof | aggregate autoclosure skip; fixed at canonical routes and mandatory plan gates |
 | Agent-native review for agent/tooling changes | yes | Run capability review | PASS; no findings after task-template gate repair |
 | Local install corruption suspected | no | N/A | no corruption signal |
-| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| Commit created | yes | Stage whole checkout and commit | `c72bbfd5` initial workflow commit; final plan receipt commit follows |
+| PR create or update | yes | Push and create/update PR | PR #363 open from dedicated branch after full check |
+| Task-style PR body verified | yes | Read back exact PR #270 emoji body | `gh pr view 363 --json body` matches all required fields and has no self-link |
 | PR proof image hosting | no | N/A | no browser proof images |
 | GitHub issue sync-back | no | N/A | no issue source |
-| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final handoff contract | yes | Fill exact PR/confidence/proof/outcome/caveat/design | complete below |
 | Final lint | yes | Run `bun lint:fix` | pass; 929 files, no fixes |
 | Output budget discipline | yes | Verify scoped/capped output | pass; one broad full-check stream belongs to prior #362 task, not this run |
 | Timed checkpoint | no | N/A | no duration |
 | Autoreview for non-trivial implementation changes | yes | Run dirty local review | clean, correct 0.99, no actionable findings |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-require-task-per-pr.md` | final audit pending after this receipt update |
 | Docs source-backed claim audit | yes | Verify contributor claims against rules | pass |
 | Docs links / routes / previews | yes | Verify README leaf link | `CONTRIBUTING.md` exists at linked path |
 | Docs MDX/content parser | no | N/A | no MDX/www change |
@@ -295,8 +295,8 @@ Phase / pass table:
 | Intake and source read | complete | user source, PR state, rules/templates/docs read | implementation |
 | Implementation | complete | canonical rules, templates, mirrors, contributor docs | verification |
 | Verification | complete | intent, source/mirror audit, reviews, and `bun check` pass | commit/PR |
-| Commit / PR / GitHub sync | pending | | final response |
-| Closeout | pending | | final response |
+| Commit / PR / GitHub sync | complete | commit pushed; PR #363 task body read back | remote gates/merge |
+| Closeout | in_progress | local proof complete | exact remote gates and merge |
 
 Findings:
 - The old workflow recommended `task` but did not require one invocation and
@@ -342,8 +342,8 @@ Source-listed case matrix:
 | human-only author | submitting without Codex remains allowed | CONTRIBUTING audit | ambiguous scope could burden external contributors | agent mandate only | CONTRIBUTING opening paragraph | pass |
 
 Final handoff contract:
-- Commit line: pending until delivery
-- PR line: follow-up required because #362 sealed during interrupted merge
+- Commit line: `c72bbfd5 docs: require task per PR`
+- PR line: #363 opened from dedicated task branch; final plan receipt follows
 - Issue line: N/A
 - Confidence line: 99%
 - Flow table:
@@ -358,7 +358,7 @@ Final handoff contract:
   - Why not broader change: no runtime/CI can reliably prove a skill invocation occurred
 - Verified: install parity, intent gates, source audit, agent-native review,
   autoreview, and full repository check
-- PR body verified: pending
+- PR body verified: exact #270 emoji shape read back with `gh pr view 363`
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -381,11 +381,11 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: pending
-- PR: pending
+- Commit: `c72bbfd5`
+- PR: https://github.com/udecode/kitcn/pull/363
 - Issue: pending
-- Browser proof: pending
-- Caveats: pending
+- Browser proof: N/A
+- Caveats: #362 was already sealed; #363 is the technically necessary follow-up
 
 Timeline:
 - 2026-08-17T08:25:05.242Z Task goal plan created.
@@ -393,14 +393,14 @@ Timeline:
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Intake and source read |
-| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
-| What is the goal? | TODO: Fill from Objective |
-| What have I learned? | See Findings |
-| What have I done? | See Timeline |
+| Where am I? | Remote closeout |
+| Where am I going? | Exact #363 gates and merge |
+| What is the goal? | Require one task invocation and plan per agent-processed PR |
+| What have I learned? | Rules need plan gates; prose alone did not prevent aggregate autoclosure |
+| What have I done? | Patched sources/templates/docs, regenerated mirrors, proved locally, opened #363 |
 
 Open risks:
-- Pending.
+- Required remote gates and merge remain for PR #363.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/templates/autoclosure.md
+++ b/docs/plans/templates/autoclosure.md
@@ -38,6 +38,7 @@ Blocked condition:
 Start Gates:
 | Gate | Applies | Evidence |
 | --- | --- | --- |
+| Dedicated task invocation and plan for exact PR | pending | pending |
 | Active source/plan reconstructed | pending | pending |
 | Intended delta and exclusions recorded | pending | pending |
 | Closure matrix classified | pending | pending |
@@ -47,6 +48,7 @@ Start Gates:
 Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
+| per-PR task ownership | pending | exact PR + dedicated task plan | pending |
 | source behavior | pending | pending | pending |
 | package/API/build | pending | pending | pending |
 | generated output | pending | pending | pending |
@@ -59,6 +61,8 @@ Closure matrix:
 | GitHub delivery | pending | pending | pending |
 
 Work Checklist:
+- [ ] Each agent-processed PR has its own `task` invocation and dedicated task
+      plan; a batch plan or aggregate autoclosure is not used as a substitute.
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
 - [ ] Each lane is proven or N/A with a concrete reason.
 - [ ] Generated output was changed through its owner and regenerated.
@@ -75,6 +79,7 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
+| Per-PR task ownership | pending | Record exact PR and dedicated task-plan path | pending |
 | Targeted behavior proof | pending | Run smallest missing owning proof | pending |
 | Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
 | Package/docs/scenario closure | pending | Run every applicable local contract | pending |

--- a/docs/plans/templates/task.md
+++ b/docs/plans/templates/task.md
@@ -39,6 +39,8 @@ Verification surface:
 Constraints:
 - Preserve existing user-facing behavior outside the task scope.
 - Prefer the durable ownership boundary over caller-by-caller patches.
+- When a GitHub PR is in scope, this plan owns exactly one PR. A coordinating
+  batch plan must link a separate task plan for every PR an agent processes.
 - Verified code changes must be committed and PR'd because the task skill
   requires that path unless the user explicitly says not to, the work has no
   local patch, or a real blocker is recorded.
@@ -114,6 +116,7 @@ Start Gates:
 | Skill analysis before edits | pending | pending |
 | Active goal checked or created | pending | pending |
 | Source of truth read before edits | pending | pending |
+| Exact per-PR task ownership | pending | Record one exact PR, or N/A before a new PR exists |
 | GitHub comments and attachments read | pending | pending |
 | Video transcript evidence required | pending | pending |
 | Pre-solution issue challenge required | pending | pending |
@@ -139,6 +142,9 @@ Work Checklist:
 - [ ] Task source classified with source type, id/link, title, task type,
       acceptance criteria, caveats, likely files/routes/packages, browser
       surface, and root-cause layer.
+- [ ] Every agent-processed GitHub PR has its own task plan. This plan owns one
+      exact PR, owns a not-yet-created PR slice, or records N/A because no PR is
+      in scope; a batch plan is not used as a substitute.
 - [ ] Required video or screen-recording evidence is cached/read as normalized
       `<video-transcripts>` XML, or marked N/A with reason.
 - [ ] For public GitHub bug reports, behavior claims, technical diagnoses, or
@@ -195,6 +201,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | pending | Run the command, proof, source audit, or artifact check named in this plan | pending |
+| Exact per-PR task ownership | pending | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | pending |
 | Pre-solution issue challenge verdict | pending | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | pending |
 | Repro escalation ladder | pending | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | pending |
 | Bug reproduced before fix | pending | Record failing test/repro or N/A with reason | pending |


### PR DESCRIPTION
🐛 Fixes ➖ N/A

🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Canonical workflow allowed one batch autoclosure without a dedicated task plan per PR | ➖ N/A |
| Verified | 🟢 Source/mirror/template audit, intent gates, autoreview, and `bun check` | ➖ N/A |

**✅ Outcome**

- Requires one dedicated `task` invocation and task plan for every PR an agent authors, reviews, repairs, or merges.
- Keeps batch plans as ordering owners and `autoclosure` as per-PR closeout only.
- Adds mandatory per-PR gates to task and autoclosure plan templates.
- Publishes the rule in root agent guidance and `CONTRIBUTING.md`.

**⚠️ Caveat**

- Follow-up to #362 because GitHub sealed that PR while its interrupted merge command was still completing.
- Human-only contributors can still submit normally. No package or release change.

**🏗️ Design**

Canonical `.agents` sources own routing; `bun install` regenerates root/Codex/Claude mirrors. Plan gates make completion representable and prevent aggregate autoclosure from substituting for per-PR task ownership.

**🧪 Verified**

- `bun install`
- `bun run intent:validate`
- `bun run intent:stale`
- fixed-string source/generated parity audit
- agent-native capability review: pass
- local autoreview: clean, 0.99
- `bun lint:fix`
- `bun check`