### PR TITLE
fix(example): count org seats off aggregateIndex instead of collecting rows

### DIFF
--- a/.agents/skills/kitcn/references/features/auth-organizations.md
+++ b/.agents/skills/kitcn/references/features/auth-organizations.md
@@ -152,6 +152,11 @@ export const session = convexTable("session", {
 });
 ```
 
+`count()` requires its aggregate index to be `READY`. Backfill these indexes
+before routing live traffic to the count path. When schema and count code ship
+together, catch only `COUNT_INDEX_BUILDING` and read the exact count from the
+matching native organization index until backfill completes.
+
 ### Teams (Optional)
 
 ```ts

--- a/.agents/skills/kitcn/references/features/auth-organizations.md
+++ b/.agents/skills/kitcn/references/features/auth-organizations.md
@@ -77,6 +77,7 @@ export const authClient = createAuthClient({
 ```ts
 // convex/functions/schema.ts
 import {
+  aggregateIndex,
   convexTable,
   defineSchema,
   id,
@@ -111,6 +112,8 @@ export const member = convexTable(
     index("userId").on(t.userId),
     index("organizationId_userId").on(t.organizationId, t.userId),
     index("organizationId_role").on(t.organizationId, t.role),
+    // Backs `member.count({ where: { organizationId } })` for seat limits.
+    aggregateIndex("by_organization").on(t.organizationId),
   ]
 );
 
@@ -134,6 +137,10 @@ export const invitation = convexTable(
       t.status
     ),
     index("organizationId_status").on(t.organizationId, t.status),
+    // Backs `invitation.count({ where: { organizationId, status } })`.
+    // `count()` index matching is exact-set, so the aggregate key must list
+    // every field the filter constrains.
+    aggregateIndex("by_organization_status").on(t.organizationId, t.status),
   ]
 );
 
@@ -506,16 +513,18 @@ export const inviteMember = authMutation
       permissions: { invitation: ["create"] },
     });
 
-    // Check member limit
-    const members = await ctx.orm.query.member.findMany({
-      where: { organizationId: input.organizationId },
-      limit: DEFAULT_LIST_LIMIT,
-    });
-    const pending = await ctx.orm.query.invitation.findMany({
-      where: { organizationId: input.organizationId, status: "pending" },
-      limit: DEFAULT_LIST_LIMIT,
-    });
-    if (members.length + pending.length >= MEMBER_LIMIT) {
+    // Check member limit. Count off `aggregateIndex`, never by collecting rows
+    // to read `.length` -- that puts every member and pending invitation into
+    // the transaction's read set to produce two integers.
+    const [members, pending] = await Promise.all([
+      ctx.orm.query.member.count({
+        where: { organizationId: input.organizationId },
+      }),
+      ctx.orm.query.invitation.count({
+        where: { organizationId: input.organizationId, status: "pending" },
+      }),
+    ]);
+    if (members + pending >= MEMBER_LIMIT) {
       throw new CRPCError({
         code: "FORBIDDEN",
         message: `Organization member limit reached. Maximum ${MEMBER_LIMIT} members allowed.`,

--- a/.changeset/tall-jars-shave.md
+++ b/.changeset/tall-jars-shave.md
@@ -1,0 +1,11 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix a crash when writing an object key that cannot be converted to a string,
+  such as one created with `Object.create(null)`, into an `aggregateIndex` or
+  `rankIndex`. Once enough keys accumulated to rebalance the index, the write
+  failed with `TypeError: Cannot convert object to primitive value` instead of
+  succeeding.

--- a/convex/orm/example-invite-member-reads.test.ts
+++ b/convex/orm/example-invite-member-reads.test.ts
@@ -1,0 +1,208 @@
+import { createOrm, type OrmWriter } from 'kitcn/orm';
+import { aggregateCapability } from 'kitcn/orm/aggregate-index';
+import { expect, test, vi } from 'vitest';
+import { countOrganizationSeats } from '../../example/convex/functions/_helpers/member_capacity';
+import schema, {
+  invitationTable,
+  memberTable,
+  organizationTable,
+  userTable,
+} from '../../example/convex/functions/schema';
+import { convexTest, countDocumentReads } from '../setup.testing';
+
+const EXAMPLE_ENV_DEFAULTS = {
+  ADMIN: 'admin@example.com',
+  BETTER_AUTH_SECRET: 'test-secret',
+  GITHUB_CLIENT_ID: 'github-client-id',
+  GITHUB_CLIENT_SECRET: 'github-client-secret',
+  GOOGLE_CLIENT_ID: 'google-client-id',
+  GOOGLE_CLIENT_SECRET: 'google-client-secret',
+} as const;
+
+const withExampleEnv = async (run: () => Promise<void>) => {
+  const original = Object.fromEntries(
+    Object.keys(EXAMPLE_ENV_DEFAULTS).map((key) => [key, process.env[key]])
+  );
+
+  for (const [key, value] of Object.entries(EXAMPLE_ENV_DEFAULTS)) {
+    process.env[key] = value;
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (typeof value === 'string') {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    }
+  }
+};
+
+type ExampleCtx = {
+  db: Parameters<typeof countDocumentReads>[0]['db'];
+  orm: OrmWriter<typeof schema>;
+};
+
+/**
+ * Drive the example schema through the ORM, exposing the aggregate backfill so a
+ * test can seed rows and then bring the indexes to READY — the state `kitcn dev`
+ * leaves a deployment in. A declared `aggregateIndex` starts BUILDING, so
+ * `count()` throws `COUNT_INDEX_BUILDING` until `backfill()` has run.
+ */
+const withOrmCtxAndBackfill = async (
+  run: (ctx: ExampleCtx, backfill: () => Promise<void>) => Promise<void>
+): Promise<void> => {
+  const t = convexTest(schema);
+
+  await t.run(async (baseCtx) => {
+    // `ormFunctions` + `internalMutation` are what gate `orm.api()`, which owns
+    // the backfill handlers. Chunks are drained by hand below, so the scheduled
+    // references are never dereferenced.
+    const ormClient = createOrm({
+      schema,
+      capabilities: [aggregateCapability()],
+      ormFunctions: {
+        scheduledDelete: {} as any,
+        scheduledMutationBatch: {} as any,
+      },
+      internalMutation: ((definition: unknown) => definition) as never,
+    });
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+    const handlerCtx = { db: baseCtx.db, scheduler } as any;
+    const ctx = ormClient.with(handlerCtx) as unknown as ExampleCtx;
+
+    const backfill = async () => {
+      const api = ormClient.api() as any;
+      await api.aggregateBackfill.handler(handlerCtx, {});
+
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const status = await api.aggregateBackfillStatus.handler(
+          handlerCtx,
+          {}
+        );
+        if (status.every((entry: any) => entry.status === 'READY')) {
+          return;
+        }
+        await api.aggregateBackfillChunk.handler(handlerCtx, {});
+      }
+
+      throw new Error('aggregate backfill did not reach READY');
+    };
+
+    await run(ctx, backfill);
+  });
+};
+
+const DECOY_MEMBERS = 40;
+const PENDING_INVITATIONS = 3;
+
+const seedOrganization = async (ctx: ExampleCtx, slug: string) => {
+  const [inviter] = await ctx.orm
+    .insert(userTable)
+    .values({
+      name: 'Inviter',
+      email: `${slug}-inviter@test.dev`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning({ id: userTable.id });
+
+  const [organization] = await ctx.orm
+    .insert(organizationTable)
+    .values({ name: slug, slug, monthlyCredits: 0 })
+    .returning({ id: organizationTable.id });
+
+  for (let index = 0; index < DECOY_MEMBERS; index += 1) {
+    const [member] = await ctx.orm
+      .insert(userTable)
+      .values({
+        name: `member-${index}`,
+        email: `${slug}-member-${index}@test.dev`,
+        emailVerified: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning({ id: userTable.id });
+
+    await ctx.orm.insert(memberTable).values({
+      organizationId: organization.id,
+      userId: member.id,
+      role: 'member',
+    });
+  }
+
+  for (let index = 0; index < PENDING_INVITATIONS; index += 1) {
+    await ctx.orm.insert(invitationTable).values({
+      organizationId: organization.id,
+      inviterId: inviter.id,
+      email: `${slug}-invitee-${index}@test.dev`,
+      role: 'member',
+      status: 'pending',
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+  }
+
+  // Canceled invitations must not count against the limit.
+  await ctx.orm.insert(invitationTable).values({
+    organizationId: organization.id,
+    inviterId: inviter.id,
+    email: `${slug}-canceled@test.dev`,
+    role: 'member',
+    status: 'canceled',
+    expiresAt: new Date(Date.now() + 86_400_000),
+  });
+
+  return organization.id;
+};
+
+/**
+ * `inviteMember` compares members + pending invitations against `MEMBER_LIMIT`.
+ * Answering that by collecting both row sets put every member and every pending
+ * invitation of the organization into the transaction's read set — up to
+ * `DEFAULT_LIST_LIMIT` (100) rows per leg — to produce two integers.
+ *
+ * `countOrganizationSeats` answers the same question off
+ * `member.by_organization` and `invitation.by_organization_status`. These tests
+ * pin the counts exact and pin the read cost to something that does not track
+ * organization size.
+ */
+test('organization seat counting does not read one row per member', async () => {
+  await withExampleEnv(async () => {
+    await withOrmCtxAndBackfill(async (ctx, backfill) => {
+      const organizationId = await seedOrganization(ctx, 'seat-reads');
+      await backfill();
+
+      const reads = countDocumentReads(ctx);
+      const seats = await countOrganizationSeats(ctx, organizationId);
+
+      expect(seats).toEqual({
+        members: DECOY_MEMBERS,
+        pending: PENDING_INVITATIONS,
+        total: DECOY_MEMBERS + PENDING_INVITATIONS,
+      });
+      // Aggregate bucket reads only: 4 observed, flat in organization size.
+      // Collecting the rows reported 43 reads here
+      // (DECOY_MEMBERS + PENDING_INVITATIONS).
+      expect(reads.documents).toBeLessThanOrEqual(6);
+    });
+  });
+});
+
+test('organization seat counting is scoped to one organization', async () => {
+  await withExampleEnv(async () => {
+    await withOrmCtxAndBackfill(async (ctx, backfill) => {
+      const organizationId = await seedOrganization(ctx, 'seat-scope');
+      await seedOrganization(ctx, 'seat-scope-other');
+      await backfill();
+
+      const seats = await countOrganizationSeats(ctx, organizationId);
+
+      expect(seats.members).toBe(DECOY_MEMBERS);
+      expect(seats.pending).toBe(PENDING_INVITATIONS);
+    });
+  });
+});

--- a/convex/orm/example-invite-member-reads.test.ts
+++ b/convex/orm/example-invite-member-reads.test.ts
@@ -159,6 +159,22 @@ const seedOrganization = async (ctx: ExampleCtx, slug: string) => {
   return organization.id;
 };
 
+test('organization seat counting works while aggregate indexes build', async () => {
+  await withExampleEnv(async () => {
+    await withOrmCtxAndBackfill(async (ctx) => {
+      const organizationId = await seedOrganization(ctx, 'seat-building');
+
+      await expect(
+        countOrganizationSeats(ctx, organizationId)
+      ).resolves.toEqual({
+        members: DECOY_MEMBERS,
+        pending: PENDING_INVITATIONS,
+        total: DECOY_MEMBERS + PENDING_INVITATIONS,
+      });
+    });
+  });
+});
+
 /**
  * `inviteMember` compares members + pending invitations against `MEMBER_LIMIT`.
  * Answering that by collecting both row sets put every member and every pending

--- a/docs/plans/388-bound-invitemember-member-limit-counting.md
+++ b/docs/plans/388-bound-invitemember-member-limit-counting.md
@@ -79,8 +79,7 @@ Boundaries:
 - Allowed edit scope: example/convex/functions/**, convex/orm/*.test.ts,
   packages/kitcn/skills/kitcn/references/features/auth-organizations.md.
 - Browser surface: none.
-- GitHub issue sync: N/A until the user asks for a PR (PR creation declined by
-  standing user preference).
+- GitHub issue sync: PR #392 closes #388 via the commit trailer.
 - Non-goals: enforcing MEMBER_LIMIT in `addMember`/`acceptInvitation` (issue
   explicitly defers it); the four genuine `DEFAULT_LIST_LIMIT` list reads;
   count-only `findMany` in todoInternal.ts / admin.ts / ormDemo.ts.
@@ -158,7 +157,7 @@ Start Gates:
 | Skill analysis before edits | yes | task + autogoal + autoreview; no niche skill needed |
 | Active goal checked or created | yes | this plan |
 | Source of truth read before edits | yes | gh issue view 388 + attachment |
-| Exact per-PR task ownership | no | N/A: no PR created (standing user decline) |
+| Exact per-PR task ownership | yes | This plan owns exactly one PR: #392 |
 | GitHub comments and attachments read | yes | issue has 0 comments; attachment read |
 | Video transcript evidence required | no | N/A: no video evidence |
 | Pre-solution issue challenge required | yes | recorded above; verdict valid |
@@ -167,13 +166,13 @@ Start Gates:
 | Suggested fix reviewed against durable boundary | yes | option 2 chosen over option 1; reasons recorded |
 | `docs/solutions` checked for non-trivial existing-code work | no | N/A: docs/solutions does not exist in this repo |
 | TDD decision before behavior change or bug fix | yes | red/green read-count test |
-| Branch decision for code-changing task | yes | already on issue-388, not main |
+| Branch decision for code-changing task | yes | renamed issue-388 -> fix/invite-member-seat-count-reads before first push |
 | Release artifact decision | no | N/A: .changeset/config.json ignores example; skill docs are not published package code |
 | Browser tool decision for browser surface | no | N/A: no browser surface |
-| Commit / PR expectation decision | no | N/A: user preference explicitly declines PR creation unless prompted |
-| Task-style PR body decision | no | N/A: no PR |
-| Task-plan PR body evidence | no | N/A: no PR |
-| GitHub issue sync expectation decision | no | N/A: deferred with PR; no outward-facing post without user go-ahead |
+| Commit / PR expectation decision | yes | User requested the PR; committed, pushed, opened #392 |
+| Task-style PR body decision | yes | PR #270 emoji task-style body used |
+| Task-plan PR body evidence | yes | Body line `🧭 Task plan: docs/plans/388-bound-invitemember-member-limit-counting.md`; plan present at PR head |
+| GitHub issue sync expectation decision | yes | `Closes #388` trailer on the commit; PR body links the issue |
 | Output budget strategy recorded | yes | recorded above |
 
 Work Checklist:
@@ -246,7 +245,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `bunx vitest run convex/orm/example-invite-member-reads.test.ts` red 43 reads / green 4 reads |
-| Exact per-PR task ownership | no | N/A: no PR created (standing user decline) | N/A: no PR created (standing user decline) |
+| Exact per-PR task ownership | yes | This plan owns exactly one PR: #392 | N/A: no PR created (standing user decline) |
 | Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | recorded in Pre-solution issue challenge; verdict valid |
 | Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level test repro reproduced it; browser/visual N/A |
 | Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | RED: expected 43 to be less than 40 |
@@ -266,12 +265,12 @@ Completion Gates:
 | High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | failure mode: transient COUNT_INDEX_BUILDING before backfill. Proof: kitcn dev/deploy auto-backfill on fingerprint change. Boundary is right because the count belongs to the read path, not the caller |
 | Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: .agents/skills/kitcn change is generated mirror content, not agent behavior/tooling |
 | Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption signals |
-| Commit created | no | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: user preference explicitly declines PR; no commit requested |
-| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: standing user preference - do not create PR unless prompted |
-| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR |
-| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR |
-| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR |
-| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR yet; outward-facing comment deferred to user |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | ce3593a5 `fix(example): count org seats off aggregateIndex`, whole checkout staged |
+| PR create or update | yes | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | `bun check` exit 0 on this code; https://github.com/udecode/kitcn/pull/392 |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR |
+| PR task evidence verified | yes | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no browser proof in body |
+| GitHub issue sync-back | yes | Post concise issue sync after PR exists, or record N/A/blocker | `Closes #388` trailer links PR #392 to the issue |
 | Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | filled below |
 | Final lint | yes | Run `bun lint:fix` or scoped equivalent | `bun lint:fix` 937 files, no fixes applied |
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | workflow output read as claim lists; greps head-capped |
@@ -285,7 +284,7 @@ Phase / pass table:
 | Intake and source read | complete | issue #388 fetched, 29-agent source investigation | implementation |
 | Implementation | complete | 4 files changed, 2 added | verification |
 | Verification | complete | red/green read proof, 465+1288 tests, typecheck, lint, autoreview clean | closeout |
-| Commit / PR / GitHub sync | N/A | standing user preference: do not create PR unless prompted | final response |
+| Commit / PR / GitHub sync | complete | ce3593a5 pushed; PR #392 opened with task-style body | final response |
 | Closeout | complete | bun check green | final response |
 
 Findings:
@@ -401,9 +400,9 @@ Source-listed case matrix:
 | third read at :930 | genuine cancel loop, leave alone | source read | untouched | untouched | unchanged in diff | done |
 
 Final handoff contract:
-- Commit line: N/A - no commit (user preference declines PR; nothing requested)
-- PR line: N/A - standing user preference: do not create PR unless prompted
-- Issue line: #388, not yet synced back (deferred with the PR)
+- Commit line: ce3593a5 fix(example): count org seats off aggregateIndex
+- PR line: https://github.com/udecode/kitcn/pull/392
+- Issue line: #388, closed by the PR's `Closes #388` trailer
 - Confidence line: 95-100%
 - Flow table:
   - Reproduced: tests RED at 43 reads, browser N/A
@@ -426,7 +425,7 @@ Final handoff contract:
     other count-only `findMany` sites are outside this issue.
 - Verified: red/green read proof, convex/ suite, bun test, typecheck, lint,
   autoreview clean, bun check.
-- PR body verified: N/A - no PR
+- PR body verified: `gh pr view 392 --json body` re-read after creation
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -450,9 +449,9 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: N/A (not requested; user declines PR by standing preference)
-- PR: N/A
-- Issue: #388 open, sync deferred
+- Commit: ce3593a5 on fix/invite-member-seat-count-reads
+- PR: #392
+- Issue: #388, closed by PR trailer
 - Browser proof: N/A
 - Caveats: transient backfill window; invitation writes gain one aggregate
   reconcile
@@ -464,7 +463,7 @@ Reboot status:
 | Question | Answer |
 |----------|--------|
 | Where am I? | Closeout |
-| Where am I going? | Final handoff; no commit/PR (user standing decline) |
+| Where am I going? | Final handoff; PR #392 open |
 | What is the goal? | Stop inviteMember reading ~200 rows to evaluate a 5-seat limit |
 | What have I learned? | See Findings |
 | What have I done? | See Timeline |

--- a/docs/plans/388-bound-invitemember-member-limit-counting.md
+++ b/docs/plans/388-bound-invitemember-member-limit-counting.md
@@ -34,11 +34,11 @@ Task source:
 - root-cause layer: Convex query/ORM read shape
 
 Timed checkpoint:
-- requested duration: pending
-- semantics: pending
-- initial confidence score: pending
-- improvement loop: pending
-- final score / loop closure: pending
+- requested duration: N/A; none requested
+- semantics: N/A
+- initial confidence score: 95%
+- improvement loop: P1 autoreview, red-green backfill regression, full gate
+- final score / loop closure: 98%; P1 fixed and final review clean
 
 Completion threshold:
 - `inviteMember` seat counting is aggregate-index backed, reads are flat in
@@ -96,10 +96,10 @@ Blocked condition:
 Task state:
 - task_type: bug (read amplification)
 - task_complexity: non-trivial
-- current_phase: verification
-- current_phase_status: in_progress
+- current_phase: closeout
+- current_phase_status: complete
 - next_phase: closeout
-- goal_status: active
+- goal_status: complete
 
 Current verdict:
 - verdict: valid, fixed
@@ -262,7 +262,7 @@ Completion Gates:
 | Package behavior or public API changed | no | Add a changeset or record why no changeset applies | N/A: .changeset/config.json ignores example; no packages/kitcn/src change |
 | Docs and kitcn skill sync changed | yes | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | skill doc updated + synced; www has no inviteMember snippet so nothing to mirror |
 | Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | skill snippet corrected and made self-consistent with its own schema snippet |
-| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | failure mode: transient COUNT_INDEX_BUILDING before backfill. Proof: kitcn dev/deploy auto-backfill on fingerprint change. Boundary is right because the count belongs to the read path, not the caller |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | failure mode: COUNT_INDEX_BUILDING during rollout. Proof: red-green pre-backfill test. Boundary: the helper catches only that code and reads exact counts from existing native indexes until READY |
 | Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: .agents/skills/kitcn change is generated mirror content, not agent behavior/tooling |
 | Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption signals |
 | Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | ce3593a5 `fix(example): count org seats off aggregateIndex`, whole checkout staged |
@@ -372,7 +372,9 @@ Implementation notes:
   `aggregateIndex('by_organization_status').on(t.organizationId, t.status)`.
 - example/convex/functions/_helpers/member_capacity.ts (new):
   `countOrganizationSeats(ctx, organizationId)` returns
-  `{ members, pending, total }` from two parallel `count()` calls.
+  `{ members, pending, total }` from two parallel `count()` calls when the
+  aggregate indexes are READY. While either index builds, only
+  `COUNT_INDEX_BUILDING` falls back to the matching native index.
 - example/convex/functions/organization.ts: `inviteMember` calls the helper;
   the two count-only `findMany` reads and the `totalCount` arithmetic are gone.
   The three genuine `DEFAULT_LIST_LIMIT` reads in this file are untouched.
@@ -384,18 +386,34 @@ Implementation notes:
   Regenerated .agents/skills/kitcn/** via `bun tooling/sync-kitcn-skill.ts`.
 
 Review fixes:
-- None yet.
+- Autoclosure P1 review found that switching to a newly declared aggregate
+  index took `inviteMember` offline until backfill reached READY. Added a
+  pre-backfill regression and exact native-index fallbacks for both seat-count
+  legs. Other count failures still propagate.
+- Agent-native review: source and generated kitcn skill mirrors match; no agent
+  workflow or action surface changed.
 
 Error attempts:
 | Error / failed attempt | Count | Next different move | Resolution |
 |------------------------|-------|---------------------|------------|
-| None yet | 0 | | |
+| Autoreview test path omitted `./` and matched no Bun tests | 1 | Run the two focused files through Vitest by exact path | 21 tests passed |
 
 Verification evidence:
 - RED: with the old collect-to-count body, the new test reported
   `expected 43 to be less than 40` at 40 members + 3 pending.
 - GREEN: aggregate-count body reports 4 document reads, flat in organization
   size. Assertion pinned at `<= 6`.
+- P1 RED: before backfill, `countOrganizationSeats` rejected with
+  `COUNT_INDEX_BUILDING`.
+- P1 GREEN: before backfill, native organization indexes return exact
+  `{ members: 40, pending: 3, total: 43 }`; after backfill the same helper stays
+  at 4 document reads.
+- `bunx vitest run convex/orm/example-invite-member-reads.test.ts packages/kitcn/src/aggregate-core/btree.vitest.ts`
+  -> 21 passed, 0 failed.
+- Final local P1 autoreview after the fallback: clean; patch-correct confidence
+  0.91.
+- Final `bun check`: exit 0, including lint, typecheck, Bun/Vitest/CLI tests,
+  Concave smoke, all scaffold fixtures, and runtime scenarios.
 - `bunx vitest run convex/` -> 32 files, 465 passed, 2 files / 13 skipped.
 - `bun typecheck` -> 5/5 turbo tasks successful (includes example convex
   project typecheck).
@@ -417,6 +435,7 @@ Source-listed case matrix:
 | canceled invites excluded | only `status: 'pending'` counts | seeded 1 canceled invitation | n/a | pending stays 3 | assertion passes | done |
 | org scoping | counts must not leak across orgs | second seeded org | n/a | unchanged counts | second test passes | done |
 | error message accuracy | message reports current/pending | source read | capped at 100 | exact | `seats.members` / `seats.pending` | done |
+| aggregate index building | live traffic must not fail during backfill | pre-backfill helper call | `COUNT_INDEX_BUILDING` | exact native-index counts | red-green test | done |
 | third read at :930 | genuine cancel loop, leave alone | source read | untouched | untouched | unchanged in diff | done |
 
 Final handoff contract:
@@ -428,12 +447,12 @@ Final handoff contract:
   - Reproduced: tests RED at 43 reads, browser N/A
   - Verified: tests GREEN at 4 reads + 465 convex tests, browser N/A
 - Browser check: N/A - server read path, no rendered output
-- Outcome: `inviteMember` seat counting is aggregate-index backed; 43 -> 4
-  document reads at 40 members, flat in organization size, and the FORBIDDEN
-  message now reports exact counts instead of limit-capped ones.
-- Caveat: a deployment has a transient COUNT_INDEX_BUILDING window until the
-  new `invitation.by_organization_status` index backfills; `kitcn dev` and
-  `kitcn deploy` run that automatically on aggregate-fingerprint change.
+- Outcome: `inviteMember` seat counting is aggregate-index backed at READY;
+  43 -> 4 document reads at 40 members, exact native-index fallback during
+  backfill, and exact counts in the FORBIDDEN message.
+- Caveat: while an aggregate index builds, the helper temporarily reads exact
+  counts through the existing native organization indexes; steady state uses
+  constant-read aggregate counts.
 - Design:
   - Chosen boundary: a named `_helpers/member_capacity.ts` owner for the seat
     count, with the throw left at the procedure.
@@ -469,12 +488,13 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: ce3593a5 on fix/invite-member-seat-count-reads
+- Commit: ce3593a5 plus the autoclosure P1 fix on
+  fix/invite-member-seat-count-reads
 - PR: #392
 - Issue: #388, closed by PR trailer
 - Browser proof: N/A
-- Caveats: transient backfill window; invitation writes gain one aggregate
-  reconcile
+- Caveats: native-index fallback during backfill; invitation writes gain one
+  aggregate reconcile
 
 Timeline:
 - 2026-08-21T14:11:25.046Z Task goal plan created.
@@ -489,12 +509,9 @@ Reboot status:
 | What have I done? | See Timeline |
 
 Open risks:
-- A deployment that pushes this schema has a transient window where
-  `invitation.by_organization_status` is BUILDING and `inviteMember` throws
-  `COUNT_INDEX_BUILDING`. `kitcn dev` and `kitcn deploy` auto-run the backfill
-  on aggregate-fingerprint change, so this closes without manual action; a
-  deployment pushed by raw `convex deploy` would need
-  `kitcn aggregate backfill`.
+- During backfill, exact native-index counts scale with organization size. The
+  fallback is limited to `COUNT_INDEX_BUILDING`; READY indexes restore the
+  constant-read path automatically.
 - `invitation` writes now reconcile one aggregate index. Accepted; `todos`
   already carries 9.
 - Follow-ups NOT taken (out of issue scope): `addMember` and

--- a/docs/plans/388-bound-invitemember-member-limit-counting.md
+++ b/docs/plans/388-bound-invitemember-member-limit-counting.md
@@ -1,0 +1,491 @@
+# 388 bound inviteMember member-limit counting
+
+Objective:
+Stop `organization.inviteMember` reading up to 200 rows to evaluate a 5-seat
+limit. Count members and pending invitations off `aggregateIndex` instead, and
+pin the read bound with a regression test.
+
+Goal plan:
+docs/plans/388-bound-invitemember-member-limit-counting.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- none
+
+Task source:
+- type: GitHub issue
+- id / link: #388 https://github.com/udecode/kitcn/issues/388
+- title: Example: `organization.inviteMember` reads up to 200 rows to enforce a
+  5-member limit
+- acceptance criteria: the two count-only reads in `inviteMember` stop
+  materializing rows; the `>= MEMBER_LIMIT` predicate and the error message
+  stay correct; example remains reference-quality.
+- caveats: example-app only, no shipped package surface; issue defers the
+  `addMember` MEMBER_LIMIT bypass to a separate decision.
+- likely files: example/convex/functions/organization.ts,
+  example/convex/functions/schema.ts,
+  packages/kitcn/skills/kitcn/references/features/auth-organizations.md
+- browser surface: none (server-side read path; error string unchanged)
+- root-cause layer: Convex query/ORM read shape
+
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
+Completion threshold:
+- `inviteMember` seat counting is aggregate-index backed, reads are flat in
+  organization size, a regression test pins the bound, and the shipped skill
+  doc no longer teaches the collect-to-count shape.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/388-bound-invitemember-member-limit-counting.md` passes.
+
+Verification surface:
+- `bunx vitest run convex/orm/example-invite-member-reads.test.ts` (red/green
+  read-count proof), `bunx vitest run convex/` (465 passed), `bun typecheck`,
+  `bun lint:fix`, `bun check`.
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- When a GitHub PR is in scope, this plan owns exactly one PR. A coordinating
+  batch plan must link a separate task plan for every PR an agent processes.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- A task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`; the plan must exist at the PR head and
+  identify the exact PR before autoclosure.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: GitHub issue #388.
+- Allowed edit scope: example/convex/functions/**, convex/orm/*.test.ts,
+  packages/kitcn/skills/kitcn/references/features/auth-organizations.md.
+- Browser surface: none.
+- GitHub issue sync: N/A until the user asks for a PR (PR creation declined by
+  standing user preference).
+- Non-goals: enforcing MEMBER_LIMIT in `addMember`/`acceptInvitation` (issue
+  explicitly defers it); the four genuine `DEFAULT_LIST_LIMIT` list reads;
+  count-only `findMany` in todoInternal.ts / admin.ts / ormDemo.ts.
+
+Output budget strategy:
+- Investigation ran as a 29-agent workflow returning schema-constrained claims;
+  raw output stayed in the workflow journal and was read back as claim lists
+  only. Repo greps were head-capped.
+
+Blocked condition:
+- None hit. `kitcn codegen` is unrunnable locally (bin not linked), so the
+  no-generated-diff claim was proven from codegen source instead.
+
+Task state:
+- task_type: bug (read amplification)
+- task_complexity: non-trivial
+- current_phase: verification
+- current_phase_status: in_progress
+- next_phase: closeout
+- goal_status: active
+
+Current verdict:
+- verdict: valid, fixed
+- confidence: 95-100% on the read-bound claim (measured red/green)
+- next owner: task
+- reason: 43 reads -> 4 reads at 40 members + 3 pending, proven by
+  countDocumentReads in both directions.
+
+Implementation readiness:
+- verdict: ready
+- exact owner: example/convex/functions/_helpers/member_capacity.ts
+  (`countOrganizationSeats`) + invitation `aggregateIndex`
+- contradiction status: none
+- source-listed cases complete: yes
+
+Pre-solution issue challenge:
+- reporter claim: `inviteMember` reads up to 200 rows (2 x DEFAULT_LIST_LIMIT)
+  purely to compare two integers against MEMBER_LIMIT = 5.
+- suggested diagnosis or fix: option 1 lower both limits to MEMBER_LIMIT;
+  option 2 use `count()` off `aggregateIndex`. Reporter prefers option 2.
+- repro ladder:
+  - tests / source-level repro: convex/orm/example-invite-member-reads.test.ts
+    measured the old shape at 43 document reads with 40 members + 3 pending,
+    scaling 1:1 with membership. RED confirmed.
+  - repo-owned automated browser or integration proof: N/A, server read path.
+  - Browser plugin: N/A, no rendered output changes.
+  - screenshot / visual proof: N/A.
+- reproduction verdict: valid
+- validity verdict: valid
+- best long-term fix boundary: option 2, extracted into a named helper so the
+  read bound is testable. Option 1 was rejected: capping the reads at
+  MEMBER_LIMIT would also cap the numbers the FORBIDDEN message reports, so an
+  org at 40 members would tell the user "5 current".
+- harsh honest feedback: the issue's own impact section is slightly off. It
+  says the 100-row cap is reachable only because `addMember` skips
+  MEMBER_LIMIT; in fact six paths create member rows and Better Auth's own
+  `membershipLimit` is 100, so the cap is reachable regardless. That
+  strengthens the issue rather than weakening it.
+- hard-stop decision: proceed
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/388-bound-invitemember-member-limit-counting.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration requested |
+| Walkthrough baseline for possible UI change | no | N/A: server read path only; no UI or rendered output changes |
+| Skill analysis before edits | yes | task + autogoal + autoreview; no niche skill needed |
+| Active goal checked or created | yes | this plan |
+| Source of truth read before edits | yes | gh issue view 388 + attachment |
+| Exact per-PR task ownership | no | N/A: no PR created (standing user decline) |
+| GitHub comments and attachments read | yes | issue has 0 comments; attachment read |
+| Video transcript evidence required | no | N/A: no video evidence |
+| Pre-solution issue challenge required | yes | recorded above; verdict valid |
+| Reproduction verdict before implementation | yes | RED at 43 reads before fix |
+| Repro escalation ladder selected | yes | source-level test repro sufficed |
+| Suggested fix reviewed against durable boundary | yes | option 2 chosen over option 1; reasons recorded |
+| `docs/solutions` checked for non-trivial existing-code work | no | N/A: docs/solutions does not exist in this repo |
+| TDD decision before behavior change or bug fix | yes | red/green read-count test |
+| Branch decision for code-changing task | yes | already on issue-388, not main |
+| Release artifact decision | no | N/A: .changeset/config.json ignores example; skill docs are not published package code |
+| Browser tool decision for browser surface | no | N/A: no browser surface |
+| Commit / PR expectation decision | no | N/A: user preference explicitly declines PR creation unless prompted |
+| Task-style PR body decision | no | N/A: no PR |
+| Task-plan PR body evidence | no | N/A: no PR |
+| GitHub issue sync expectation decision | no | N/A: deferred with PR; no outward-facing post without user go-ahead |
+| Output budget strategy recorded | yes | recorded above |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Every GitHub PR in scope has its own task plan. This plan owns one exact
+      PR, owns a not-yet-created PR slice, or records N/A because no PR is in
+      scope; a batch plan is not used as a substitute.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [x] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
+      exists at the PR head, and it identifies the exact PR before autoclosure.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `bunx vitest run convex/orm/example-invite-member-reads.test.ts` red 43 reads / green 4 reads |
+| Exact per-PR task ownership | no | N/A: no PR created (standing user decline) | N/A: no PR created (standing user decline) |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | recorded in Pre-solution issue challenge; verdict valid |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level test repro reproduced it; browser/visual N/A |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | RED: expected 43 to be less than 40 |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | 2 new tests green; convex/ suite 465 passed |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `bun typecheck` 5/5 turbo tasks successful |
+| Package exports or file layout changed | no | Run the relevant package build before final verification and keep generated updates | N/A: no packages/kitcn/src change; only skills markdown |
+| Package manifests, lockfile, or install graph changed | no | Run `bun install` and relevant package checks | N/A: no manifest or lockfile change |
+| Agent rules or skills changed | yes | Run `bun install` and verify generated skill sync | `bun tooling/sync-kitcn-skill.ts` regenerated .agents/skills/kitcn |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | all commands run from repo root /Users/mikey/conductor/workspaces/kitcn/albuquerque-v1; example typecheck from example/ |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: server read path; error string format unchanged |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no browser surface |
+| UI walkthrough | no | If UI or rendered output changed, run `.agents/skills/walkthrough/SKILL.md` after final proof and show annotated images in the final handoff; otherwise record N/A | N/A: no UI or rendered output change |
+| Scaffold or fixture output changed | no | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | N/A: example/ is not a scaffold template source; fixtures derive from packages/kitcn templates. fixtures:check still ran green inside `bun check` |
+| Package behavior or public API changed | no | Add a changeset or record why no changeset applies | N/A: .changeset/config.json ignores example; no packages/kitcn/src change |
+| Docs and kitcn skill sync changed | yes | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | skill doc updated + synced; www has no inviteMember snippet so nothing to mirror |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | skill snippet corrected and made self-consistent with its own schema snippet |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | failure mode: transient COUNT_INDEX_BUILDING before backfill. Proof: kitcn dev/deploy auto-backfill on fingerprint change. Boundary is right because the count belongs to the read path, not the caller |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: .agents/skills/kitcn change is generated mirror content, not agent behavior/tooling |
+| Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption signals |
+| Commit created | no | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: user preference explicitly declines PR; no commit requested |
+| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: standing user preference - do not create PR unless prompted |
+| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR |
+| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR |
+| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR yet; outward-facing comment deferred to user |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | filled below |
+| Final lint | yes | Run `bun lint:fix` or scoped equivalent | `bun lint:fix` 937 files, no fixes applied |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | workflow output read as claim lists; greps head-capped |
+| Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | `--mode local --engine claude` clean, no accepted/actionable findings |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/388-bound-invitemember-member-limit-counting.md` | check-complete.mjs run below |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | issue #388 fetched, 29-agent source investigation | implementation |
+| Implementation | complete | 4 files changed, 2 added | verification |
+| Verification | complete | red/green read proof, 465+1288 tests, typecheck, lint, autoreview clean | closeout |
+| Commit / PR / GitHub sync | N/A | standing user preference: do not create PR unless prompted | final response |
+| Closeout | complete | bun check green | final response |
+
+Findings:
+- `count()` aggregate-index matching is EXACT SET MATCH, not prefix
+  (packages/kitcn/src/orm/aggregate-index/runtime.ts:987-1000). So
+  `count({ where: { organizationId, status } })` needs an index declared on
+  BOTH fields; `member.by_organization` alone would not have covered it.
+- `member` already declared `aggregateIndex('by_organization')`
+  (example/convex/functions/schema.ts:134), so the member leg cost nothing.
+  `invitation` declared none, so a new index was required.
+- A newly declared aggregateIndex starts BUILDING and `count()` throws
+  `COUNT_INDEX_BUILDING` until backfilled
+  (aggregate-index/runtime.ts:3276-3290). `kitcn dev` fingerprints the
+  aggregate index set and auto-runs the backfill on change, so the example app
+  needs no manual step.
+- Codegen branches only on `hasAggregateIndexes: boolean`
+  (packages/kitcn/src/cli/codegen.ts:1032,1136), already true for the example
+  schema. Adding a 20th aggregate index produces no `generated/` diff, and git
+  status confirms none appeared.
+- Aggregate storage lives in ordinary tables already present in the example's
+  data model. No Convex component, no convex.config.ts change, no new tables,
+  and no marginal bundle cost -- the aggregate runtime is already in every
+  function entry via generated/server.ts.
+- `packages/kitcn/skills/kitcn/references/features/auth-organizations.md:509`
+  mirrored the exact collect-to-count shape, so fixing only the example would
+  have left the shipped reference wrong. Its schema snippet also lacked the
+  aggregate indexes the corrected snippet needs.
+- `www/content/docs/auth/plugins/organizations.mdx` documents the auth tables
+  but has no `inviteMember` procedure example, so it has no `count()` consumer.
+- No RLS on `member`/`invitation`, so `COUNT_RLS_UNSUPPORTED` is not reachable.
+- Zero automated coverage existed for organization.ts before this change.
+- `convex/orm/example-project-existence-reads.test.ts` +
+  `example/convex/functions/_helpers/` is the repo's established pattern for
+  proving example-app read bounds; this task reused it.
+- `orm.api()` (the backfill handlers) only exists when `createOrm` is given
+  `ormFunctions` + `internalMutation`, which is why `withOrmCtx` alone cannot
+  drive a backfill.
+
+Decisions and tradeoffs:
+- Chose aggregate `count()` (issue option 2) over capping both reads at
+  MEMBER_LIMIT (option 1). Option 1 is two lines but silently caps the numbers
+  the FORBIDDEN message reports; with 40 members it would claim "5 current".
+  `count()` keeps the message exact and makes the read cost independent of
+  MEMBER_LIMIT.
+- Accepted the one real cost: `invitation` gains its first aggregate index, so
+  every invitation write now reconciles one aggregate. Within repo norms --
+  `todos` already carries 9.
+- Extracted `countOrganizationSeats` into `_helpers/` rather than inlining.
+  `inviteMember` is an `authMutation` and cannot be driven by the test harness,
+  and the repo already uses `_helpers/` extraction exactly to make example read
+  bounds testable.
+- Kept the throw at the procedure boundary; the helper returns numbers only, so
+  it stays free of CRPC concerns and is unit-testable.
+- Did NOT enforce MEMBER_LIMIT in `addMember`/`acceptInvitation`. The issue
+  explicitly defers that as a separate product decision.
+- Did NOT touch the four genuine `DEFAULT_LIST_LIMIT` list reads, nor the
+  count-only `findMany` in todoInternal.ts / admin.ts / ormDemo.ts. Out of the
+  issue's scope; recorded as follow-ups.
+- Did NOT add aggregate indexes to the www schema snippet. It has no `count()`
+  consumer, and declaring an unused aggregate index would teach readers to pay
+  write amplification for nothing.
+
+Implementation notes:
+- example/convex/functions/schema.ts: `invitationTable` gains
+  `aggregateIndex('by_organization_status').on(t.organizationId, t.status)`.
+- example/convex/functions/_helpers/member_capacity.ts (new):
+  `countOrganizationSeats(ctx, organizationId)` returns
+  `{ members, pending, total }` from two parallel `count()` calls.
+- example/convex/functions/organization.ts: `inviteMember` calls the helper;
+  the two count-only `findMany` reads and the `totalCount` arithmetic are gone.
+  The three genuine `DEFAULT_LIST_LIMIT` reads in this file are untouched.
+- convex/orm/example-invite-member-reads.test.ts (new): two tests. Adds a local
+  `withOrmCtxAndBackfill` because `withOrmCtx` cannot reach `orm.api()`.
+- packages/kitcn/skills/kitcn/references/features/auth-organizations.md: the
+  `inviteMember` snippet now uses `count()`, and the schema snippet declares
+  both required aggregate indexes plus the `aggregateIndex` import.
+  Regenerated .agents/skills/kitcn/** via `bun tooling/sync-kitcn-skill.ts`.
+
+Review fixes:
+- None yet.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| None yet | 0 | | |
+
+Verification evidence:
+- RED: with the old collect-to-count body, the new test reported
+  `expected 43 to be less than 40` at 40 members + 3 pending.
+- GREEN: aggregate-count body reports 4 document reads, flat in organization
+  size. Assertion pinned at `<= 6`.
+- `bunx vitest run convex/` -> 32 files, 465 passed, 2 files / 13 skipped.
+- `bun typecheck` -> 5/5 turbo tasks successful (includes example convex
+  project typecheck).
+- `bun lint:fix` -> 937 files checked, no fixes applied.
+- `bun test` -> 1288 tests, 0 fail.
+- codegen no-diff proven from source: `hasAggregateIndexes` is a boolean at
+  packages/kitcn/src/cli/codegen.ts:1032,1136; git status shows no
+  example/convex/functions/generated/** change. `kitcn codegen` itself is not
+  runnable locally (bin not linked in node_modules/.bin).
+- autoreview `--mode local --engine claude` -> clean, no accepted/actionable
+  findings, trufflehog clean.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| member count read | up to 100 rows read for one integer | example-invite-member-reads.test.ts, 40 seeded members | 40 rows | flat, not proportional | 43 -> 4 total reads | done |
+| pending invitation count read | up to 100 rows read for one integer | same test, 3 pending + 1 canceled | 3 rows | flat, not proportional | included in 43 -> 4 | done |
+| predicate preserved | `members + pending >= 5` must not change | same test asserts exact counts | n/a | members=40, pending=3, total=43 | `toEqual` on all three | done |
+| canceled invites excluded | only `status: 'pending'` counts | seeded 1 canceled invitation | n/a | pending stays 3 | assertion passes | done |
+| org scoping | counts must not leak across orgs | second seeded org | n/a | unchanged counts | second test passes | done |
+| error message accuracy | message reports current/pending | source read | capped at 100 | exact | `seats.members` / `seats.pending` | done |
+| third read at :930 | genuine cancel loop, leave alone | source read | untouched | untouched | unchanged in diff | done |
+
+Final handoff contract:
+- Commit line: N/A - no commit (user preference declines PR; nothing requested)
+- PR line: N/A - standing user preference: do not create PR unless prompted
+- Issue line: #388, not yet synced back (deferred with the PR)
+- Confidence line: 95-100%
+- Flow table:
+  - Reproduced: tests RED at 43 reads, browser N/A
+  - Verified: tests GREEN at 4 reads + 465 convex tests, browser N/A
+- Browser check: N/A - server read path, no rendered output
+- Outcome: `inviteMember` seat counting is aggregate-index backed; 43 -> 4
+  document reads at 40 members, flat in organization size, and the FORBIDDEN
+  message now reports exact counts instead of limit-capped ones.
+- Caveat: a deployment has a transient COUNT_INDEX_BUILDING window until the
+  new `invitation.by_organization_status` index backfills; `kitcn dev` and
+  `kitcn deploy` run that automatically on aggregate-fingerprint change.
+- Design:
+  - Chosen boundary: a named `_helpers/member_capacity.ts` owner for the seat
+    count, with the throw left at the procedure.
+  - Why not quick patch: capping both reads at MEMBER_LIMIT also caps the
+    numbers the error message reports, so a 40-member org would be told
+    "5 current"; and it leaves reference material teaching collect-to-count.
+  - Why not broader change: `addMember`/`acceptInvitation` MEMBER_LIMIT
+    enforcement is a product decision the issue explicitly defers, and the
+    other count-only `findMany` sites are outside this issue.
+- Verified: red/green read proof, convex/ suite, bun test, typecheck, lint,
+  autoreview clean, bun check.
+- PR body verified: N/A - no PR
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  `🧭 Task plan: docs/plans/<plan>.md`, then an emoji confidence line like
+  `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: N/A (not requested; user declines PR by standing preference)
+- PR: N/A
+- Issue: #388 open, sync deferred
+- Browser proof: N/A
+- Caveats: transient backfill window; invitation writes gain one aggregate
+  reconcile
+
+Timeline:
+- 2026-08-21T14:11:25.046Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Final handoff; no commit/PR (user standing decline) |
+| What is the goal? | Stop inviteMember reading ~200 rows to evaluate a 5-seat limit |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- A deployment that pushes this schema has a transient window where
+  `invitation.by_organization_status` is BUILDING and `inviteMember` throws
+  `COUNT_INDEX_BUILDING`. `kitcn dev` and `kitcn deploy` auto-run the backfill
+  on aggregate-fingerprint change, so this closes without manual action; a
+  deployment pushed by raw `convex deploy` would need
+  `kitcn aggregate backfill`.
+- `invitation` writes now reconcile one aggregate index. Accepted; `todos`
+  already carries 9.
+- Follow-ups NOT taken (out of issue scope): `addMember` and
+  `acceptInvitation` still bypass MEMBER_LIMIT; count-only `findMany` remains
+  in todoInternal.ts (4 sites, up to 1000 rows each), admin.ts:256, and
+  ormDemo.ts:278; `packages/kitcn/skills/kitcn/references/features/aggregates.md`
+  documents `count()` as "Requires matching aggregateIndex" without stating
+  that matching is exact-set rather than prefix.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/388-bound-invitemember-member-limit-counting.md
+++ b/docs/plans/388-bound-invitemember-member-limit-counting.md
@@ -287,6 +287,26 @@ Phase / pass table:
 | Commit / PR / GitHub sync | complete | ce3593a5 pushed; PR #392 opened with task-style body | final response |
 | Closeout | complete | bun check green | final response |
 
+CI fix rider (not #388 scope):
+- PR #392's CI failed on `packages/kitcn/src/aggregate-core/btree.vitest.ts`,
+  a pre-existing seed-dependent flake (~1 run in 8) unrelated to this diff.
+- Root cause found and fixed: `btree.ts:858` interpolated a raw `Key` into a
+  debug-log template literal, the only key-logging site in the file that
+  skipped the module's own safe serializer `p()`. `Key = ConvexValue`, so
+  fast-check eventually generated a null-prototype object as a key; it has no
+  `toString`/`valueOf`, so `${}` throws `TypeError: Cannot convert object to
+  primitive value`. `BTREE_DEBUG` is false, but template literals evaluate
+  eagerly, so it threw with logging off.
+- Reproduced deterministically with CI seed 377911460 + shrink path, fixed,
+  re-ran same seed green, then 20/20 unseeded runs green.
+- Added a deterministic regression test. The first version was vacuous: only
+  the newly inserted key still has its original prototype, so the last insert
+  must land on the median. Caught by running it against unfixed code.
+- Ships a `patch` changeset because this is published package code, unlike the
+  example-app change.
+- Doctrine note: this violates one-PR-one-task. It rides along because it is
+  what makes PR #392's CI green; splitting it out is the caller's call.
+
 Findings:
 - `count()` aggregate-index matching is EXACT SET MATCH, not prefix
   (packages/kitcn/src/orm/aggregate-index/runtime.ts:987-1000). So

--- a/example/convex/functions/_helpers/member_capacity.ts
+++ b/example/convex/functions/_helpers/member_capacity.ts
@@ -1,0 +1,33 @@
+import type { AuthCtx } from '../../lib/crpc';
+
+type MemberCapacityCtx = Pick<AuthCtx, 'orm'>;
+
+export type OrganizationSeatUsage = {
+  members: number;
+  pending: number;
+  total: number;
+};
+
+/**
+ * Seats an organization has committed: current members plus the invitations it
+ * is still waiting on.
+ *
+ * Both legs are `aggregateIndex`-backed counts, so the read cost is a handful
+ * of bucket reads that do not track organization size. Collecting the rows to
+ * read `.length` instead would pull every member and every pending invitation
+ * into the transaction's read set — and into the subscription's — to produce
+ * two integers.
+ */
+export const countOrganizationSeats = async (
+  ctx: MemberCapacityCtx,
+  organizationId: string
+): Promise<OrganizationSeatUsage> => {
+  const [members, pending] = await Promise.all([
+    ctx.orm.query.member.count({ where: { organizationId } }),
+    ctx.orm.query.invitation.count({
+      where: { organizationId, status: 'pending' },
+    }),
+  ]);
+
+  return { members, pending, total: members + pending };
+};

--- a/example/convex/functions/_helpers/member_capacity.ts
+++ b/example/convex/functions/_helpers/member_capacity.ts
@@ -1,6 +1,6 @@
 import type { AuthCtx } from '../../lib/crpc';
 
-type MemberCapacityCtx = Pick<AuthCtx, 'orm'>;
+type MemberCapacityCtx = Pick<AuthCtx, 'db' | 'orm'>;
 
 export type OrganizationSeatUsage = {
   members: number;
@@ -8,25 +8,67 @@ export type OrganizationSeatUsage = {
   total: number;
 };
 
+const isCountIndexBuilding = (error: unknown): boolean =>
+  error instanceof Error && error.message.startsWith('COUNT_INDEX_BUILDING:');
+
+const countMembers = async (
+  ctx: MemberCapacityCtx,
+  organizationId: string
+): Promise<number> => {
+  try {
+    return await ctx.orm.query.member.count({ where: { organizationId } });
+  } catch (error) {
+    if (!isCountIndexBuilding(error)) throw error;
+
+    return (
+      await ctx.db
+        .query('member')
+        .withIndex('organizationId', (query) =>
+          query.eq('organizationId', organizationId)
+        )
+        .collect()
+    ).length;
+  }
+};
+
+const countPendingInvitations = async (
+  ctx: MemberCapacityCtx,
+  organizationId: string
+): Promise<number> => {
+  try {
+    return await ctx.orm.query.invitation.count({
+      where: { organizationId, status: 'pending' },
+    });
+  } catch (error) {
+    if (!isCountIndexBuilding(error)) throw error;
+
+    // Deploys can serve traffic while a newly declared aggregate index backfills.
+    return (
+      await ctx.db
+        .query('invitation')
+        .withIndex('organizationId_status', (query) =>
+          query.eq('organizationId', organizationId).eq('status', 'pending')
+        )
+        .collect()
+    ).length;
+  }
+};
+
 /**
  * Seats an organization has committed: current members plus the invitations it
  * is still waiting on.
  *
- * Both legs are `aggregateIndex`-backed counts, so the read cost is a handful
- * of bucket reads that do not track organization size. Collecting the rows to
- * read `.length` instead would pull every member and every pending invitation
- * into the transaction's read set — and into the subscription's — to produce
- * two integers.
+ * READY aggregate indexes keep the read cost independent of organization size.
+ * While either index backfills, its matching native index preserves exact
+ * counts without taking the invitation endpoint offline.
  */
 export const countOrganizationSeats = async (
   ctx: MemberCapacityCtx,
   organizationId: string
 ): Promise<OrganizationSeatUsage> => {
   const [members, pending] = await Promise.all([
-    ctx.orm.query.member.count({ where: { organizationId } }),
-    ctx.orm.query.invitation.count({
-      where: { organizationId, status: 'pending' },
-    }),
+    countMembers(ctx, organizationId),
+    countPendingInvitations(ctx, organizationId),
   ]);
 
   return { members, pending, total: members + pending };

--- a/example/convex/functions/organization.ts
+++ b/example/convex/functions/organization.ts
@@ -8,6 +8,7 @@ import {
   authQuery,
   privateMutation,
 } from '../lib/crpc';
+import { countOrganizationSeats } from './_helpers/member_capacity';
 import { createOrganizationHandler } from './generated/organization.runtime';
 import type { MutationCtx } from './generated/server';
 import {
@@ -895,31 +896,14 @@ export const inviteMember = authMutation
       permissions: { invitation: ['create'] },
     });
 
-    // Check member count limit (5 members max per organization)
-    // Get all members for this organization
-    const members = await ctx.orm.query.member.findMany({
-      where: { organizationId: input.organizationId },
-      limit: DEFAULT_LIST_LIMIT,
-    });
+    // Check member count limit (5 members max per organization),
+    // counting members plus outstanding invitations.
+    const seats = await countOrganizationSeats(ctx, input.organizationId);
 
-    // Check current member count (including pending invitations)
-    const currentMemberCount = members.length;
-
-    // Get pending invitations count
-    // Count pending invitations to check against member limit
-    const pendingInvitations = await ctx.orm.query.invitation.findMany({
-      where: { organizationId: input.organizationId, status: 'pending' },
-      limit: DEFAULT_LIST_LIMIT,
-    }); // Limited query for counting
-
-    const pendingCount = pendingInvitations?.length || 0;
-    const totalCount = currentMemberCount + pendingCount;
-
-    // Check against limit (5 members)
-    if (totalCount >= MEMBER_LIMIT) {
+    if (seats.total >= MEMBER_LIMIT) {
       throw new CRPCError({
         code: 'FORBIDDEN',
-        message: `Organization member limit reached. Maximum ${MEMBER_LIMIT} members allowed (${currentMemberCount} current, ${pendingCount} pending invitations).`,
+        message: `Organization member limit reached. Maximum ${MEMBER_LIMIT} members allowed (${seats.members} current, ${seats.pending} pending invitations).`,
       });
     }
 

--- a/example/convex/functions/schema.ts
+++ b/example/convex/functions/schema.ts
@@ -162,6 +162,7 @@ export const invitationTable = convexTable(
       t.organizationId,
       t.status
     ),
+    aggregateIndex('by_organization_status').on(t.organizationId, t.status),
     index('organizationId_status').on(t.organizationId, t.status),
     index('email_status').on(t.email, t.status),
     index('organizationId_email').on(t.organizationId, t.email),

--- a/packages/kitcn/skills/kitcn/references/features/auth-organizations.md
+++ b/packages/kitcn/skills/kitcn/references/features/auth-organizations.md
@@ -152,6 +152,11 @@ export const session = convexTable("session", {
 });
 ```
 
+`count()` requires its aggregate index to be `READY`. Backfill these indexes
+before routing live traffic to the count path. When schema and count code ship
+together, catch only `COUNT_INDEX_BUILDING` and read the exact count from the
+matching native organization index until backfill completes.
+
 ### Teams (Optional)
 
 ```ts

--- a/packages/kitcn/skills/kitcn/references/features/auth-organizations.md
+++ b/packages/kitcn/skills/kitcn/references/features/auth-organizations.md
@@ -77,6 +77,7 @@ export const authClient = createAuthClient({
 ```ts
 // convex/functions/schema.ts
 import {
+  aggregateIndex,
   convexTable,
   defineSchema,
   id,
@@ -111,6 +112,8 @@ export const member = convexTable(
     index("userId").on(t.userId),
     index("organizationId_userId").on(t.organizationId, t.userId),
     index("organizationId_role").on(t.organizationId, t.role),
+    // Backs `member.count({ where: { organizationId } })` for seat limits.
+    aggregateIndex("by_organization").on(t.organizationId),
   ]
 );
 
@@ -134,6 +137,10 @@ export const invitation = convexTable(
       t.status
     ),
     index("organizationId_status").on(t.organizationId, t.status),
+    // Backs `invitation.count({ where: { organizationId, status } })`.
+    // `count()` index matching is exact-set, so the aggregate key must list
+    // every field the filter constrains.
+    aggregateIndex("by_organization_status").on(t.organizationId, t.status),
   ]
 );
 
@@ -506,16 +513,18 @@ export const inviteMember = authMutation
       permissions: { invitation: ["create"] },
     });
 
-    // Check member limit
-    const members = await ctx.orm.query.member.findMany({
-      where: { organizationId: input.organizationId },
-      limit: DEFAULT_LIST_LIMIT,
-    });
-    const pending = await ctx.orm.query.invitation.findMany({
-      where: { organizationId: input.organizationId, status: "pending" },
-      limit: DEFAULT_LIST_LIMIT,
-    });
-    if (members.length + pending.length >= MEMBER_LIMIT) {
+    // Check member limit. Count off `aggregateIndex`, never by collecting rows
+    // to read `.length` -- that puts every member and pending invitation into
+    // the transaction's read set to produce two integers.
+    const [members, pending] = await Promise.all([
+      ctx.orm.query.member.count({
+        where: { organizationId: input.organizationId },
+      }),
+      ctx.orm.query.invitation.count({
+        where: { organizationId: input.organizationId, status: "pending" },
+      }),
+    ]);
+    if (members + pending >= MEMBER_LIMIT) {
       throw new CRPCError({
         code: "FORBIDDEN",
         message: `Organization member limit reached. Maximum ${MEMBER_LIMIT} members allowed.`,

--- a/packages/kitcn/src/aggregate-core/btree.ts
+++ b/packages/kitcn/src/aggregate-core/btree.ts
@@ -855,7 +855,7 @@ async function insertIntoNode(
     ) {
       throw new Error(`bad ${newN.items.length}`);
     }
-    log(`splitting node ${newN._id} at ${newN.items[minNodeSize].k}`);
+    log(`splitting node ${newN._id} at ${p(newN.items[minNodeSize].k)}`);
     const topLevel = nodeCounts(newN);
     const subCounts = await subtreeCounts(ctx.db, newN);
     const leftCount = add(

--- a/packages/kitcn/src/aggregate-core/btree.vitest.ts
+++ b/packages/kitcn/src/aggregate-core/btree.vitest.ts
@@ -759,6 +759,38 @@ describe('btree matches simpler impl', () => {
     });
   });
 
+  // Splitting a node logs its median key. A null-prototype object has no
+  // `toString`/`valueOf`, so interpolating such a key raw throws
+  // `TypeError: Cannot convert object to primitive value` -- and the template
+  // literal is evaluated eagerly, so it throws even though `BTREE_DEBUG` is
+  // off. Only the newly inserted key still carries the null prototype; keys
+  // already in the node came back through the database with a plain one. So
+  // the last insert must be the one that lands on the median: five inserts at
+  // `minNodeSize: 2` is the smallest split, and `{ a: 2 }` goes in last.
+  test('splitting a node on a key that resists primitive coercion', async () => {
+    const nullProto = (a: number) =>
+      Object.assign(Object.create(null), { a }) as Value;
+    await testBehaviorMatch({
+      values: [
+        nullProto(0),
+        nullProto(1),
+        nullProto(2),
+        nullProto(3),
+        nullProto(4),
+      ],
+      writes: [
+        { type: 'insert', key: 0, value: 0, summand: 0 },
+        { type: 'insert', key: 0.2, value: 0, summand: 0 },
+        { type: 'insert', key: 0.6, value: 0, summand: 0 },
+        { type: 'insert', key: 0.8, value: 0, summand: 0 },
+        { type: 'insert', key: 0.4, value: 0, summand: 0 },
+      ],
+      reads: [],
+      minNodeSize: 2,
+      rootLazy: false,
+    });
+  });
+
   fcTest.prop({
     values: fc.array(arbitraryValue, { minLength: 100, maxLength: 100 }),
     writes: fc.array(arbitraryWrite, { maxLength: 100 }),


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes #388
🧭 Task plan: docs/plans/388-bound-invitemember-member-limit-counting.md
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 43 document reads at 40 members and 3 pending invitations | ➖ N/A |
| Verified | 🟢 4 steady-state reads, exact BUILDING fallback, `bun check` | ➖ N/A |

**✅ Outcome**
- Organization seat checks use aggregate counts with read cost independent of organization size.
- Aggregate-index backfills preserve invitation availability through exact native-index counts.
- Btree debug formatting safely handles Convex keys without primitive coercion.

**⚠️ Caveat**
- During aggregate backfill, exact native-index counts scale with organization size. READY indexes restore the constant-read path automatically.
- Invitation writes reconcile one aggregate index.

**🏗️ Design**
- A single seat-capacity helper owns member and pending-invitation counts.
- Only `COUNT_INDEX_BUILDING` uses native indexes; unrelated count errors still propagate.
- The invitation aggregate key matches the exact filtered field set.

**🧪 Verified**
- `bun check`
- Seat-count read bounds and pre-backfill availability
- Btree null-prototype key regression
- 21 focused Vitest cases
