### PR TITLE
docs: close PRs without task evidence

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -16,11 +16,15 @@
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
 - **Task PR default:** The `task` and `major-task` skills explicitly require verified code-changing work to be committed, pushed, and opened/updated as a PR unless the user explicitly says not to, the work has no local patch, or a real blocker is recorded. Do not treat the lack of a separate "open a PR" user sentence as a blocker.
-- **One PR, one task:** Every PR an agent authors, reviews, repairs, or merges
-  requires its own `task` invocation and dedicated task plan. A batch plan may
-  order PRs, but one batch-level `task`, `auto`, or `autoclosure` run never
-  substitutes for the per-PR task. Use `autoclosure` only inside or after that
-  PR's task contract is established.
+- **One PR, one task:** Every PR requires its own `task` invocation and
+  dedicated task plan. The PR body must name that plan, the plan must exist at
+  the PR head, and it must identify the exact PR. A batch plan may order PRs,
+  but one batch-level `task`, `auto`, or `autoclosure` run never substitutes.
+- **Noncompliant PR:** `autoclosure` must comment and close any PR without valid
+  per-PR task evidence. The comment must explain the requirement, show how to
+  run `task`, and recommend GPT-5.6 with high-or-higher reasoning effort. The
+  comment must succeed before closing; read back both the comment and `CLOSED`
+  state, then stop without reviewing, repairing, or merging the PR.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.
@@ -74,8 +78,8 @@ Use those skills when relevant:
   `milestone`, `prd`, timed, or review-until work. `auto full` continues through
   local task packets, implementation, proof, sync, review, checks, and GitHub
   PR delivery.
-- `task` for normal repo task execution. It is mandatory once per PR an agent
-  authors, reviews, repairs, or merges, including every PR inside a batch.
+- `task` for normal repo task execution. It is mandatory once per PR, including
+  every PR inside a batch.
 - `walkthrough` after final proof whenever a task, major task, or auto run
   changes UI or rendered output. Show the annotated images in the final
   handoff.
@@ -88,7 +92,7 @@ Use those skills when relevant:
 - `architecture-cleanup` for public exports, package boundaries, Convex import
   graphs, plugins, CLI/scaffolds, generated ownership, and navigation cost.
 - `autoclosure` to finish the current tree without creating new product scope,
-  after the current PR has its own `task` invocation and task plan.
+  or to comment and close a PR that lacks verifiable per-PR `task` evidence.
 - `design` for live `www`/`example` UI decisions and Browser proof.
 - `react-query` for cRPC query/mutation options, live subscription ownership,
   RSC preloading, and bounded invalidation.

--- a/.agents/rules/autoclosure.mdc
+++ b/.agents/rules/autoclosure.mdc
@@ -7,7 +7,8 @@ argument-hint: '[current tree | plan path | PR]'
 
 Autoclosure finishes already-started work. It does not invent the next feature.
 It also does not replace `task`: every PR must enter through its own `task`
-invocation and dedicated task plan before autoclosure can finish it.
+invocation and dedicated task plan. A PR without verifiable task evidence is
+commented on and closed, not reviewed, repaired, or merged.
 
 ## Use When
 
@@ -29,15 +30,50 @@ Create or resume a goal plan from the `autoclosure` template with the
 `agent-native` pack. Inventory the current intended delta from the active plan,
 source owners, and actual files. Do not absorb unrelated product scope.
 
-When the source is a PR, record the dedicated task invocation and task-plan
-path before any closure work. If only a batch-level plan exists, route back to
-`task`; missing per-PR task ownership is not an autoclosure waiver.
+## Task Compliance Gate
+
+Before reading the implementation diff or review feedback:
+
+1. Read `state`, `body`, `headRefOid`, and `url` with `gh pr view`. If the PR is
+   not `OPEN`, record its state and stop without adding another comment.
+2. Require all three:
+
+   - The PR body includes exactly one
+     `🧭 Task plan: docs/plans/<plan>.md` line.
+   - That plan file exists at the exact fetched PR head. Fetch
+     `pull/<number>/head` into a local `refs/pr/<number>` ref and inspect the
+     path with `git show`; do not browse GitHub files or trust a mutable branch.
+   - The plan identifies the exact PR number or URL in its task source or exact
+     per-PR ownership evidence. A batch plan is invalid evidence.
+
+Do not infer compliance from the author, labels, CI, comments, review state, or
+generic prose. If any requirement is missing or invalid:
+
+1. Build this comment, substituting the exact PR URL or number:
+
+   > Closing because this PR has no verifiable per-PR `task` run. Every PR must
+   > include `🧭 Task plan: docs/plans/<plan>.md` in its body, that plan must
+   > exist at the PR head, and it must identify this exact PR. Run
+   > `$kitcn:task <PR URL or #>` and add the evidence before reopening or
+   > submitting a replacement. We recommend GPT-5.6 with high-or-higher
+   > reasoning effort.
+
+2. Read existing comments first. If the exact remediation comment already
+   exists, reuse it; otherwise post it once with `gh pr comment`.
+3. Read the comment back and verify the exact explanation is present.
+4. Only after comment verification succeeds, close the PR with `gh pr close`.
+5. Read back `state: CLOSED` and the comment with `gh pr view`, record both
+   receipts, and stop.
+
+If commenting fails, do not close. Missing task evidence is not a waiver and
+must never continue into source review, repair, checks, merge, or release.
 
 ## Closure Matrix
 
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| per-PR task ownership | yes/no | exact PR + dedicated task plan | pending |
+| per-PR task ownership | yes | body path + head file + exact PR owner | pending |
+| noncompliant close | conditional | comment + `CLOSED` read-back | pending |
 | source behavior | yes/no | focused tests/runtime | pending |
 | package API/build | yes/no | exports/build/types | pending |
 | generated output | yes/no | source + regenerate + diff | pending |
@@ -53,9 +89,9 @@ Mark N/A only with a concrete reason.
 
 ## Closure Loop
 
-1. Verify the exact PR already has its own `task` invocation and dedicated task
-   plan. Route to `task` first when it does not.
-2. Reconstruct intended behavior and exclusions from the active source.
+1. Run the task compliance gate. If it fails, comment, verify, close, verify,
+   record receipts, and stop.
+2. Reconstruct intended behavior and exclusions only for a compliant PR.
 3. Run the smallest missing proof first; classify failures before editing.
 4. Repair accepted defects within the existing contract.
 5. When package behavior changed, ensure changeset, package build, focused tests,
@@ -77,8 +113,8 @@ Mark N/A only with a concrete reason.
 Clean means:
 
 - requested behavior exists with regression proof;
-- when a PR is in scope, its exact slice has a dedicated `task` invocation and
-  task plan;
+- a compliant PR has body/head/exact-owner task evidence, or a noncompliant PR
+  has the required comment and verified `CLOSED` state;
 - source/generated ownership is correct;
 - public exports, docs, package skill, examples, fixtures, and scenarios agree;
 - no stale alias, placeholder, skipped required gate, or accepted review finding
@@ -94,9 +130,10 @@ an authorized whole-checkout commit.
 
 ## Stop Conditions
 
-Stop only for missing authority, an external action the user must perform, an
-irreversible choice outside the source contract, or a reproducible environment
-blocker after different repair attempts. Record exact evidence and next owner.
+Stop only for a failed required comment, missing authority, an external action
+the user must perform, an irreversible choice outside the source contract, or
+a reproducible environment blocker after different repair attempts. Record
+exact evidence and next owner.
 
 Do not call closeout complete because code compiles, a PR exists, or a reviewer
 returned clean. Those are receipts inside the closure matrix.

--- a/.agents/rules/task.mdc
+++ b/.agents/rules/task.mdc
@@ -23,9 +23,12 @@ they earn their keep, and verify before calling the task done.
 - Verify the actual result before claiming done.
 - Do not default to research swarms, review swarms, browser proof, GitHub
   comments, or compounding.
-- Every GitHub PR an agent authors, reviews, repairs, or merges requires a
-  dedicated `task` invocation and task plan for that exact PR. A batch-level
-  task, plan, `auto`, or `autoclosure` run does not satisfy this requirement.
+- Every GitHub PR requires a dedicated `task` invocation and task plan for that
+  exact PR. A batch-level task, plan, `auto`, or `autoclosure` run does not
+  satisfy this requirement.
+- Every task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`. Before autoclosure, the plan must exist
+  at the PR head and identify the exact PR number or URL.
 - For verified code-changing work, commit, push, and create or update a PR by
   default. The `task` skill is the explicit git permission. Only skip that path
   when the user explicitly says not to, the work has no local patch, the task is
@@ -98,7 +101,10 @@ they earn their keep, and verify before calling the task done.
     verified code-changing work, this branch decision must assume commit, push,
     and PR as the default closeout path unless the user explicitly declined it
     or a real blocker is recorded.
-14. If anything important is still ambiguous after the source and nearby code
+14. When a PR is created, update its dedicated plan from a not-yet-created PR
+    slice to the exact PR number or URL and add its plan path to the PR body
+    before invoking `autoclosure`.
+15. If anything important is still ambiguous after the source and nearby code
     pass, ask the smallest useful clarifying question.
 
 ## GitHub Source Rules
@@ -432,12 +438,14 @@ Use the accepted task PR format from PR #270. The shape is not optional:
    `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`. Never include a line that links to the
    current PR itself; the current PR URL belongs in the final response, not in
    its own description.
-3. Use an emoji confidence line, for example `🟢 95-100% confidence`.
-4. Use this exact table header:
+3. Add `🧭 Task plan: docs/plans/<plan>.md`; the path must resolve at the PR
+   head and the plan must identify the exact PR before autoclosure.
+4. Use an emoji confidence line, for example `🟢 95-100% confidence`.
+5. Use this exact table header:
    `| Phase | 🧪 Tests | 🌐 Browser |`
-5. Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+6. Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
    failing proof with `🔴`, and non-applicable browser/test cells with `➖ N/A`.
-6. Use bold emoji section headings exactly in this family:
+7. Use bold emoji section headings exactly in this family:
    `**✅ Outcome**`, `**⚠️ Caveat**`, `**🏗️ Design**`, and
    `**🧪 Verified**`.
 
@@ -460,8 +468,10 @@ with `gh pr view --json body` before final handoff.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.
-- Every agent-processed PR in a batch has its own `task` invocation and task
-  plan; no aggregate `autoclosure` was used as a substitute.
+- Every PR in a batch has its own `task` invocation and task plan; no aggregate
+  `autoclosure` was used as a substitute.
+- The PR body names the dedicated task plan, the plan exists at the PR head,
+  and it identifies the exact PR before autoclosure.
 - Verification matched change scope.
 - Verified code-changing work was committed and PR'd, or the user explicitly
   declined that path, the work had no local patch, or a real blocker was

--- a/.agents/skills/autoclosure/SKILL.md
+++ b/.agents/skills/autoclosure/SKILL.md
@@ -11,7 +11,8 @@ metadata:
 
 Autoclosure finishes already-started work. It does not invent the next feature.
 It also does not replace `task`: every PR must enter through its own `task`
-invocation and dedicated task plan before autoclosure can finish it.
+invocation and dedicated task plan. A PR without verifiable task evidence is
+commented on and closed, not reviewed, repaired, or merged.
 
 ## Use When
 
@@ -33,15 +34,50 @@ Create or resume a goal plan from the `autoclosure` template with the
 `agent-native` pack. Inventory the current intended delta from the active plan,
 source owners, and actual files. Do not absorb unrelated product scope.
 
-When the source is a PR, record the dedicated task invocation and task-plan
-path before any closure work. If only a batch-level plan exists, route back to
-`task`; missing per-PR task ownership is not an autoclosure waiver.
+## Task Compliance Gate
+
+Before reading the implementation diff or review feedback:
+
+1. Read `state`, `body`, `headRefOid`, and `url` with `gh pr view`. If the PR is
+   not `OPEN`, record its state and stop without adding another comment.
+2. Require all three:
+
+   - The PR body includes exactly one
+     `🧭 Task plan: docs/plans/<plan>.md` line.
+   - That plan file exists at the exact fetched PR head. Fetch
+     `pull/<number>/head` into a local `refs/pr/<number>` ref and inspect the
+     path with `git show`; do not browse GitHub files or trust a mutable branch.
+   - The plan identifies the exact PR number or URL in its task source or exact
+     per-PR ownership evidence. A batch plan is invalid evidence.
+
+Do not infer compliance from the author, labels, CI, comments, review state, or
+generic prose. If any requirement is missing or invalid:
+
+1. Build this comment, substituting the exact PR URL or number:
+
+   > Closing because this PR has no verifiable per-PR `task` run. Every PR must
+   > include `🧭 Task plan: docs/plans/<plan>.md` in its body, that plan must
+   > exist at the PR head, and it must identify this exact PR. Run
+   > `$kitcn:task <PR URL or #>` and add the evidence before reopening or
+   > submitting a replacement. We recommend GPT-5.6 with high-or-higher
+   > reasoning effort.
+
+2. Read existing comments first. If the exact remediation comment already
+   exists, reuse it; otherwise post it once with `gh pr comment`.
+3. Read the comment back and verify the exact explanation is present.
+4. Only after comment verification succeeds, close the PR with `gh pr close`.
+5. Read back `state: CLOSED` and the comment with `gh pr view`, record both
+   receipts, and stop.
+
+If commenting fails, do not close. Missing task evidence is not a waiver and
+must never continue into source review, repair, checks, merge, or release.
 
 ## Closure Matrix
 
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
-| per-PR task ownership | yes/no | exact PR + dedicated task plan | pending |
+| per-PR task ownership | yes | body path + head file + exact PR owner | pending |
+| noncompliant close | conditional | comment + `CLOSED` read-back | pending |
 | source behavior | yes/no | focused tests/runtime | pending |
 | package API/build | yes/no | exports/build/types | pending |
 | generated output | yes/no | source + regenerate + diff | pending |
@@ -57,9 +93,9 @@ Mark N/A only with a concrete reason.
 
 ## Closure Loop
 
-1. Verify the exact PR already has its own `task` invocation and dedicated task
-   plan. Route to `task` first when it does not.
-2. Reconstruct intended behavior and exclusions from the active source.
+1. Run the task compliance gate. If it fails, comment, verify, close, verify,
+   record receipts, and stop.
+2. Reconstruct intended behavior and exclusions only for a compliant PR.
 3. Run the smallest missing proof first; classify failures before editing.
 4. Repair accepted defects within the existing contract.
 5. When package behavior changed, ensure changeset, package build, focused tests,
@@ -81,8 +117,8 @@ Mark N/A only with a concrete reason.
 Clean means:
 
 - requested behavior exists with regression proof;
-- when a PR is in scope, its exact slice has a dedicated `task` invocation and
-  task plan;
+- a compliant PR has body/head/exact-owner task evidence, or a noncompliant PR
+  has the required comment and verified `CLOSED` state;
 - source/generated ownership is correct;
 - public exports, docs, package skill, examples, fixtures, and scenarios agree;
 - no stale alias, placeholder, skipped required gate, or accepted review finding
@@ -98,9 +134,10 @@ an authorized whole-checkout commit.
 
 ## Stop Conditions
 
-Stop only for missing authority, an external action the user must perform, an
-irreversible choice outside the source contract, or a reproducible environment
-blocker after different repair attempts. Record exact evidence and next owner.
+Stop only for a failed required comment, missing authority, an external action
+the user must perform, an irreversible choice outside the source contract, or
+a reproducible environment blocker after different repair attempts. Record
+exact evidence and next owner.
 
 Do not call closeout complete because code compiles, a PR exists, or a reviewer
 returned clean. Those are receipts inside the closure matrix.

--- a/.agents/skills/task/SKILL.md
+++ b/.agents/skills/task/SKILL.md
@@ -27,9 +27,12 @@ they earn their keep, and verify before calling the task done.
 - Verify the actual result before claiming done.
 - Do not default to research swarms, review swarms, browser proof, GitHub
   comments, or compounding.
-- Every GitHub PR an agent authors, reviews, repairs, or merges requires a
-  dedicated `task` invocation and task plan for that exact PR. A batch-level
-  task, plan, `auto`, or `autoclosure` run does not satisfy this requirement.
+- Every GitHub PR requires a dedicated `task` invocation and task plan for that
+  exact PR. A batch-level task, plan, `auto`, or `autoclosure` run does not
+  satisfy this requirement.
+- Every task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`. Before autoclosure, the plan must exist
+  at the PR head and identify the exact PR number or URL.
 - For verified code-changing work, commit, push, and create or update a PR by
   default. The `task` skill is the explicit git permission. Only skip that path
   when the user explicitly says not to, the work has no local patch, the task is
@@ -102,7 +105,10 @@ they earn their keep, and verify before calling the task done.
     verified code-changing work, this branch decision must assume commit, push,
     and PR as the default closeout path unless the user explicitly declined it
     or a real blocker is recorded.
-14. If anything important is still ambiguous after the source and nearby code
+14. When a PR is created, update its dedicated plan from a not-yet-created PR
+    slice to the exact PR number or URL and add its plan path to the PR body
+    before invoking `autoclosure`.
+15. If anything important is still ambiguous after the source and nearby code
     pass, ask the smallest useful clarifying question.
 
 ## GitHub Source Rules
@@ -436,12 +442,14 @@ Use the accepted task PR format from PR #270. The shape is not optional:
    `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`. Never include a line that links to the
    current PR itself; the current PR URL belongs in the final response, not in
    its own description.
-3. Use an emoji confidence line, for example `🟢 95-100% confidence`.
-4. Use this exact table header:
+3. Add `🧭 Task plan: docs/plans/<plan>.md`; the path must resolve at the PR
+   head and the plan must identify the exact PR before autoclosure.
+4. Use an emoji confidence line, for example `🟢 95-100% confidence`.
+5. Use this exact table header:
    `| Phase | 🧪 Tests | 🌐 Browser |`
-5. Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+6. Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
    failing proof with `🔴`, and non-applicable browser/test cells with `➖ N/A`.
-6. Use bold emoji section headings exactly in this family:
+7. Use bold emoji section headings exactly in this family:
    `**✅ Outcome**`, `**⚠️ Caveat**`, `**🏗️ Design**`, and
    `**🧪 Verified**`.
 
@@ -464,8 +472,10 @@ with `gh pr view --json body` before final handoff.
 - Testing work loaded the testing policy before implementation.
 - Only necessary skills were loaded.
 - Batch work did not sprawl without explicit instruction.
-- Every agent-processed PR in a batch has its own `task` invocation and task
-  plan; no aggregate `autoclosure` was used as a substitute.
+- Every PR in a batch has its own `task` invocation and task plan; no aggregate
+  `autoclosure` was used as a substitute.
+- The PR body names the dedicated task plan, the plan exists at the PR head,
+  and it identifies the exact PR before autoclosure.
 - Verification matched change scope.
 - Verified code-changing work was committed and PR'd, or the user explicitly
   declined that path, the work had no local patch, or a real blocker was

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,15 @@
 
 - **Git:** Never git add, commit, push, or create PR unless the user explicitly asks, or the active command/skill explicitly requires it.
 - **Task PR default:** The `task` and `major-task` skills explicitly require verified code-changing work to be committed, pushed, and opened/updated as a PR unless the user explicitly says not to, the work has no local patch, or a real blocker is recorded. Do not treat the lack of a separate "open a PR" user sentence as a blocker.
-- **One PR, one task:** Every PR an agent authors, reviews, repairs, or merges
-  requires its own `task` invocation and dedicated task plan. A batch plan may
-  order PRs, but one batch-level `task`, `auto`, or `autoclosure` run never
-  substitutes for the per-PR task. Use `autoclosure` only inside or after that
-  PR's task contract is established.
+- **One PR, one task:** Every PR requires its own `task` invocation and
+  dedicated task plan. The PR body must name that plan, the plan must exist at
+  the PR head, and it must identify the exact PR. A batch plan may order PRs,
+  but one batch-level `task`, `auto`, or `autoclosure` run never substitutes.
+- **Noncompliant PR:** `autoclosure` must comment and close any PR without valid
+  per-PR task evidence. The comment must explain the requirement, show how to
+  run `task`, and recommend GPT-5.6 with high-or-higher reasoning effort. The
+  comment must succeed before closing; read back both the comment and `CLOSED`
+  state, then stop without reviewing, repairing, or merging the PR.
 - **Push scope:** When you do commit and push, include unrelated dirty files outside src; those are often manual user changes or synced skill/docs updates, so do not silently leave them behind.
 - **PR:** Before creating or updating a PR, run `check`. If it fails, stop and fix it or report the blocker. Do not open a PR with failing `check` unless the user explicitly says to.
 - **PR branch:** If the user explicitly says to open or create a PR, do not ask for confirmation. If the current branch is `main`, create a new `codex/` branch first, then commit/push/open the PR. If already on a non-`main` branch, proceed directly.
@@ -79,8 +83,8 @@ Use those skills when relevant:
   `milestone`, `prd`, timed, or review-until work. `auto full` continues through
   local task packets, implementation, proof, sync, review, checks, and GitHub
   PR delivery.
-- `task` for normal repo task execution. It is mandatory once per PR an agent
-  authors, reviews, repairs, or merges, including every PR inside a batch.
+- `task` for normal repo task execution. It is mandatory once per PR, including
+  every PR inside a batch.
 - `walkthrough` after final proof whenever a task, major task, or auto run
   changes UI or rendered output. Show the annotated images in the final
   handoff.
@@ -93,7 +97,7 @@ Use those skills when relevant:
 - `architecture-cleanup` for public exports, package boundaries, Convex import
   graphs, plugins, CLI/scaffolds, generated ownership, and navigation cost.
 - `autoclosure` to finish the current tree without creating new product scope,
-  after the current PR has its own `task` invocation and task plan.
+  or to comment and close a PR that lacks verifiable per-PR `task` evidence.
 - `design` for live `www`/`example` UI decisions and Browser proof.
 - `react-query` for cRPC query/mutation options, live subscription ownership,
   RSC preloading, and bounded invalidation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,14 @@
 
 ## One PR, one task
 
-Human contributors can open PRs normally. Whenever an agent authors, reviews,
-repairs, or merges a PR, invoke `task` for that exact PR and keep a dedicated
-task plan under `docs/plans/**`.
+Every PR requires a dedicated `task` invocation and task plan under
+`docs/plans/**`.
 
 Invoke `$kitcn:task <PR URL or #>` for an existing PR. For a new PR, invoke
 `$kitcn:task <issue, spec, or single-PR task>` before editing.
+
+The PR body must include `🧭 Task plan: docs/plans/<plan>.md`. The plan must
+exist at the PR head and identify the exact PR before autoclosure.
 
 - A batch plan can choose dependency order, but it cannot replace per-PR task
   plans.
@@ -16,6 +18,11 @@ Invoke `$kitcn:task <PR URL or #>` for an existing PR. For a new PR, invoke
   PR unless parallel work was explicitly requested.
 - Use the task-style PR body and record exact checks, merge, release, and
   read-back receipts when they apply.
+
+Autoclosure comments on and closes PRs without valid task evidence before any
+code review or repair. Its remediation comment recommends GPT-5.6 with
+high-or-higher reasoning effort. The comment must be visible before the PR is
+closed.
 
 ## Verification
 

--- a/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
+++ b/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
@@ -200,7 +200,7 @@ Phase / pass table:
 | Repair | complete | accepted correctness, ownership, and proof defects fixed | review |
 | Review/checks | complete | focused/full gates and final reviews pass | delivery |
 | Delivery | complete | every PR merged and applicable releases published | final audit |
-| Closeout | in_progress | batch receipts and task requirement landed; noncompliant close policy pending | workflow repair |
+| Closeout | complete | batch receipts plus per-PR task and noncompliant close policies | done |
 
 Verification evidence:
 - GitHub snapshot: 14 contributor PRs #329-#342; every head had green CI and

--- a/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
+++ b/docs/plans/2026-08-16-review-and-autoclose-prs-329-through-342.md
@@ -17,6 +17,8 @@ Applied packs:
 - agent-native (docs/plans/templates/packs/agent-native.md)
 
 Linked plans:
+- [Noncompliant PR autoclosure](docs/plans/2026-08-17-autoclose-prs-without-task.md) -
+  Comment and close PRs without exact per-PR task evidence.
 - [Per-PR task workflow repair](docs/plans/2026-08-17-require-task-per-pr.md) -
   Make one dedicated `task` run and plan mandatory for every future PR slice.
 - [PR #329 autoclosure](docs/plans/2026-08-16-pr-329-autoclosure.md) -
@@ -198,7 +200,7 @@ Phase / pass table:
 | Repair | complete | accepted correctness, ownership, and proof defects fixed | review |
 | Review/checks | complete | focused/full gates and final reviews pass | delivery |
 | Delivery | complete | every PR merged and applicable releases published | final audit |
-| Closeout | complete | batch receipts plus per-PR task workflow repair PR #363 | done |
+| Closeout | in_progress | batch receipts and task requirement landed; noncompliant close policy pending | workflow repair |
 
 Verification evidence:
 - GitHub snapshot: 14 contributor PRs #329-#342; every head had green CI and

--- a/docs/plans/2026-08-17-autoclose-prs-without-task.md
+++ b/docs/plans/2026-08-17-autoclose-prs-without-task.md
@@ -1,0 +1,417 @@
+# autoclose prs without task
+
+Objective:
+Make autoclosure comment on and close any PR without verifiable per-PR `task`
+evidence, including a GPT-5.6 high-or-higher effort recommendation.
+
+Goal plan:
+docs/plans/2026-08-17-autoclose-prs-without-task.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- docs (docs/plans/templates/packs/docs.md)
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Task source:
+- type: user workflow requirement
+- id / link: current Codex task
+- title: Autoclose PRs without task
+- acceptance criteria: define verifiable task evidence; comment before close;
+  recommend GPT-5.6 with high-or-higher reasoning effort; verify comment and
+  closed state; hard-cut the human-only exception; sync all agent mirrors/docs
+
+Timed checkpoint:
+- requested duration: N/A
+- semantics: N/A
+- initial confidence score: 90%
+- improvement loop: evidence contract, destructive-path review, mirrors,
+  templates, contributor docs, structured review, full gate, GitHub delivery
+- final score / loop closure: 98%; exact remote delivery pending
+
+Completion threshold:
+- Task and PR-body rules expose verifiable per-PR evidence. Autoclosure checks
+  it before all other work, comments with the exact remediation/model guidance,
+  closes the PR only after comment success, and reads both actions back.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-autoclose-prs-without-task.md` passes.
+
+Verification surface:
+- Canonical/mirror/source audit; template completion gates; contributor docs;
+  install/intent parity; agent-native review; autoreview; `bun check`;
+  task-style PR body; exact remote gates and merge read-back.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- When a GitHub PR is in scope, this plan owns exactly one PR. A coordinating
+  batch plan must link a separate task plan for every PR an agent processes.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- A task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`; the plan must exist at the PR head and
+  identify the exact PR before autoclosure.
+- Do not add broad ceremony when the task is trivial or docs-only.
+- Comment must succeed before close. Do not infer task execution from author,
+  green CI, labels, or prose without a task-plan path and exact-PR ownership.
+
+Boundaries:
+- Source of truth: user requirement and canonical task/autoclosure rules.
+- Allowed edit scope: AGENTS, task/autoclosure sources and mirrors, plan
+  templates, CONTRIBUTING/README discovery, and active proof plans.
+- Browser surface: N/A.
+- GitHub issue sync: N/A.
+- Non-goals: bulk-closing currently open PRs, product/package behavior, cron,
+  or weakening review/check requirements for compliant PRs.
+
+Output budget strategy:
+- Scope audits to named workflow sources/mirrors/templates/docs; cap review and
+  check output; use exact GitHub summaries rather than streaming logs.
+
+Blocked condition:
+- Stop only if source/mirror generation disagrees after a clean install, the
+  comment-before-close contract cannot be represented safely, or GitHub
+  delivery remains unauthorized after three verified attempts.
+
+Task state:
+- task_type: agent workflow policy hard cut
+- task_complexity: non-trivial
+- current_phase: verification
+- current_phase_status: in_progress
+- next_phase: commit and PR
+- goal_status: active
+
+Current verdict:
+- verdict: valid
+- confidence: 90%
+- next owner: task
+- reason: current autoclosure routes back to task but leaves a noncompliant PR open
+
+Implementation readiness:
+- verdict: ready
+- exact owner: `.agents/rules/autoclosure.mdc`, `.agents/rules/task.mdc`,
+  `.agents/AGENTS.md`, and repo plan templates
+- contradiction status: user requirement supersedes the current human-only
+  exception and route-back-only behavior
+- source-listed cases complete: yes
+
+Pre-solution issue challenge:
+- reporter claim: autoclosure must close PRs without a task run and explain why
+- suggested diagnosis or fix: verify task-plan evidence; comment; close; mention
+  GPT-5.6 high-or-higher reasoning effort
+- repro ladder:
+  - tests / source-level repro: pending
+  - repo-owned automated browser or integration proof: N/A; structural policy
+  - Browser plugin: N/A
+  - screenshot / visual proof: N/A
+- reproduction verdict: reproduced in current autoclosure route-back-only text
+- validity verdict: valid
+- best long-term fix boundary: canonical rules, evidence contract, templates,
+  generated mirrors, and contributor discovery
+- harsh honest feedback: a requirement without a close action is toothless
+- hard-stop decision: proceed
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-autoclose-prs-without-task.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration |
+| Walkthrough baseline for possible UI change | no | N/A: no UI/rendered output |
+| Skill analysis before edits | yes | user invoked `task` and `autoclosure`; agent-native review/autoreview required |
+| Active goal checked or created | yes | dedicated one-PR task plan created |
+| Source of truth read before edits | yes | user requirement and current generated task/autoclosure skills |
+| Exact per-PR task ownership | yes | this plan owns one not-yet-created workflow PR |
+| GitHub comments and attachments read | no | N/A: user prompt is source; no source PR yet |
+| Video transcript evidence required | no | N/A: no video |
+| Pre-solution issue challenge required | yes | current route-back-only policy reproduced |
+| Reproduction verdict before implementation | yes | valid gap in canonical autoclosure source |
+| Repro escalation ladder selected | yes | source/mirror/template audit owns proof |
+| Suggested fix reviewed against durable boundary | yes | exact evidence + comment-before-close at autoclosure intake |
+| `docs/solutions` checked for non-trivial existing-code work | yes | no stronger owner; canonical rules own repository workflow |
+| TDD decision before behavior change or bug fix | no | N/A: rule/docs hard cut, no runtime code |
+| Branch decision for code-changing task | yes | `codex/autoclose-prs-without-task` from released main |
+| Release artifact decision | no | N/A: no package delta |
+| Browser tool decision for browser surface | no | N/A: no browser surface |
+| Commit / PR expectation decision | yes | task requires commit, push, PR, gates, and merge |
+| Task-style PR body decision | yes | include task-plan evidence line in PR body |
+| Task-plan PR body evidence | yes | this plan path will be added to the PR body and updated with exact PR number |
+| GitHub issue sync expectation decision | no | N/A: no issue |
+| Output budget strategy recorded | yes | scoped source/mirror/template audits |
+| Docs pack selected | yes | CONTRIBUTING and plan templates support agent workflow |
+| Docs guidance loaded | yes | docs ownership map and contributor guidance |
+| Docs lane selected | yes | repository workflow docs, not www user docs |
+| Target docs and nearest sibling docs read | yes | task/autoclosure templates, CONTRIBUTING, AGENTS |
+| Docs style doctrine read | no | N/A: no `www/**` docs |
+| Documented source owner identified | yes | `.agents` sources; CONTRIBUTING discovery |
+| Agent-native pack selected | yes | applied at plan creation |
+| Agent-facing action surface identified | yes | autoclosure compliance intake, comment, close, read-back |
+| Source rule versus generated mirror boundary identified | yes | edit `.agents` sources; regenerate with `bun install` |
+| Installed-skill lock versus local-rule owner identified | yes | local rules changed; no lock mutation |
+| `agent-native-reviewer` loaded or waiver recorded | yes | loaded; two safety findings accepted and fixed |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Every GitHub PR in scope has its own task plan. This plan owns one exact
+      PR, owns a not-yet-created PR slice, or records N/A because no PR is in
+      scope; a batch plan is not used as a substitute.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [ ] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
+      exists at the PR head, and it identifies the exact PR before autoclosure.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+- [x] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [x] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [x] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [x] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [x] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [x] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Source/mirror/template audit, reviews, full check | all pass |
+| Exact per-PR task ownership | yes | Record one not-yet-created single-PR slice | this plan owns the workflow PR and will be updated with its number |
+| Pre-solution issue challenge verdict | yes | Record claim, repro, verdict, boundary | valid route-back-only gap; hard cut authorized |
+| Repro escalation ladder | yes | Source-level proof; higher layers N/A | current rule leaves noncompliant PR open |
+| Bug reproduced before fix | yes | Record source repro | autoclosure step 1 routed to task without comment/close |
+| Targeted behavior verification | yes | Source/generated/template audit | pass after install regeneration |
+| TypeScript or typed config changed | no | N/A | Markdown rules/docs only |
+| Package exports or file layout changed | no | N/A | no package delta |
+| Package manifests, lockfile, or install graph changed | no | N/A | install produced no manifest/lock delta |
+| Agent rules or skills changed | yes | Install and mirror audit | pass |
+| Workspace authority proof | yes | Verify in `/Users/zbeyens/git/better-convex` | canonical sources, generated mirrors, docs, templates |
+| Browser surface changed | no | N/A | no browser surface |
+| Browser final proof | no | N/A | no rendered output |
+| UI walkthrough | no | N/A | no UI/rendered output |
+| Scaffold or fixture output changed | no | N/A | no scaffold delta |
+| Package behavior or public API changed | no | N/A | no changeset |
+| Docs and kitcn skill sync changed | no | N/A | no www/published skill change |
+| Docs or content changed | yes | Audit current claims | CONTRIBUTING matches canonical rules |
+| High-risk mini gate | yes | Prove destructive ordering/authority/idempotency | comment success precedes close; retry reuses comment; closed state stops |
+| Agent-native review for agent/tooling changes | yes | Capability/safety review | pass after two accepted findings |
+| Local install corruption suspected | no | N/A | no corruption signal |
+| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
+| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR task evidence verified | pending | Verify body plan line, plan at PR head, and exact PR ownership | pending |
+| PR proof image hosting | no | N/A | no browser images |
+| GitHub issue sync-back | no | N/A | no issue source |
+| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final lint | yes | Run `bun lint:fix` | pass; 929 files, no fixes |
+| Output budget discipline | yes | Scope/cap noisy commands | pass |
+| Timed checkpoint | no | N/A | no duration |
+| Autoreview for non-trivial implementation changes | yes | Dirty local review | clean, correct 0.98, no actionable findings |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-autoclose-prs-without-task.md` | pending |
+| Docs source-backed claim audit | yes | Compare CONTRIBUTING with rules | pass |
+| Docs links / routes / previews | yes | README contributor link | existing leaf resolves |
+| Docs MDX/content parser | no | N/A | no MDX/www change |
+| Kitcn docs sync | no | N/A | no www/published skill change |
+| Agent source / generated sync | yes | Install and compare mirrors | pass |
+| Installed lock audit | no | N/A | no installed-skill change |
+| Agent action discoverability | yes | Audit AGENTS/task/autoclosure/CONTRIBUTING | pass |
+| Helper and template smoke | yes | Required evidence and disposition gates exist | pass |
+| Agent-native review | yes | Close accepted safety findings | pass |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | user source, skills, owners, docs read | implementation |
+| Implementation | complete | evidence gate, comment/close path, templates, docs, mirrors | verification |
+| Verification | complete | source/mirror/intent/reviews and `bun check` pass | commit/PR |
+| Commit / PR / GitHub sync | pending | | final response |
+| Closeout | pending | | final response |
+
+Findings:
+- Current autoclosure routed missing task evidence back to task and left the PR
+  open, contradicting the requested enforcement.
+- Agent-native review found retry duplication and non-open PR ambiguity; both
+  were repaired before destructive delivery.
+
+Decisions and tradeoffs:
+- Accept only exact body/head/PR-owner evidence; do not infer compliance.
+- Comment must succeed before close. Retries reuse the exact comment.
+- Do not bulk-apply the new policy during this implementation task.
+
+Implementation notes:
+- Canonical `.agents` rules own behavior; install regenerates root, Codex, and
+  Claude mirrors. Templates make compliant and noncompliant completion visible.
+
+Review fixes:
+- Agent-native P1 accepted: make retries reuse the exact remediation comment
+  and stop cleanly for non-open PRs.
+- Agent-native P2 accepted: name exact `gh pr view`, fetched PR-head, `git
+  show`, comment, close, and read-back proof steps.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- `bun install` regenerated all mirrors after each source edit.
+- Fixed-string source/mirror audits and mirror comparisons pass.
+- `bun run intent:validate` and `bun run intent:stale` pass.
+- Agent-native review passes after idempotency and exact-proof repairs.
+- Autoreview local is clean at 0.98 with no actionable findings.
+- `bun check` passes, including every fresh fixture comparison and runtime
+  scenario.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| compliant PR | task evidence exists | body + fetched head + exact plan owner | route continues | proceed with normal autoclosure | source/template audit | pass |
+| missing body line | no verifiable task evidence | body audit | PR stayed open | exact comment, verify, close, verify, stop | comment template and ordered steps | pass |
+| missing plan at head | mutable prose only | fetched `pull/<n>/head` + `git show` | could be falsely accepted | same noncompliant close | exact-head rule | pass |
+| batch/wrong plan | no exact PR owner | task source/ownership audit | aggregate plan could substitute | same noncompliant close | explicit invalid-evidence rule | pass |
+| comment failure | explanation not delivered | `gh pr comment` + read-back | close could be unexplained | leave open and stop | hard stop rule | pass |
+| retry | exact comment already exists | comment read-back | duplicate public comments | reuse comment then close/read back | idempotency rule | pass |
+| already closed | no action needed | initial state read-back | duplicate comment possible | record and stop | non-open state rule | pass |
+
+Final handoff contract:
+- Commit line: pending
+- PR line: pending
+- Issue line: pending
+- Confidence line: pending
+- Flow table:
+  - Reproduced: tests pending, browser pending
+  - Verified: tests pending, browser pending
+- Browser check: pending
+- Outcome: pending
+- Caveat: pending
+- Design:
+  - Chosen boundary: pending
+  - Why not quick patch: pending
+  - Why not broader change: pending
+- Verified: pending
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  `🧭 Task plan: docs/plans/<plan>.md`, then an emoji confidence line like
+  `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: pending
+- PR: pending
+- Issue: pending
+- Browser proof: pending
+- Caveats: pending
+
+Timeline:
+- 2026-08-17T08:55:01.517Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Intake and source read |
+| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
+| What is the goal? | TODO: Fill from Objective |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Pending.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/2026-08-17-autoclose-prs-without-task.md
+++ b/docs/plans/2026-08-17-autoclose-prs-without-task.md
@@ -213,12 +213,12 @@ Work Checklist:
       N/A with reason.
 - [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
       requirements, PR body sync, and issue sync when applicable.
-- [ ] Commit/PR handling recorded for code-changing work: commit and PR
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
       completed, no local patch, user explicitly declined, or blocker recorded.
       "User did not separately ask for a PR" is not a valid blocker.
-- [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
       recorded, or blocker recorded.
-- [ ] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
+- [x] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
       exists at the PR head, and it identifies the exact PR before autoclosure.
 - [x] Branch handling recorded for code-changing work: dedicated branch used,
       new branch needed, or N/A with reason.
@@ -273,13 +273,13 @@ Completion Gates:
 | High-risk mini gate | yes | Prove destructive ordering/authority/idempotency | comment success precedes close; retry reuses comment; closed state stops |
 | Agent-native review for agent/tooling changes | yes | Capability/safety review | pass after two accepted findings |
 | Local install corruption suspected | no | N/A | no corruption signal |
-| Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
-| Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
-| PR task evidence verified | pending | Verify body plan line, plan at PR head, and exact PR ownership | pending |
+| Commit created | yes | Stage whole checkout and commit | `117d699e`; exact PR binding `60319be3` |
+| PR create or update | yes | Push and create/update PR | PR #364 open on dedicated branch |
+| Task-style PR body verified | yes | Read back exact body | required issue, plan, confidence, table, and sections present; no self-link |
+| PR task evidence verified | yes | Verify body line, fetched head file, exact owner | exactly one line; `refs/pr/364` contains plan identifying PR #364 |
 | PR proof image hosting | no | N/A | no browser images |
 | GitHub issue sync-back | no | N/A | no issue source |
-| Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
+| Final handoff contract | yes | Fill exact PR/confidence/proof/outcome/caveat/design | complete below |
 | Final lint | yes | Run `bun lint:fix` | pass; 929 files, no fixes |
 | Output budget discipline | yes | Scope/cap noisy commands | pass |
 | Timed checkpoint | no | N/A | no duration |
@@ -301,7 +301,7 @@ Phase / pass table:
 | Intake and source read | complete | user source, skills, owners, docs read | implementation |
 | Implementation | complete | evidence gate, comment/close path, templates, docs, mirrors | verification |
 | Verification | complete | source/mirror/intent/reviews and `bun check` pass | commit/PR |
-| Commit / PR / GitHub sync | pending | | final response |
+| Commit / PR / GitHub sync | complete | PR #364 body and task evidence read back | remote gates |
 | Closeout | pending | | final response |
 
 Findings:
@@ -338,6 +338,8 @@ Verification evidence:
 - Autoreview local is clean at 0.98 with no actionable findings.
 - `bun check` passes, including every fresh fixture comparison and runtime
   scenario.
+- PR #364 body contains exactly one task-plan line. Its exact fetched head
+  contains this plan, which identifies PR #364 in task source and ownership.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |
@@ -351,22 +353,22 @@ Source-listed case matrix:
 | already closed | no action needed | initial state read-back | duplicate comment possible | record and stop | non-open state rule | pass |
 
 Final handoff contract:
-- Commit line: pending
-- PR line: pending
-- Issue line: pending
-- Confidence line: pending
+- Commit line: `117d699e docs: close PRs without task evidence`
+- PR line: #364 opened and exact task evidence verified at `60319be3`
+- Issue line: N/A
+- Confidence line: 98%
 - Flow table:
-  - Reproduced: tests pending, browser pending
-  - Verified: tests pending, browser pending
-- Browser check: pending
-- Outcome: pending
-- Caveat: pending
+  - Reproduced: source policy red, browser N/A
+  - Verified: source/mirror/template/review/check/PR evidence green, browser N/A
+- Browser check: N/A
+- Outcome: noncompliant PRs get one verified explanation, then close/read-back
+- Caveat: policy is not bulk-applied during this task
 - Design:
-  - Chosen boundary: pending
-  - Why not quick patch: pending
-  - Why not broader change: pending
-- Verified: pending
-- PR body verified: pending
+  - Chosen boundary: autoclosure intake plus task evidence and plan templates
+  - Why not quick patch: AGENTS-only prose would not define proof or destructive ordering
+  - Why not broader change: no CI can prove an unrecorded model invocation
+- Verified: install, intent, parity, reviews, full check, exact PR evidence
+- PR body verified: `gh pr view 364 --json body`; exact evidence smoke passes
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -390,11 +392,11 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: pending
-- PR: pending
-- Issue: pending
-- Browser proof: pending
-- Caveats: pending
+- Commit: `117d699e`, `60319be3`
+- PR: https://github.com/udecode/kitcn/pull/364
+- Issue: N/A
+- Browser proof: N/A
+- Caveats: no bulk-close in this implementation PR
 
 Timeline:
 - 2026-08-17T08:55:01.517Z Task goal plan created.
@@ -402,14 +404,14 @@ Timeline:
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Intake and source read |
-| Where am I going? | Implementation, verification, commit/PR/GitHub sync, closeout |
-| What is the goal? | TODO: Fill from Objective |
-| What have I learned? | See Findings |
-| What have I done? | See Timeline |
+| Where am I? | Remote closeout |
+| Where am I going? | Exact #364 gates and merge |
+| What is the goal? | Comment and close PRs without verifiable task evidence |
+| What have I learned? | Destructive enforcement needs immutable evidence and idempotent ordering |
+| What have I done? | Patched sources/templates/docs, regenerated, reviewed, checked, opened compliant #364 |
 
 Open risks:
-- Pending.
+- Required remote gates and exact merge remain for PR #364.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/2026-08-17-autoclose-prs-without-task.md
+++ b/docs/plans/2026-08-17-autoclose-prs-without-task.md
@@ -19,7 +19,7 @@ Applied packs:
 
 Task source:
 - type: user workflow requirement
-- id / link: current Codex task
+- id / link: https://github.com/udecode/kitcn/pull/364
 - title: Autoclose PRs without task
 - acceptance criteria: define verifiable task evidence; comment before close;
   recommend GPT-5.6 with high-or-higher reasoning effort; verify comment and
@@ -253,7 +253,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | yes | Source/mirror/template audit, reviews, full check | all pass |
-| Exact per-PR task ownership | yes | Record one not-yet-created single-PR slice | this plan owns the workflow PR and will be updated with its number |
+| Exact per-PR task ownership | yes | Record exact PR and dedicated plan | this plan owns PR #364 |
 | Pre-solution issue challenge verdict | yes | Record claim, repro, verdict, boundary | valid route-back-only gap; hard cut authorized |
 | Repro escalation ladder | yes | Source-level proof; higher layers N/A | current rule leaves noncompliant PR open |
 | Bug reproduced before fix | yes | Record source repro | autoclosure step 1 routed to task without comment/close |

--- a/docs/plans/2026-08-17-autoclose-prs-without-task.md
+++ b/docs/plans/2026-08-17-autoclose-prs-without-task.md
@@ -31,7 +31,7 @@ Timed checkpoint:
 - initial confidence score: 90%
 - improvement loop: evidence contract, destructive-path review, mirrors,
   templates, contributor docs, structured review, full gate, GitHub delivery
-- final score / loop closure: 98%; exact remote delivery pending
+- final score / loop closure: 99%; exact source head remote gates green
 
 Completion threshold:
 - Task and PR-body rules expose verifiable per-PR evidence. Autoclosure checks
@@ -90,10 +90,10 @@ Blocked condition:
 Task state:
 - task_type: agent workflow policy hard cut
 - task_complexity: non-trivial
-- current_phase: verification
-- current_phase_status: in_progress
-- next_phase: commit and PR
-- goal_status: active
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: done
+- goal_status: complete after exact merge read-back
 
 Current verdict:
 - verdict: valid
@@ -114,7 +114,7 @@ Pre-solution issue challenge:
 - suggested diagnosis or fix: verify task-plan evidence; comment; close; mention
   GPT-5.6 high-or-higher reasoning effort
 - repro ladder:
-  - tests / source-level repro: pending
+  - tests / source-level repro: current autoclosure step left noncompliant PRs open
   - repo-owned automated browser or integration proof: N/A; structural policy
   - Browser plugin: N/A
   - screenshot / visual proof: N/A
@@ -284,7 +284,7 @@ Completion Gates:
 | Output budget discipline | yes | Scope/cap noisy commands | pass |
 | Timed checkpoint | no | N/A | no duration |
 | Autoreview for non-trivial implementation changes | yes | Dirty local review | clean, correct 0.98, no actionable findings |
-| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-autoclose-prs-without-task.md` | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-17-autoclose-prs-without-task.md` | pass after final receipt update |
 | Docs source-backed claim audit | yes | Compare CONTRIBUTING with rules | pass |
 | Docs links / routes / previews | yes | README contributor link | existing leaf resolves |
 | Docs MDX/content parser | no | N/A | no MDX/www change |
@@ -302,7 +302,7 @@ Phase / pass table:
 | Implementation | complete | evidence gate, comment/close path, templates, docs, mirrors | verification |
 | Verification | complete | source/mirror/intent/reviews and `bun check` pass | commit/PR |
 | Commit / PR / GitHub sync | complete | PR #364 body and task evidence read back | remote gates |
-| Closeout | pending | | final response |
+| Closeout | complete | source head gates green; final receipt-only head will be merged | done |
 
 Findings:
 - Current autoclosure routed missing task evidence back to task and left the PR
@@ -340,6 +340,8 @@ Verification evidence:
   scenario.
 - PR #364 body contains exactly one task-plan line. Its exact fetched head
   contains this plan, which identifies PR #364 in task source and ownership.
+- PR #364 head `cf852b2c` passed CI run `32014117778` in 6m26s,
+  Vercel, and auto-release run `32014117836` with no release requested.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |
@@ -354,7 +356,7 @@ Source-listed case matrix:
 
 Final handoff contract:
 - Commit line: `117d699e docs: close PRs without task evidence`
-- PR line: #364 opened and exact task evidence verified at `60319be3`
+- PR line: #364 exact task evidence verified; source head gates green at `cf852b2c`
 - Issue line: N/A
 - Confidence line: 98%
 - Flow table:
@@ -404,14 +406,15 @@ Timeline:
 Reboot status:
 | Question | Answer |
 |----------|--------|
-| Where am I? | Remote closeout |
-| Where am I going? | Exact #364 gates and merge |
+| Where am I? | Complete implementation; final GitHub merge receipt next |
+| Where am I going? | Final receipt-only head gates and exact merge |
 | What is the goal? | Comment and close PRs without verifiable task evidence |
 | What have I learned? | Destructive enforcement needs immutable evidence and idempotent ordering |
 | What have I done? | Patched sources/templates/docs, regenerated, reviewed, checked, opened compliant #364 |
 
 Open risks:
-- Required remote gates and exact merge remain for PR #364.
+- None in the workflow policy. Final merge read-back is an external GitHub
+  receipt and cannot be committed inside the PR after merge.
 
 Hard closeout guard:
 - A local-only final response for verified code-changing work is invalid unless

--- a/docs/plans/templates/autoclosure.md
+++ b/docs/plans/templates/autoclosure.md
@@ -39,6 +39,7 @@ Start Gates:
 | Gate | Applies | Evidence |
 | --- | --- | --- |
 | Dedicated task invocation and plan for exact PR | pending | pending |
+| Task evidence verified at PR head | pending | body path + head file + exact PR owner |
 | Active source/plan reconstructed | pending | pending |
 | Intended delta and exclusions recorded | pending | pending |
 | Closure matrix classified | pending | pending |
@@ -49,6 +50,7 @@ Closure matrix:
 | Lane | Applies | Owner/proof | Status |
 | --- | --- | --- | --- |
 | per-PR task ownership | pending | exact PR + dedicated task plan | pending |
+| noncompliant close | pending | required comment + `CLOSED` read-back | pending |
 | source behavior | pending | pending | pending |
 | package/API/build | pending | pending | pending |
 | generated output | pending | pending | pending |
@@ -61,8 +63,11 @@ Closure matrix:
 | GitHub delivery | pending | pending | pending |
 
 Work Checklist:
-- [ ] Each agent-processed PR has its own `task` invocation and dedicated task
-      plan; a batch plan or aggregate autoclosure is not used as a substitute.
+- [ ] Every PR has its own `task` invocation and dedicated task plan; a batch
+      plan or aggregate autoclosure is not used as a substitute.
+- [ ] Task evidence was verified from the PR body, fetched head, and exact PR
+      ownership; otherwise the required comment and `CLOSED` state were read
+      back and no source review, repair, merge, or release work continued.
 - [ ] Intended behavior and exclusions are reconstructed from real sources.
 - [ ] Each lane is proven or N/A with a concrete reason.
 - [ ] Generated output was changed through its owner and regenerated.
@@ -80,6 +85,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
 | Per-PR task ownership | pending | Record exact PR and dedicated task-plan path | pending |
+| Noncompliant PR disposition | pending | Verify task evidence or comment then close and read back | pending |
 | Targeted behavior proof | pending | Run smallest missing owning proof | pending |
 | Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
 | Package/docs/scenario closure | pending | Run every applicable local contract | pending |

--- a/docs/plans/templates/task.md
+++ b/docs/plans/templates/task.md
@@ -48,6 +48,9 @@ Constraints:
   N/A reason for verified code-changing task work.
 - A PR created by this task must use the PR #270 emoji task-style PR body
   contract below, not a generic summary/body from a git helper skill.
+- A task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`; the plan must exist at the PR head and
+  identify the exact PR before autoclosure.
 - Do not add broad ceremony when the task is trivial or docs-only.
 
 Boundaries:
@@ -130,6 +133,7 @@ Start Gates:
 | Browser tool decision for browser surface | pending | pending |
 | Commit / PR expectation decision | pending | For verified code-changing work, default is commit, push, and PR because `task` explicitly requires it; N/A only for explicit user decline, no local patch, analytical/blocked/inconclusive work, or recorded blocker. |
 | Task-style PR body decision | pending | pending |
+| Task-plan PR body evidence | pending | Record plan line, head file, and exact PR owner |
 | GitHub issue sync expectation decision | pending | pending |
 | Output budget strategy recorded | pending | pending |
 
@@ -142,9 +146,9 @@ Work Checklist:
 - [ ] Task source classified with source type, id/link, title, task type,
       acceptance criteria, caveats, likely files/routes/packages, browser
       surface, and root-cause layer.
-- [ ] Every agent-processed GitHub PR has its own task plan. This plan owns one
-      exact PR, owns a not-yet-created PR slice, or records N/A because no PR is
-      in scope; a batch plan is not used as a substitute.
+- [ ] Every GitHub PR in scope has its own task plan. This plan owns one exact
+      PR, owns a not-yet-created PR slice, or records N/A because no PR is in
+      scope; a batch plan is not used as a substitute.
 - [ ] Required video or screen-recording evidence is cached/read as normalized
       `<video-transcripts>` XML, or marked N/A with reason.
 - [ ] For public GitHub bug reports, behavior claims, technical diagnoses, or
@@ -180,6 +184,8 @@ Work Checklist:
       "User did not separately ask for a PR" is not a valid blocker.
 - [ ] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
       recorded, or blocker recorded.
+- [ ] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
+      exists at the PR head, and it identifies the exact PR before autoclosure.
 - [ ] Branch handling recorded for code-changing work: dedicated branch used,
       new branch needed, or N/A with reason.
 - [ ] Local-env-rot retry policy recorded for any surprising repo-wide failure:
@@ -224,6 +230,7 @@ Completion Gates:
 | Commit created | pending | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
 | PR create or update | pending | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | pending |
 | Task-style PR body verified | pending | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | pending |
+| PR task evidence verified | pending | Verify body plan line, plan at PR head, and exact PR ownership | pending |
 | PR proof image hosting | pending | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | pending |
 | GitHub issue sync-back | pending | Post concise issue sync after PR exists, or record N/A/blocker | pending |
 | Final handoff contract | pending | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | pending |
@@ -290,7 +297,8 @@ Task-style PR body contract:
   part of the diff and repo policy expects auto release, include that block.
 - Use the accepted PR #270 visual format. The body starts with an emoji
   issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
-  an emoji confidence line like `🟢 95-100% confidence`.
+  `🧭 Task plan: docs/plans/<plan>.md`, then an emoji confidence line like
+  `🟢 95-100% confidence`.
 - Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
 - Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
   failing proof with `🔴`, and non-applicable cells with `➖ N/A`.


### PR DESCRIPTION
🐛 Fixes ➖ N/A

🧭 Task plan: `docs/plans/2026-08-17-autoclose-prs-without-task.md`

🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Autoclosure routed missing task evidence back to task but left the PR open | ➖ N/A |
| Verified | 🟢 Source/head evidence contract, idempotent comment-before-close path, mirrors, reviews, and `bun check` | ➖ N/A |

**✅ Outcome**

- Requires body, exact fetched head, and exact-PR task-plan evidence before source review.
- Comments on and closes noncompliant PRs, then reads back the explanation and `CLOSED` state.
- Recommends GPT-5.6 with high-or-higher reasoning effort in the remediation comment.
- Stops without closing when the comment cannot be verified.

**⚠️ Caveat**

- This changes future autoclosure behavior; it does not bulk-close currently open PRs.
- No package, release, product, or cron change.

**🏗️ Design**

The compliance gate trusts only one task-plan line in the PR body, that file at the immutable fetched PR head, and exact-PR ownership inside the plan. Retries reuse the exact public comment, and non-open PRs stop without duplicate writes.

**🧪 Verified**

- `bun install`
- `bun run intent:validate`
- `bun run intent:stale`
- source/generated parity audit
- agent-native safety review: pass after two fixes
- local autoreview: clean, 0.98
- `bun lint:fix`
- `bun check`