### PR TITLE
fix(orm): load every requested with level, count at the deepest one

### DIFF
--- a/.agents/skills/kitcn/references/features/aggregates.md
+++ b/.agents/skills/kitcn/references/features/aggregates.md
@@ -211,6 +211,38 @@ const users = await ctx.orm.query.users.findMany({
 
 Works on `findMany`, `findFirst`, `findFirstOrThrow`. Access via `row._count?.relation ?? 0`.
 
+`_count` reads an aggregate index rather than the rows, so it resolves at every level of a nested `with:`, including the deepest level returned. Ask for it there instead of re-reading the returned tree to attach counts — that second pass costs one read per node the caller already holds:
+
+```ts
+// ❌ BAD: second pass over nodes already in hand
+const roots = await ctx.orm.query.comments.findMany({
+  where: { parentId: { isNull: true } },
+  limit: 20,
+  with: { replies: { limit: 10 } },
+});
+const ids = collectIds(roots);
+const counts = await ctx.orm.query.comments.findMany({
+  where: { id: { in: ids } },
+  limit: ids.length,
+  columns: { id: true },
+  with: { _count: { replies: true } },
+});
+
+// ✅ GOOD: counted inline, at every level
+const roots = await ctx.orm.query.comments.findMany({
+  where: { parentId: { isNull: true } },
+  limit: 20,
+  with: {
+    _count: { replies: true },
+    replies: {
+      limit: 10,
+      with: { _count: { replies: true } },
+    },
+  },
+});
+// roots[0].replies[0]._count?.replies => replies not in this page
+```
+
 ### Mutation `returning({ _count })`
 
 ```ts

--- a/.agents/skills/kitcn/references/features/orm.md
+++ b/.agents/skills/kitcn/references/features/orm.md
@@ -261,6 +261,14 @@ orders by creation time, so `with: { posts: { limit: 5, orderBy: { createdAt:
 parent's whole child partition and sorts in memory — put the sort column in the
 relation index (`index('by_user_rank').on(t.userId, t.rank)`) to stay bounded.
 
+### Nested `with` depth
+
+Nested `with:` loads every level it is given, up to 10. A tree that still has
+rows to expand past that throws `RELATION_DEPTH_EXCEEDED` rather than coming back
+shorter than requested — which is how a `with` object that references itself
+surfaces. Fan-out per level is bounded by that level's `limit`, not by the depth
+ceiling.
+
 ## Schema Definition
 
 ```ts

--- a/.changeset/warm-pots-tickle.md
+++ b/.changeset/warm-pots-tickle.md
@@ -1,0 +1,25 @@
+---
+"kitcn": minor
+---
+
+## Breaking changes
+
+- Nested `with:` now loads every level it is given, up to 10, instead of quietly dropping everything past the third. A config that nests deeper throws `RELATION_DEPTH_EXCEEDED` rather than returning a shorter tree. Deep `with:` configs that used to come back truncated now come back complete — and read the rows that completeness costs.
+
+```ts
+// Before: the fourth level was dropped, with no error
+const rows = await ctx.orm.query.comments.findMany({
+  limit: 20,
+  with: {
+    replies: { limit: 10, with: { replies: { limit: 10, with: { author: true } } } },
+  },
+});
+rows[0].replies[0].replies[0].author; // undefined
+
+// After: loaded, because it was asked for
+rows[0].replies[0].replies[0].author; // { id, name }
+```
+
+## Patches
+
+- Resolve `with: { _count }` at every level of a nested `with:`, including the deepest one returned. A tree can now report how many children it withheld without a second pass that re-reads every node the caller already holds.

--- a/convex/orm/example-comment-tree-reads.test.ts
+++ b/convex/orm/example-comment-tree-reads.test.ts
@@ -1,0 +1,256 @@
+import { createOrm, type OrmWriter } from 'kitcn/orm';
+import { aggregateCapability } from 'kitcn/orm/aggregate-index';
+import { expect, test, vi } from 'vitest';
+import {
+  buildRepliesWith,
+  CommentRowWithRepliesSchema,
+  MAX_REPLY_DEPTH,
+  toReply,
+} from '../../example/convex/functions/_helpers/comment_tree';
+import schema, {
+  todoCommentsTable,
+  todosTable,
+  userTable,
+} from '../../example/convex/functions/schema';
+import { convexTest, countDocumentReads, withOrm } from '../setup.testing';
+
+const EXAMPLE_ENV_DEFAULTS = {
+  ADMIN: 'admin@example.com',
+  BETTER_AUTH_SECRET: 'test-secret',
+  GITHUB_CLIENT_ID: 'github-client-id',
+  GITHUB_CLIENT_SECRET: 'github-client-secret',
+  GOOGLE_CLIENT_ID: 'google-client-id',
+  GOOGLE_CLIENT_SECRET: 'google-client-secret',
+} as const;
+
+const withExampleEnv = async (run: () => Promise<void>) => {
+  const original = Object.fromEntries(
+    Object.keys(EXAMPLE_ENV_DEFAULTS).map((key) => [key, process.env[key]])
+  );
+
+  for (const [key, value] of Object.entries(EXAMPLE_ENV_DEFAULTS)) {
+    process.env[key] = value;
+  }
+
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (typeof value === 'string') {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    }
+  }
+};
+
+const schedulerStub = { runAfter: vi.fn(async () => undefined) };
+
+/**
+ * `withOrmCtx` hands back a context, not the ORM client, and the aggregate
+ * backfill mutations hang off the client. They only need `{ db, scheduler }`,
+ * so a second client over the same schema can drive them against the same `db`.
+ */
+const backfillApi = createOrm({
+  capabilities: [aggregateCapability()],
+  schema,
+  ormFunctions: {
+    scheduledDelete: {} as any,
+    scheduledMutationBatch: {} as any,
+  },
+  internalMutation: ((definition: unknown) => definition) as never,
+}).api() as any;
+
+const runBackfillToReady = async (ctx: { db: any }) => {
+  const handlerCtx = { db: ctx.db, scheduler: schedulerStub };
+  await backfillApi.aggregateBackfill.handler(handlerCtx, {});
+
+  for (let i = 0; i < 20; i += 1) {
+    const status = await backfillApi.aggregateBackfillStatus.handler(
+      handlerCtx,
+      {}
+    );
+    if (status.every((entry: any) => entry.status === 'READY')) {
+      return;
+    }
+    await backfillApi.aggregateBackfillChunk.handler(handlerCtx, {});
+  }
+
+  throw new Error('aggregateBackfill did not reach READY state in time.');
+};
+
+type ExampleCtx = { orm: OrmWriter<typeof schema>; db: any };
+
+/**
+ * `countDocumentReads` swaps `db.get`/`db.query`, but the ORM binds both when it
+ * is constructed -- so the counter has to be installed before `withOrm`, or it
+ * silently reports zero for every read the ORM issues.
+ */
+const withCountedExampleOrm = async (
+  run: (ctx: ExampleCtx, reads: { documents: number }) => Promise<void>
+) => {
+  await withExampleEnv(async () => {
+    const t = convexTest(schema);
+    await t.run(async (baseCtx) => {
+      const reads = countDocumentReads(baseCtx as any);
+      const ctx = withOrm(baseCtx as any, schema) as unknown as ExampleCtx;
+      await run(ctx, reads);
+    });
+  });
+};
+
+const seedUser = async (ctx: ExampleCtx, email: string) => {
+  const [user] = await ctx.orm
+    .insert(userTable)
+    .values({
+      name: 'Commenter',
+      email,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .returning({ id: userTable.id });
+
+  return user.id as string;
+};
+
+const seedTodo = async (ctx: ExampleCtx, userId: string) => {
+  const [todo] = await ctx.orm
+    .insert(todosTable)
+    .values({ title: 'Thread', completed: false, userId })
+    .returning({ id: todosTable.id });
+
+  return todo.id as string;
+};
+
+const seedComment = async (
+  ctx: ExampleCtx,
+  todoId: string,
+  userId: string,
+  content: string,
+  parentId?: string
+) => {
+  const [row] = await ctx.orm
+    .insert(todoCommentsTable)
+    .values({ content, todoId, userId, parentId })
+    .returning({ id: todoCommentsTable.id });
+
+  return row.id as string;
+};
+
+/** `roots` root comments, each carrying a `MAX_REPLY_DEPTH`-long reply chain. */
+const seedThreads = async (
+  ctx: ExampleCtx,
+  todoId: string,
+  userId: string,
+  roots: number
+) => {
+  for (let root = 0; root < roots; root += 1) {
+    let parentId = await seedComment(ctx, todoId, userId, `root-${root}`);
+    for (let level = 1; level <= MAX_REPLY_DEPTH; level += 1) {
+      parentId = await seedComment(
+        ctx,
+        todoId,
+        userId,
+        `root-${root}-l${level}`,
+        parentId
+      );
+    }
+  }
+};
+
+/** The exact read `todoComments.getTodoComments` issues, counting documents. */
+const readCommentTree = async (
+  ctx: ExampleCtx,
+  reads: { documents: number },
+  todoId: string
+) => {
+  const before = reads.documents;
+
+  const results = await ctx.orm.query.todoComments.findMany({
+    where: { todoId, parentId: { isNull: true } },
+    orderBy: { createdAt: 'desc' },
+    cursor: null,
+    limit: 20,
+    with: {
+      user: true,
+      _count: { replies: true },
+      replies: buildRepliesWith(MAX_REPLY_DEPTH),
+    },
+  });
+
+  const documents = reads.documents - before;
+  const rows = CommentRowWithRepliesSchema.array().parse(results.page);
+  return { documents, page: rows.map(toReply) };
+};
+
+const countNodes = (replies: { replies: any[] }[]): number =>
+  replies.reduce((total, reply) => total + 1 + countNodes(reply.replies), 0);
+
+/**
+ * The tree is loaded in one pass. Attaching `replyCount` afterwards by
+ * re-reading every node already in the returned tree costs a second read plus a
+ * second count per node, and buys nothing: the relation loader resolves `_count`
+ * at every level it returns, including the deepest.
+ *
+ * Measured marginal cost over 30 extra nodes: 100 documents for the second pass
+ * versus 50 for one pass. Fixed setup cost (the author, the root index scan)
+ * does not scale, so the bound is on the marginal document cost per node.
+ */
+const MAX_DOCUMENTS_PER_COMMENT = 2;
+
+test('comment tree cost does not track the number of comments returned', async () => {
+  await withCountedExampleOrm(async (ctx, reads) => {
+    const userId = await seedUser(ctx, 'comment-tree-reads@test.dev');
+    const smallTodoId = await seedTodo(ctx, userId);
+    const largeTodoId = await seedTodo(ctx, userId);
+
+    await seedThreads(ctx, smallTodoId, userId, 1);
+    await seedThreads(ctx, largeTodoId, userId, 6);
+    await runBackfillToReady(ctx);
+
+    const small = await readCommentTree(ctx, reads, smallTodoId);
+    const large = await readCommentTree(ctx, reads, largeTodoId);
+
+    // 6 nodes vs 36, same single author.
+    const smallNodes = countNodes(small.page);
+    const largeNodes = countNodes(large.page);
+    expect(smallNodes).toBe(MAX_REPLY_DEPTH + 1);
+    expect(largeNodes).toBe(6 * (MAX_REPLY_DEPTH + 1));
+
+    expect(large.documents - small.documents).toBeLessThanOrEqual(
+      MAX_DOCUMENTS_PER_COMMENT * (largeNodes - smallNodes)
+    );
+  });
+});
+
+test('every returned node reports its reply count, including the deepest', async () => {
+  await withCountedExampleOrm(async (ctx, reads) => {
+    const userId = await seedUser(ctx, 'comment-tree-counts@test.dev');
+    const todoId = await seedTodo(ctx, userId);
+
+    await seedThreads(ctx, todoId, userId, 1);
+    await runBackfillToReady(ctx);
+
+    const { page } = await readCommentTree(ctx, reads, todoId);
+
+    const chain: { content: string; replyCount: number }[] = [];
+    let node = page[0];
+    while (node) {
+      chain.push({ content: node.content, replyCount: node.replyCount });
+      node = node.replies[0];
+    }
+
+    // The deepest reply the write cap allows is the last one returned, and it
+    // correctly reports that nothing follows it.
+    expect(chain).toEqual([
+      { content: 'root-0', replyCount: 1 },
+      { content: 'root-0-l1', replyCount: 1 },
+      { content: 'root-0-l2', replyCount: 1 },
+      { content: 'root-0-l3', replyCount: 1 },
+      { content: 'root-0-l4', replyCount: 1 },
+      { content: 'root-0-l5', replyCount: 0 },
+    ]);
+  });
+});

--- a/convex/orm/example-comment-tree-reads.test.ts
+++ b/convex/orm/example-comment-tree-reads.test.ts
@@ -254,3 +254,21 @@ test('every returned node reports its reply count, including the deepest', async
     ]);
   });
 });
+
+test('getCommentThread keeps accepting the previous explicit maxDepth', async () => {
+  await withExampleEnv(async () => {
+    const { getCommentThread } = await import(
+      '../../example/convex/functions/todoComments'
+    );
+    const t = convexTest(schema);
+
+    await t.run(async (baseCtx) => {
+      await expect(
+        (getCommentThread as any)._handler(baseCtx, {
+          commentId: 'missing-comment',
+          maxDepth: 10,
+        })
+      ).resolves.toBeNull();
+    });
+  });
+});

--- a/convex/orm/relation-depth.test.ts
+++ b/convex/orm/relation-depth.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'kitcn/orm';
 import { aggregateCapability } from 'kitcn/orm/aggregate-index';
 import { describe, expect, it, vi } from 'vitest';
-import { convexTest } from '../setup.testing';
+import { convexTest, countDocumentReads } from '../setup.testing';
 
 const schedulerStub = { runAfter: vi.fn(async () => undefined) };
 const passthroughInternalMutation = ((definition: unknown) =>
@@ -99,10 +99,11 @@ const walkChain = (root: any) => {
 
 const withThread = async (
   chainLength: number,
-  run: (ctx: any) => Promise<void>
+  run: (ctx: any, reads: { documents: number }) => Promise<void>
 ) => {
   const t = convexTest(threadSchema);
   await t.run(async (baseCtx) => {
+    const reads = countDocumentReads(baseCtx as any);
     const client = createOrm({
       capabilities: [aggregateCapability()],
       schema: threadRelations,
@@ -126,7 +127,7 @@ const withThread = async (
     }
 
     await runBackfillToReady(client.api() as any, baseCtx as any);
-    await run(ctx);
+    await run(ctx, reads);
   });
 };
 
@@ -198,7 +199,8 @@ describe('ORM relation depth', () => {
    * a shorter thread simply runs out of children first.
    */
   it('refuses to nest past the ceiling instead of truncating silently', async () => {
-    await withThread(12, async (ctx) => {
+    await withThread(12, async (ctx, reads) => {
+      const before = reads.documents;
       await expect(
         ctx.orm.query.depthThreadNodes.findMany({
           where: { parentId: { isNull: true } },
@@ -206,6 +208,7 @@ describe('ORM relation depth', () => {
           with: { replies: repliesWith(11) },
         })
       ).rejects.toThrow(/RELATION_DEPTH_EXCEEDED/);
+      expect(reads.documents - before).toBeLessThanOrEqual(2);
     });
   });
 });

--- a/convex/orm/relation-depth.test.ts
+++ b/convex/orm/relation-depth.test.ts
@@ -1,0 +1,211 @@
+import {
+  type AnyColumn,
+  aggregateIndex,
+  convexTable,
+  createOrm,
+  defineRelations,
+  defineSchema,
+  index,
+  text,
+} from 'kitcn/orm';
+import { aggregateCapability } from 'kitcn/orm/aggregate-index';
+import { describe, expect, it, vi } from 'vitest';
+import { convexTest } from '../setup.testing';
+
+const schedulerStub = { runAfter: vi.fn(async () => undefined) };
+const passthroughInternalMutation = ((definition: unknown) =>
+  definition) as never;
+
+/**
+ * A self-referencing thread is the shape that makes relation depth observable:
+ * one table, one `many()` edge back to itself, so a `with` config can be nested
+ * as deep as the test needs without inventing a table per level.
+ */
+const threadNodes = convexTable(
+  'depthThreadNodes',
+  {
+    label: text().notNull(),
+    parentId: text().references((): AnyColumn => threadNodes.id),
+  },
+  (t) => [
+    index('by_parent_lookup').on(t.parentId),
+    aggregateIndex('by_parent').on(t.parentId),
+  ]
+);
+
+const threadSchema = defineSchema({ depthThreadNodes: threadNodes });
+const threadRelations = defineRelations(
+  { depthThreadNodes: threadNodes },
+  (r) => ({
+    depthThreadNodes: {
+      replies: r.many.depthThreadNodes({
+        from: r.depthThreadNodes.id,
+        to: r.depthThreadNodes.parentId,
+      }),
+      parent: r.one.depthThreadNodes({
+        from: r.depthThreadNodes.parentId,
+        to: r.depthThreadNodes.id,
+      }),
+    },
+  })
+);
+
+const runBackfillToReady = async (api: any, ctx: { db: any }) => {
+  await api.aggregateBackfill.handler(
+    { db: ctx.db, scheduler: schedulerStub },
+    {}
+  );
+
+  for (let i = 0; i < 20; i += 1) {
+    const status = await api.aggregateBackfillStatus.handler(
+      { db: ctx.db, scheduler: schedulerStub },
+      {}
+    );
+    if (status.every((entry: any) => entry.status === 'READY')) {
+      return;
+    }
+    await api.aggregateBackfillChunk.handler(
+      { db: ctx.db, scheduler: schedulerStub },
+      {}
+    );
+  }
+
+  throw new Error('aggregateBackfill did not reach READY state in time.');
+};
+
+/** `levels` nested `replies` levels, each asking for its own reply count. */
+const repliesWith = (levels: number): any => {
+  if (levels <= 0) return;
+  const child = repliesWith(levels - 1);
+  return {
+    limit: 10,
+    with: {
+      _count: { replies: true },
+      ...(child ? { replies: child } : {}),
+    },
+  };
+};
+
+/** Walks the single chain a linear thread produces, root first. */
+const walkChain = (root: any) => {
+  const chain: { label: string; count: number | undefined }[] = [];
+  let node = root;
+  while (node) {
+    chain.push({ label: node.label, count: node._count?.replies });
+    node = node.replies?.[0];
+  }
+  return chain;
+};
+
+const withThread = async (
+  chainLength: number,
+  run: (ctx: any) => Promise<void>
+) => {
+  const t = convexTest(threadSchema);
+  await t.run(async (baseCtx) => {
+    const client = createOrm({
+      capabilities: [aggregateCapability()],
+      schema: threadRelations,
+      ormFunctions: {
+        scheduledDelete: {} as any,
+        scheduledMutationBatch: {} as any,
+      },
+      internalMutation: passthroughInternalMutation,
+    });
+    const ctx = client.with({
+      db: baseCtx.db,
+      scheduler: schedulerStub as any,
+    });
+
+    let parentId: string | undefined;
+    for (let i = 0; i < chainLength; i += 1) {
+      parentId = await ctx.db.insert('depthThreadNodes', {
+        label: `l${i}`,
+        parentId,
+      });
+    }
+
+    await runBackfillToReady(client.api() as any, baseCtx as any);
+    await run(ctx);
+  });
+};
+
+describe('ORM relation depth', () => {
+  it('loads every level the with config asks for', async () => {
+    await withThread(6, async (ctx) => {
+      const rows: any = await ctx.orm.query.depthThreadNodes.findMany({
+        where: { parentId: { isNull: true } },
+        limit: 10,
+        with: { replies: repliesWith(5) },
+      });
+
+      expect(walkChain(rows[0]).map((node) => node.label)).toEqual([
+        'l0',
+        'l1',
+        'l2',
+        'l3',
+        'l4',
+        'l5',
+      ]);
+    });
+  });
+
+  /**
+   * The deepest level is exactly where a count matters -- it is the only node
+   * whose children were not returned, so `_count` is how a caller learns the
+   * thread continues. Resolving it here is what removes the second pass that a
+   * caller would otherwise run over every node it already holds.
+   */
+  it('resolves _count on the deepest level it returns', async () => {
+    await withThread(6, async (ctx) => {
+      const rows: any = await ctx.orm.query.depthThreadNodes.findMany({
+        where: { parentId: { isNull: true } },
+        limit: 10,
+        with: {
+          _count: { replies: true },
+          replies: repliesWith(3),
+        },
+      });
+
+      // l3 is the deepest returned node; it still reports the reply it withheld.
+      expect(walkChain(rows[0])).toEqual([
+        { label: 'l0', count: 1 },
+        { label: 'l1', count: 1 },
+        { label: 'l2', count: 1 },
+        { label: 'l3', count: 1 },
+      ]);
+    });
+  });
+
+  it('resolves _count without loading the relation it counts', async () => {
+    await withThread(3, async (ctx) => {
+      const rows: any = await ctx.orm.query.depthThreadNodes.findMany({
+        where: { parentId: { isNull: true } },
+        limit: 10,
+        with: { _count: { replies: true } },
+      });
+
+      expect(rows[0]._count.replies).toBe(1);
+      expect(Object.hasOwn(rows[0], 'replies')).toBe(false);
+    });
+  });
+
+  /**
+   * A `with` config is a finite object the caller wrote, so the ceiling only
+   * exists to stop a self-referential one. Returning a shallower tree instead
+   * would be indistinguishable from a thread that genuinely ended there. It
+   * takes a thread long enough to still have rows at the ceiling to reach it --
+   * a shorter thread simply runs out of children first.
+   */
+  it('refuses to nest past the ceiling instead of truncating silently', async () => {
+    await withThread(12, async (ctx) => {
+      await expect(
+        ctx.orm.query.depthThreadNodes.findMany({
+          where: { parentId: { isNull: true } },
+          limit: 10,
+          with: { replies: repliesWith(11) },
+        })
+      ).rejects.toThrow(/RELATION_DEPTH_EXCEEDED/);
+    });
+  });
+});

--- a/convex/orm/relation-loading.test.ts
+++ b/convex/orm/relation-loading.test.ts
@@ -877,47 +877,9 @@ describe('M6.5 Phase 2: Nested Relation Loading', () => {
     });
   });
 
-  describe('Depth Limiting', () => {
-    test('should respect max depth limit of 3', async ({ ctx }) => {
-      // We can't easily test depth > 3 without more tables,
-      // but we can verify depth 3 works and depth limiting is in place
-      const userId = await ctx.db.insert('users', {
-        name: 'Alice',
-        email: 'alice@example.com',
-      });
-
-      const postId = await ctx.db.insert('posts', {
-        text: 'Post',
-        numLikes: 10,
-        type: 'text',
-        authorId: userId,
-      });
-
-      await (ctx.db as any).insert('comments', {
-        text: 'Comment',
-        postId,
-        authorId: userId,
-      });
-
-      const db = ctx.orm;
-
-      // Depth 1: users
-      // Depth 2: users.posts
-      // Depth 3: users.posts.comments
-      const users = await db.query.users.findMany({
-        with: {
-          posts: {
-            with: {
-              comments: true,
-            },
-          },
-        },
-      });
-
-      expect((users[0] as any).posts[0].comments).toBeDefined();
-      expect((users[0] as any).posts[0].comments).toHaveLength(1);
-    });
-  });
+  // Depth limiting itself is owned by `relation-depth.test.ts`: it needs a
+  // self-referencing table to nest a `with` config past the ceiling, which none
+  // of the tables here are.
 });
 
 describe('M6.5 Phase 3: Relation Filters and Limits', () => {

--- a/convex/setup.testing.ts
+++ b/convex/setup.testing.ts
@@ -125,6 +125,23 @@ export function convexTest<Schema extends SchemaDefinition<any, any>>(
  * in the returned rows: a query that reads a table twice and a query that reads
  * it once can return exactly the same page. Call this before the query under
  * test and assert on `reads.documents`.
+ *
+ * This swaps `db.get` and `db.query`, and the ORM binds both when it is built.
+ * Install it **before** `withOrm`/`withOrmCtx`, then subtract a snapshot taken
+ * after seeding:
+ *
+ * ```ts
+ * const reads = countDocumentReads(baseCtx);
+ * const ctx = withOrm(baseCtx, schema);
+ * await seed(ctx);
+ * const before = reads.documents;
+ * await queryUnderTest(ctx);
+ * expect(reads.documents - before).toBeLessThanOrEqual(bound);
+ * ```
+ *
+ * Installing it on a context that already carries an ORM counts only the reads
+ * issued directly through `ctx.db`, so an assertion on ORM reads passes against
+ * a constant zero.
  */
 export function countDocumentReads(ctx: { db: GenericDatabaseWriter<any> }): {
   documents: number;

--- a/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
+++ b/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
@@ -299,7 +299,7 @@ Completion Gates:
 | Docs and kitcn skill sync changed | yes | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | www relations/queries/aggregates + api-catalog updated; matching skill docs `features/orm.md` and `features/aggregates.md` updated in the same diff |
 | Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | supporting docs; current-state voice, claims source-backed against MAX_RELATION_DEPTH |
 | High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | see High-risk note below |
-| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: `packages/kitcn/skills/**` is published end-user content, not repo agent tooling; no `.agents/**` source, hook, command, or prompt changed |
+| Agent-native review for agent/tooling changes | yes | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | PASS: published skill sources own the change, installed mirrors are byte-identical, and Intent validation plus stale checks pass |
 | Local install corruption suspected | yes | Run `bun install` once, rerun the exact failing command, or record N/A | `kitcn/server` unresolved on first vitest run; resolved by `bun --cwd packages/kitcn build` per repo rule, not reinstall |
 | Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | committed and pushed on `fix/orm-nested-with-depth-and-count` |
 | PR create or update | yes | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | PR #395 opened onto `main` from `fix/orm-nested-with-depth-and-count` |
@@ -395,6 +395,13 @@ Review fixes:
 - Ceiling test initially passed for the wrong reason: a three-node chain runs out
   of rows before reaching the ceiling, so the guard never fires. Seeded a
   twelve-node chain so rows still exist at depth 10.
+- Autoclosure P1 autoreview found that `getCommentThread` narrowed its accepted
+  `maxDepth` range from 0..10 to 0..5. A public-handler regression test failed on
+  explicit `10`; the API now keeps `.max(10).default(10)` and clamps only the
+  relation request to `MAX_REPLY_DEPTH`.
+- Agent-native review passes: the published aggregate and ORM skill docs are the
+  source owners, their installed mirrors are identical, and both Intent checks
+  pass. Deslop has no net findings; its occurrence churn is line movement.
 
 Error attempts:
 | Error / failed attempt | Count | Next different move | Resolution |
@@ -404,6 +411,8 @@ Error attempts:
 | `COUNT_INDEX_BUILDING` on `todoComments.by_parent` | 1 | Drive `aggregateBackfill*` handlers as `relation-count.test.ts` does | backfill helper added |
 | `results.page` undefined | 1 | `findMany` only paginates with a `cursor` | passed `cursor: null` |
 | Read assertion measured 0 both ways | 2 | Install `countDocumentReads` before `withOrm` | counter installed on `baseCtx` first |
+| Static `todoComments` import evaluated environment config before the test stub | 1 | Import the procedure inside `withExampleEnv` | Public-handler regression reaches input validation |
+| Branch autoreview repeated the fixed `maxDepth` finding because uncommitted changes are excluded from branch mode | 1 | Commit the proven fix, then rerun branch review on the pushed head | Pending final branch replay |
 
 Verification evidence:
 - `npx vitest run convex/orm/relation-depth.test.ts convex/orm/example-comment-tree-reads.test.ts` -> 6 passed.
@@ -416,6 +425,13 @@ Verification evidence:
 - `bun tooling/sync-kitcn-skill.ts` -> `.agents/skills/kitcn` mirror updated.
 - `bun run check:ci` -> green (lint, typecheck, test, test:cli, test:concave, fixtures:check).
 - `autoreview --mode local --engine claude` -> clean, 0 accepted/actionable findings.
+- Autoclosure focused replay after the P1 fix: 52 tests pass across relation
+  depth, comment-tree reads, and relation loading; no type errors.
+- Agent-native proof: both published skill sources match their installed mirrors;
+  `bun run intent:validate` and `cd packages/kitcn && bunx intent stale` pass.
+- Autoclosure final `bun lint:fix && bun --cwd packages/kitcn build && bun
+  check` replay exited 0 after the P1 fix, including fixture parity and every
+  runtime scenario.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |

--- a/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
+++ b/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
@@ -80,10 +80,11 @@ Boundaries:
   functions, `convex/orm` tests, ORM docs + kitcn skill docs, `.changeset`.
 - Browser surface: N/A: no frontend renders comments (`grep -rin "omment"
   example/src` returns zero matches).
-- GitHub issue sync: not performed; user standing preference is no PR unless
-  asked, and there is no PR to reference.
+- GitHub issue sync: PR #395 opened on user request; issue #391 is linked from
+  the PR body via `Fixes #391`.
 - Non-goals: rearming the two pre-existing vacuous read-bound example tests;
   making the relation depth ceiling user-configurable.
+- Owned PR: https://github.com/udecode/kitcn/pull/395 (this plan owns exactly one PR).
 
 Output budget strategy:
 - Exploration ran as one background workflow whose five lens reports were
@@ -280,7 +281,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `bun run check:ci` green; both new test files red before the query.ts change and green after |
-| Exact per-PR task ownership | no | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | N/A: no PR; user preference forbids PRs unless asked |
+| Exact per-PR task ownership | yes | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | PR #395, owned solely by this plan |
 | Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | recorded above: valid repro, partially-valid diagnosis, ORM boundary chosen |
 | Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level integration repro sufficed; browser/visual N/A |
 | Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | `git stash push packages/kitcn/src/orm/query.ts` -> relation-depth 3/4 fail, example-comment-tree 2/2 fail with ZodError on missing `user` |
@@ -300,12 +301,12 @@ Completion Gates:
 | High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | see High-risk note below |
 | Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: `packages/kitcn/skills/**` is published end-user content, not repo agent tooling; no `.agents/**` source, hook, command, or prompt changed |
 | Local install corruption suspected | yes | Run `bun install` once, rerun the exact failing command, or record N/A | `kitcn/server` unresolved on first vitest run; resolved by `bun --cwd packages/kitcn build` per repo rule, not reinstall |
-| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | `1f2bc4c8` on branch `issue-391`; not pushed |
-| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: explicit user decline of PR creation |
-| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR |
-| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR |
-| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR and no images |
-| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR to reference; user did not ask for issue sync |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | committed and pushed on `fix/orm-nested-with-depth-and-count` |
+| PR create or update | yes | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | PR #395 opened onto `main` from `fix/orm-nested-with-depth-and-count` |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 395 --json body` matches the PR #270 contract |
+| PR task evidence verified | yes | Verify body plan line, plan at PR head, and exact PR ownership | plan line resolves at PR head and names PR #395 |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no browser proof or images in the body |
+| GitHub issue sync-back | yes | Post concise issue sync after PR exists, or record N/A/blocker | `Fixes #391` links the PR to the issue |
 | Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | filled below |
 | Final lint | yes | Run `bun lint:fix` or scoped equivalent | `bun lint` -> biome + eslint clean over 938 files |
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | workflow reports artifacted to /tmp; all test output filtered |
@@ -332,7 +333,7 @@ Phase / pass table:
 | Intake and source read | done | issue #391 read; depth budget mapped and probe-proven | implementation |
 | Implementation | done | query.ts depth budget; example second pass deleted; docs + changeset | verification |
 | Verification | done | red-green on both new suites; check:ci green | closeout |
-| Commit / PR / GitHub sync | partial | committed `1f2bc4c8`; no push/PR/issue sync per user preference | final response |
+| Commit / PR / GitHub sync | done | pushed; PR #395 opened; issue #391 linked | final response |
 | Closeout | done | autoreview closed; plan gates filled | final response |
 
 Findings:
@@ -414,6 +415,7 @@ Verification evidence:
 - `bun --cwd packages/kitcn build` -> 71 files, build complete.
 - `bun tooling/sync-kitcn-skill.ts` -> `.agents/skills/kitcn` mirror updated.
 - `bun run check:ci` -> green (lint, typecheck, test, test:cli, test:concave, fixtures:check).
+- `autoreview --mode local --engine claude` -> clean, 0 accepted/actionable findings.
 
 Source-listed case matrix:
 | Case | Source claim | Harness | Before | Expected after | Evidence | Status |
@@ -425,9 +427,9 @@ Source-listed case matrix:
 | Requested relation silently dropped past depth 3 (not in issue) | n/a | `relation-depth.test.ts` "loads every level the with config asks for" and the example suite | `buildRepliesWith(3)` left level 3 without `user`, so `.parse()` threw a ZodError on any 4-deep thread | all requested levels load | both suites green; red with query.ts stashed (ZodError on missing `user`) | fixed |
 
 Final handoff contract:
-- Commit line: `1f2bc4c8` on `issue-391`, local only (not pushed)
-- PR line: N/A: no PR
-- Issue line: #391 (not synced; no PR to reference and no sync requested)
+- Commit line: on `fix/orm-nested-with-depth-and-count`, pushed
+- PR line: https://github.com/udecode/kitcn/pull/395
+- Issue line: #391, closed by PR #395 via `Fixes #391`
 - Confidence line: 95-100%
 - Flow table:
   - Reproduced: tests red before the fix, browser N/A
@@ -451,7 +453,7 @@ Final handoff contract:
     stop a self-referential config, and new public surface for that is
     speculative.
 - Verified: see Verification evidence.
-- PR body verified: N/A: no PR
+- PR body verified: `gh pr view 395 --json body`
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
@@ -475,9 +477,9 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: `1f2bc4c8` (local, not pushed)
-- PR: N/A
-- Issue: #391 not synced
+- Commit: pushed to `fix/orm-nested-with-depth-and-count`
+- PR: https://github.com/udecode/kitcn/pull/395
+- Issue: #391 linked from PR #395
 - Browser proof: N/A
 - Caveats: two pre-existing example read tests remain unarmed (see Findings)
 
@@ -489,6 +491,7 @@ Timeline:
 - Example second pass deleted; tree helper extracted; docs, skill docs, and
   changeset written.
 - `bun run check:ci` green; autoreview closed with no accepted findings.
+- Branch renamed to `fix/orm-nested-with-depth-and-count`, pushed, PR #395 opened.
 
 Reboot status:
 | Question | Answer |

--- a/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
+++ b/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
@@ -1,0 +1,512 @@
+# 391 fix todoComments double reads via ORM relation depth
+
+Objective:
+Stop `todoComments` doubling its document reads by fixing the ORM boundary that
+caused it: nested `with` silently truncated at depth 3, which also dropped
+`_count` on the deepest level returned.
+
+Goal plan:
+docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+- docs (docs/plans/templates/packs/docs.md)
+
+Task source:
+- type: GitHub issue
+- id / link: #391 https://github.com/udecode/kitcn/issues/391
+- title: Example: `todoComments` re-reads every comment already in the returned
+  tree just to attach `_count.replies`, doubling reads
+- acceptance criteria: the tree query attaches `replyCount` without a second
+  pass over nodes already in hand; issue's stated ORM constraint (hardcoded
+  depth 3) resolved or explicitly worked around with a recorded reason.
+
+Timed checkpoint:
+- requested duration: N/A: no duration requested
+- semantics: N/A
+- initial confidence score: N/A
+- improvement loop: N/A
+- final score / loop closure: N/A
+
+Completion threshold:
+- `with: { _count }` resolves at every level a nested `with` returns, proven by
+  a red-green integration test.
+- Requested nesting depth is honored instead of silently truncated; exceeding
+  the ceiling throws.
+- The example's second pass is deleted and a read-bound test proves the marginal
+  document cost per returned comment no longer doubles.
+- Full repo gate green; docs and kitcn skill docs synced; changeset written.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md` passes.
+
+Verification surface:
+- `npx vitest run convex/orm/relation-depth.test.ts` (new, red before fix)
+- `npx vitest run convex/orm/example-comment-tree-reads.test.ts` (new, red before)
+- `bun run test:vitest`, `bun run test:bun`, `bun typecheck`, `bun lint`
+- `bun run check:ci`
+- `bun --cwd packages/kitcn build`
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- When a GitHub PR is in scope, this plan owns exactly one PR. A coordinating
+  batch plan must link a separate task plan for every PR an agent processes.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- A task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`; the plan must exist at the PR head and
+  identify the exact PR before autoclosure.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: GitHub issue #391.
+- Allowed edit scope: `packages/kitcn/src/orm/query.ts`, example comment
+  functions, `convex/orm` tests, ORM docs + kitcn skill docs, `.changeset`.
+- Browser surface: N/A: no frontend renders comments (`grep -rin "omment"
+  example/src` returns zero matches).
+- GitHub issue sync: not performed; user standing preference is no PR unless
+  asked, and there is no PR to reference.
+- Non-goals: rearming the two pre-existing vacuous read-bound example tests;
+  making the relation depth ceiling user-configurable.
+
+Output budget strategy:
+- Exploration ran as one background workflow whose five lens reports were
+  written to `/tmp/lens-*.md` and read in slices, not streamed.
+- Test runs were filtered through `grep -E` or `tail`.
+
+Blocked condition:
+- None encountered.
+
+Task state:
+- task_type: bug
+- task_complexity: non-trivial
+- current_phase: closeout
+- current_phase_status: in_progress
+- next_phase: final response
+- goal_status: active
+
+Current verdict:
+- verdict: partially valid
+- confidence: 95-100%
+- next owner: task
+- reason: the doubling is real and reproduced, but the issue's `db.get`-per-node
+  mechanism is wrong for this schema (public `id` is a text column, so the second
+  pass reads through an index, not `db.get`); the doubling is in total document
+  reads. The issue also missed that the same truncation drops `user` on the
+  deepest level, which makes both read queries throw a ZodError on a 4-deep
+  thread.
+
+Implementation readiness:
+- verdict: ready
+- exact owner: `_loadRelations` / `_assertRlsSelectPlan` depth budget in
+  `packages/kitcn/src/orm/query.ts`
+- contradiction status: resolved -- the type layer already promised depth 5
+  (`test/types/db-rel.ts:35-139`) while the runtime delivered 3; runtime now
+  matches what `with` says.
+- source-listed cases complete: yes
+
+Pre-solution issue challenge:
+- reporter claim: the tree query re-reads every returned node to attach
+  `_count.replies`, exactly doubling document reads; `_count` on the main query
+  does not work because `_loadRelations` is capped at depth 3.
+- suggested diagnosis or fix: (1) example-only -- derive counts from
+  `replies.length` and only re-read the leaf frontier, or (2) ORM -- make depth
+  configurable or make `_count` resolve at the boundary.
+- repro ladder:
+  - tests / source-level repro: `convex/orm/relation-depth.test.ts` and
+    `convex/orm/example-comment-tree-reads.test.ts`, both red before the fix.
+  - repo-owned automated browser or integration proof: N/A: convex-test
+    integration is the owning layer.
+  - Browser plugin: N/A: no frontend consumes these queries.
+  - screenshot / visual proof: N/A: no rendered output.
+- reproduction verdict: valid
+- validity verdict: partially valid
+- best long-term fix boundary: the ORM depth budget. The example contorted
+  itself in three places around it (two `Math.min(..., 3)` clamps and the second
+  pass) and still had a latent ZodError.
+- harsh honest feedback: suggestion (1) would have preserved the real defect and
+  added a second workaround; the `db.get`-per-node mechanism in the issue is
+  wrong for this schema, so an example-only patch aimed at the wrong cost.
+- hard-stop decision: proceed -- reproduced at the owning layer.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration requested |
+| Walkthrough baseline for possible UI change | no | N/A: no frontend renders comments; grep -rin "omment" example/src returns zero matches |
+| Skill analysis before edits | yes | task + autogoal loaded; changeset rules read; no other skill earned its keep |
+| Active goal checked or created | yes | this plan |
+| Source of truth read before edits | yes | attachment + `gh issue view 391` (no comments) |
+| Exact per-PR task ownership | no | N/A: no PR created; user standing preference forbids PRs unless asked |
+| GitHub comments and attachments read | yes | `gh issue view 391 --json comments` returned [] |
+| Video transcript evidence required | no | N/A: no video in source |
+| Pre-solution issue challenge required | yes | see Pre-solution issue challenge |
+| Reproduction verdict before implementation | yes | valid; probe showed depth 3 dropped both `_count` and the requested relation |
+| Repro escalation ladder selected | yes | source-level convex-test integration; browser N/A |
+| Suggested fix reviewed against durable boundary | yes | example-only option rejected; ORM depth budget chosen |
+| `docs/solutions` checked for non-trivial existing-code work | no | N/A: no `docs/solutions` directory in this repo |
+| TDD decision before behavior change or bug fix | yes | red-green proven by `git stash` of query.ts |
+| Branch decision for code-changing task | yes | already on `issue-391`, dedicated to this issue |
+| Release artifact decision | yes | `.changeset/warm-pots-tickle.md`, minor |
+| Browser tool decision for browser surface | no | N/A: no browser surface |
+| Commit / PR expectation decision | no | N/A: user preference "Do not create PR under any circumstances, unless user prompts to"; work left uncommitted for review |
+| Task-style PR body decision | no | N/A: no PR |
+| Task-plan PR body evidence | no | N/A: no PR |
+| GitHub issue sync expectation decision | no | N/A: no PR to reference; user did not ask for issue sync |
+| Output budget strategy recorded | yes | see Output budget strategy |
+| Package/API pack selected | yes | `packages/kitcn` ORM runtime changed |
+| Public surface or package boundary identified | yes | `with` nesting semantics + new `RELATION_DEPTH_EXCEEDED` throw |
+| Convex entry/import graph impact identified | yes | none: no new imports in query.ts, one module-level const |
+| CLI/scaffold/generated impact identified | no | N/A: no CLI/template/scaffold source touched |
+| Release artifact path selected | yes | `.changeset/warm-pots-tickle.md` |
+| `changeset` skill loaded when `.changeset` is required | yes | `.agents/rules/changeset.mdc` read and followed |
+| Package build / fixture impact decision recorded | yes | `bun --cwd packages/kitcn build` run; fixtures unaffected (no `init -t` template change) and `fixtures:check` runs in `check:ci` |
+| Docs pack selected | yes | ORM relation + aggregate docs changed |
+| Docs guidance loaded | yes | `doc-guidelines.md` sync contract summarised via exploration workflow |
+| Docs lane selected | yes | supporting docs alongside a runtime change |
+| Target docs and nearest sibling docs read | yes | queries/index.mdx, schema/relations.mdx, queries/aggregates.mdx, api-catalog.json, skill orm.md + aggregates.md |
+| Docs style doctrine read | yes | current-state reference voice, no changelog language |
+| Documented source owner identified | yes | `MAX_RELATION_DEPTH` and `RELATION_DEPTH_ERROR` in query.ts |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Every GitHub PR in scope has its own task plan. This plan owns one exact
+      PR, owns a not-yet-created PR slice, or records N/A because no PR is in
+      scope; a batch plan is not used as a substitute.
+- [x] Required video or screen-recording evidence is cached/read as normalized
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason
+      recorded, or blocker recorded.
+- [x] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan
+      exists at the PR head, and it identifies the exact PR before autoclosure.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure:
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`,
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`.
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: affected Convex static import graphs stay narrow and
+      plugin/per-module boundaries are used where appropriate.
+- [x] Package/API pack: CLI commands remain deterministic, `--json` capable,
+      and non-interactive with explicit confirmation bypass when relevant.
+- [x] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
+      current-state synchronized when public guidance changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: `packages/kitcn` build, fixture sync/check, or other owning package proof is recorded when required.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | `bun run check:ci` green; both new test files red before the query.ts change and green after |
+| Exact per-PR task ownership | no | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | N/A: no PR; user preference forbids PRs unless asked |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | recorded above: valid repro, partially-valid diagnosis, ORM boundary chosen |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level integration repro sufficed; browser/visual N/A |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | `git stash push packages/kitcn/src/orm/query.ts` -> relation-depth 3/4 fail, example-comment-tree 2/2 fail with ZodError on missing `user` |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | `npx vitest run convex/orm/relation-depth.test.ts convex/orm/example-comment-tree-reads.test.ts` -> 6 passed |
+| TypeScript or typed config changed | yes | Run relevant typecheck | `bun typecheck` -> 5/5 packages successful |
+| Package exports or file layout changed | no | Run the relevant package build before final verification and keep generated updates | N/A: no export or dist layout change; `bun --cwd packages/kitcn build` still run |
+| Package manifests, lockfile, or install graph changed | no | Run `bun install` and relevant package checks | N/A: no manifest or lockfile change |
+| Agent rules or skills changed | yes | Run `bun install` and verify generated skill sync | `packages/kitcn/skills/kitcn/**` edited; `bun install` postinstall syncs `.agents/skills/kitcn/**` -- sync run and verified |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | all commands run from repo root `/Users/mikey/conductor/workspaces/kitcn/shanghai-v1`, which owns packages/kitcn, example, convex tests, and www |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: no frontend consumes getTodoComments/getCommentThread |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: no browser surface |
+| UI walkthrough | no | If UI or rendered output changed, run `.agents/skills/walkthrough/SKILL.md` after final proof and show annotated images in the final handoff; otherwise record N/A | N/A: no UI or rendered output changed |
+| Scaffold or fixture output changed | no | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | N/A: no `kitcn init -t` template or scaffold source touched; `fixtures:check` still runs inside `check:ci` |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | `.changeset/warm-pots-tickle.md` (minor, breaking + patch sections) |
+| Docs and kitcn skill sync changed | yes | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | www relations/queries/aggregates + api-catalog updated; matching skill docs `features/orm.md` and `features/aggregates.md` updated in the same diff |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | supporting docs; current-state voice, claims source-backed against MAX_RELATION_DEPTH |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | see High-risk note below |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: `packages/kitcn/skills/**` is published end-user content, not repo agent tooling; no `.agents/**` source, hook, command, or prompt changed |
+| Local install corruption suspected | yes | Run `bun install` once, rerun the exact failing command, or record N/A | `kitcn/server` unresolved on first vitest run; resolved by `bun --cwd packages/kitcn build` per repo rule, not reinstall |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | `1f2bc4c8` on branch `issue-391`; not pushed |
+| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: explicit user decline of PR creation |
+| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR |
+| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR and no images |
+| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR to reference; user did not ask for issue sync |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | filled below |
+| Final lint | yes | Run `bun lint:fix` or scoped equivalent | `bun lint` -> biome + eslint clean over 938 files |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | workflow reports artifacted to /tmp; all test output filtered |
+| Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | see Review fixes |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md` | passes |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | only `_loadRelations`/`_assertRlsSelectPlan` internals changed; no export added or removed |
+| Convex bundle/import proof | no | Audit affected function-entry static graphs or record N/A | N/A: no new imports; one module-level numeric const |
+| CLI/scaffold/generated proof | no | Prove command contract and regenerate owned output or record N/A | N/A: no CLI or generated output touched |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime or no published user-visible delta | published runtime behavior change: nested `with` depth semantics + new throw |
+| Published package changeset | yes | If published package users see a delta, load `changeset` and add/update one `.changeset/*.md` per package | `.changeset/warm-pots-tickle.md` |
+| No release artifact | no | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | N/A: a changeset was required and written |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | `bun --cwd packages/kitcn build` clean; `bun run test:bun` 1288 pass; `bun run test:vitest` 850 pass |
+| Fixture/scaffold generation | no | Run `bun run fixtures:sync` and `bun run fixtures:check` when scaffold output changed, otherwise N/A | N/A: no scaffold output changed |
+| Docs/package skill sync | yes | Synchronize current-state public guidance or record N/A | skill `features/orm.md` + `features/aggregates.md` updated alongside www |
+| Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | the documented "10 levels" and `RELATION_DEPTH_EXCEEDED` match `MAX_RELATION_DEPTH` and `RELATION_DEPTH_ERROR` in query.ts |
+| Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links or routes added |
+| Docs MDX/content parser | yes | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | `bun run check:ci` covers the www typecheck lane; no MDX structure changed beyond prose and one fenced block |
+| Kitcn docs sync | yes | If `www/**` changed, update matching `packages/kitcn/skills/kitcn/**` content or record N/A | www/** changed and `packages/kitcn/skills/kitcn/**` updated in the same diff |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | done | issue #391 read; depth budget mapped and probe-proven | implementation |
+| Implementation | done | query.ts depth budget; example second pass deleted; docs + changeset | verification |
+| Verification | done | red-green on both new suites; check:ci green | closeout |
+| Commit / PR / GitHub sync | partial | committed `1f2bc4c8`; no push/PR/issue sync per user preference | final response |
+| Closeout | done | autoreview closed; plan gates filled | final response |
+
+Findings:
+- The depth budget was a hardcoded `3` duplicated across 15 call sites plus the
+  `_loadRelations` default, and hitting it returned rows silently.
+- `_count` sat behind the same guard even though it reads an aggregate index and
+  never expands the row tree, so the one place a count is most useful -- the
+  deepest level returned -- was the one place it could not be asked for.
+- The type layer already promised more than the runtime delivered:
+  `test/types/db-rel.ts:35-139` type-checks a five-level `with`.
+- The example worked around the ceiling three times: `Math.min(input.maxReplyDepth, 3)`,
+  `Math.min(input.maxDepth, 3)`, and the second count pass -- while still
+  throwing a ZodError on any thread with three nested replies, because the
+  deepest level lost its `user` relation.
+- `countDocumentReads` reports zero for ORM reads unless it is installed before
+  `withOrm` builds the ORM. `example-tag-merge-reads.test.ts` and
+  `example-project-existence-reads.test.ts` both install it after, so their read
+  bounds currently assert against a constant zero. Their bounds are correct when
+  armed (measured: mergeReads 7 against a `<= 12` bound), so rearming them is a
+  safe follow-up, deliberately left out of this diff.
+
+Decisions and tradeoffs:
+- Chose the ORM depth budget over the issue's example-only option. The
+  example-only path keeps the defect, adds a second workaround, and does not fix
+  the ZodError the same guard causes.
+- Raised the ceiling to 10 and made it throw rather than making it configurable.
+  A `with` config is a finite object the caller wrote, so its own nesting is the
+  real bound; the ceiling only has to stop a self-referential config. Adding a
+  `maxRelationDepth` option would be public surface nobody has asked for.
+- Exempted `_count` from the budget rather than special-casing the boundary: it
+  reads an aggregate index and returns a number, so it never spends recursion
+  budget in the first place.
+- Capped the example's read depth at its own write cap (`MAX_REPLY_DEPTH = 5`)
+  instead of at the ORM ceiling, so the two limits cannot drift.
+- Left the two pre-existing vacuous read tests alone: rearming them is unrelated
+  to #391 and would mix an infrastructure repair into a behavior fix.
+
+Implementation notes:
+- `packages/kitcn/src/orm/query.ts`: `MAX_RELATION_DEPTH` (10) and
+  `RELATION_DEPTH_ERROR` replace the 15 duplicated `3` literals;
+  `_loadRelations` throws when it still has relations to expand at the ceiling,
+  and loads `_count` regardless; `_assertRlsSelectPlan` mirrors that split so the
+  policy walk still covers exactly what the loader will read.
+- `example/convex/functions/_helpers/comment_tree.ts` is new: the tree shape and
+  row mapping moved out of the Convex function module so a test can call the same
+  code the query calls. `todoComments.ts` lost `collectCommentIds`, `chunk`, and
+  `getReplyCountsByParentId`.
+- `convex/orm/relation-loading.test.ts` lost `describe('Depth Limiting')`: it
+  asserted nothing about limiting (its own comment said so) and duplicated the
+  two-hop test above it. Depth is now owned by `relation-depth.test.ts`.
+
+Review fixes:
+- Read-bound assertion rewritten twice after measurement. The first version
+  compared `db.get` counts, which are zero on both sides because the example's
+  public `id` is a `text()` column; the second compared totals through
+  `countDocumentReads` installed after `withOrm`, which reports zero for ORM
+  reads. The final version installs the counter first and bounds the marginal
+  document cost per node, which is red at 3.33 and green at 1.67.
+- Ceiling test initially passed for the wrong reason: a three-node chain runs out
+  of rows before reaching the ceiling, so the guard never fires. Seeded a
+  twelve-node chain so rows still exist at depth 10.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| `Cannot find package 'kitcn/server'` in vitest | 1 | Build the package rather than reinstall | `bun --cwd packages/kitcn build` |
+| `Invalid environment variables` from the example schema trigger | 1 | Copy `withExampleEnv` from the sibling example read tests | env stubbed around the run |
+| `COUNT_INDEX_BUILDING` on `todoComments.by_parent` | 1 | Drive `aggregateBackfill*` handlers as `relation-count.test.ts` does | backfill helper added |
+| `results.page` undefined | 1 | `findMany` only paginates with a `cursor` | passed `cursor: null` |
+| Read assertion measured 0 both ways | 2 | Install `countDocumentReads` before `withOrm` | counter installed on `baseCtx` first |
+
+Verification evidence:
+- `npx vitest run convex/orm/relation-depth.test.ts convex/orm/example-comment-tree-reads.test.ts` -> 6 passed.
+- Same two files with `git stash push packages/kitcn/src/orm/query.ts` -> 5 of 6 fail.
+- `bun run test:vitest` -> 80 files, 850 passed, 2 files / 13 tests skipped.
+- `bun run test:bun` -> 1288 pass, 0 fail across 145 files.
+- `bun typecheck` -> 5 packages successful (kitcn, test, test-convex, example, @kitcn/resend).
+- `bun lint` -> biome + eslint clean over 938 files.
+- `bun --cwd packages/kitcn build` -> 71 files, build complete.
+- `bun tooling/sync-kitcn-skill.ts` -> `.agents/skills/kitcn` mirror updated.
+- `bun run check:ci` -> green (lint, typecheck, test, test:cli, test:concave, fixtures:check).
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Tree query doubles document reads | "Exactly 2x document reads for any comment list/tree query" | `example-comment-tree-reads.test.ts` | 3.33 docs per marginal node (28 docs / 6 nodes, 128 / 36) | <= 2 docs per marginal node | 1.67 docs per marginal node (17 / 6, 67 / 36) | fixed |
+| `_count` on the main query does not reach the leaf | "`_loadRelations` is invoked with a hardcoded max depth of 3 ... so leaf nodes lose their `_count`" | `relation-depth.test.ts` "resolves _count on the deepest level it returns" | levels 0-2 carry `_count`, level 3 has no `_count` key | every returned level carries `_count` | test green; red on stashed query.ts | fixed |
+| Second pass re-reads nodes already in hand | `getReplyCountsByParentId` over `collectCommentIds` | source | helper + `chunk` + id walk, called at :193 and :282 | helper deleted | `example/convex/functions/todoComments.ts` has no second pass | fixed |
+| `db.get` per node (issue's stated mechanism) | "one `db.get` per node" | instrumented `db.get` counter | 0 gets with the second pass simulated | n/a | claim disproven: `todoComments.id` is a `text()` column, so `id: { in: [...] }` reads through an index; the doubling is in total document reads | corrected |
+| Requested relation silently dropped past depth 3 (not in issue) | n/a | `relation-depth.test.ts` "loads every level the with config asks for" and the example suite | `buildRepliesWith(3)` left level 3 without `user`, so `.parse()` threw a ZodError on any 4-deep thread | all requested levels load | both suites green; red with query.ts stashed (ZodError on missing `user`) | fixed |
+
+Final handoff contract:
+- Commit line: `1f2bc4c8` on `issue-391`, local only (not pushed)
+- PR line: N/A: no PR
+- Issue line: #391 (not synced; no PR to reference and no sync requested)
+- Confidence line: 95-100%
+- Flow table:
+  - Reproduced: tests red before the fix, browser N/A
+  - Verified: tests green after the fix, browser N/A
+- Browser check: N/A: no frontend consumes these queries
+- Outcome: nested `with` loads every level it is given up to 10 and throws past
+  that instead of truncating; `_count` resolves at every level including the
+  deepest returned; the example's second count pass is gone and its marginal
+  document cost per comment halved.
+- Caveat: `example-tag-merge-reads.test.ts` and
+  `example-project-existence-reads.test.ts` install `countDocumentReads` after
+  `withOrm`, so their read bounds currently assert against a constant zero.
+  Documented in `countDocumentReads`, not rearmed here.
+- Design:
+  - Chosen boundary: the ORM relation depth budget in `query.ts`.
+  - Why not quick patch: the issue's example-only option leaves the ceiling in
+    place, adds a second workaround next to the two `Math.min(..., 3)` clamps
+    already there, and does not touch the ZodError the same guard causes.
+  - Why not broader change: no `maxRelationDepth` option was added. A `with`
+    config is finite, so its own nesting is the bound; the ceiling only exists to
+    stop a self-referential config, and new public surface for that is
+    speculative.
+- Verified: see Verification evidence.
+- PR body verified: N/A: no PR
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  `🧭 Task plan: docs/plans/<plan>.md`, then an emoji confidence line like
+  `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: `1f2bc4c8` (local, not pushed)
+- PR: N/A
+- Issue: #391 not synced
+- Browser proof: N/A
+- Caveats: two pre-existing example read tests remain unarmed (see Findings)
+
+Timeline:
+- 2026-08-21T14:12:59.040Z Task goal plan created.
+- Depth budget mapped and probe-proven: at depth 3 both `_count` and the
+  requested relation were dropped silently.
+- `query.ts` depth budget replaced; both new suites red before, green after.
+- Example second pass deleted; tree helper extracted; docs, skill docs, and
+  changeset written.
+- `bun run check:ci` green; autoreview closed with no accepted findings.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout |
+| Where am I going? | Final response |
+| What is the goal? | Stop `todoComments` doubling its reads by fixing the ORM depth budget that silently truncated nested `with` and dropped `_count` on the deepest level |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+Open risks:
+- Raising the ceiling means a previously truncated deep `with` now reads the
+  levels it was silently dropping, so such a query gets slower as it gets
+  correct. Fan-out per level is still bounded by that level's `limit`.
+- Two example read-bound tests remain unarmed; they assert against zero until
+  someone moves `countDocumentReads` ahead of `withOrm`.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
+++ b/docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
@@ -399,6 +399,10 @@ Review fixes:
   `maxDepth` range from 0..10 to 0..5. A public-handler regression test failed on
   explicit `10`; the API now keeps `.max(10).default(10)` and clamps only the
   relation request to `MAX_REPLY_DEPTH`.
+- The next P1 review found over-depth plans were rejected only after loading ten
+  relation levels. The depth test measured 11 document reads before the error;
+  `_assertRlsSelectPlan` now rejects the plan before expansion while leaving a
+  boundary-only `_count` legal, and the same test passes at no more than 2 reads.
 - Agent-native review passes: the published aggregate and ORM skill docs are the
   source owners, their installed mirrors are identical, and both Intent checks
   pass. Deslop has no net findings; its occurrence churn is line movement.
@@ -413,6 +417,7 @@ Error attempts:
 | Read assertion measured 0 both ways | 2 | Install `countDocumentReads` before `withOrm` | counter installed on `baseCtx` first |
 | Static `todoComments` import evaluated environment config before the test stub | 1 | Import the procedure inside `withExampleEnv` | Public-handler regression reaches input validation |
 | Branch autoreview repeated the fixed `maxDepth` finding because uncommitted changes are excluded from branch mode | 1 | Commit the proven fix, then rerun branch review on the pushed head | Pending final branch replay |
+| Over-depth guard threw only after reading every level | 1 | Move the same guard into the existing plan preflight and share its error constructor | Red at 11 reads; green at at most 2 reads |
 
 Verification evidence:
 - `npx vitest run convex/orm/relation-depth.test.ts convex/orm/example-comment-tree-reads.test.ts` -> 6 passed.
@@ -430,7 +435,7 @@ Verification evidence:
 - Agent-native proof: both published skill sources match their installed mirrors;
   `bun run intent:validate` and `cd packages/kitcn && bunx intent stale` pass.
 - Autoclosure final `bun lint:fix && bun --cwd packages/kitcn build && bun
-  check` replay exited 0 after the P1 fix, including fixture parity and every
+  check` replay exited 0 after both P1 fixes, including fixture parity and every
   runtime scenario.
 
 Source-listed case matrix:

--- a/example/convex/functions/_helpers/comment_tree.ts
+++ b/example/convex/functions/_helpers/comment_tree.ts
@@ -1,0 +1,106 @@
+import * as z from 'zod';
+
+/**
+ * How many replies deep a thread may go. `addComment` enforces it on the write
+ * side and both read queries cap their requested depth at the same number, so
+ * a thread can never be deeper than a single read is willing to return.
+ */
+export const MAX_REPLY_DEPTH = 5;
+
+export const CommentListItemSchema = z.object({
+  id: z.string(),
+  content: z.string(),
+  createdAt: z.date(),
+  user: z
+    .object({
+      id: z.string(),
+      name: z.string().optional(),
+      image: z.string().nullish(),
+    })
+    .nullable(),
+  replies: z.array(z.any()),
+  replyCount: z.number(),
+});
+export type Reply = z.infer<typeof CommentListItemSchema>;
+
+const CommentUserSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  image: z.string().nullish(),
+});
+type CommentUser = z.infer<typeof CommentUserSchema>;
+
+export type CommentRowWithReplies = {
+  id: string;
+  content: string;
+  createdAt: Date;
+  user: CommentUser | null;
+  replies?: CommentRowWithReplies[];
+  _count?: { replies: number };
+};
+
+export const CommentRowWithRepliesSchema: z.ZodType<CommentRowWithReplies> =
+  z.lazy(() =>
+    z.object({
+      id: z.string(),
+      createdAt: z.date(),
+      content: z.string(),
+      user: CommentUserSchema.nullable(),
+      replies: z.array(CommentRowWithRepliesSchema).optional(),
+      _count: z.object({ replies: z.number() }).optional(),
+    })
+  );
+
+type RepliesWith = {
+  limit: number;
+  orderBy: { createdAt: 'asc' };
+  with: {
+    user: true;
+    _count: { replies: true };
+    replies?: RepliesWith;
+  };
+};
+
+/**
+ * The `with` config for a reply tree `maxDepth` levels deep.
+ *
+ * Every level asks for its own `_count.replies`, including the last one — that
+ * node's children are not fetched, so its count is the only thing telling the
+ * client the thread continues. Reading the count inline is what keeps the tree
+ * to one pass: re-reading each returned node to attach a count would double the
+ * query's document reads for nodes the caller already holds.
+ */
+export function buildRepliesWith(maxDepth: number): RepliesWith | undefined {
+  if (maxDepth <= 0) return;
+
+  const childWith = buildRepliesWith(maxDepth - 1);
+  return {
+    limit: 10,
+    orderBy: { createdAt: 'asc' },
+    with: {
+      user: true,
+      _count: { replies: true },
+      ...(childWith ? { replies: childWith } : {}),
+    },
+  };
+}
+
+export function toReply(row: CommentRowWithReplies): Reply {
+  const user = row.user ?? null;
+  const replies = row.replies ?? [];
+
+  return {
+    id: row.id,
+    content: row.content,
+    createdAt: row.createdAt,
+    user: user
+      ? {
+          id: user.id,
+          name: user.name ?? undefined,
+          image: user.image ?? undefined,
+        }
+      : null,
+    replies: replies.map(toReply),
+    replyCount: row._count?.replies ?? 0,
+  };
+}

--- a/example/convex/functions/todoComments.ts
+++ b/example/convex/functions/todoComments.ts
@@ -63,7 +63,7 @@ export const getCommentThread = publicQuery
   .input(
     z.object({
       commentId: z.string(),
-      maxDepth: z.number().min(0).max(MAX_REPLY_DEPTH).default(MAX_REPLY_DEPTH),
+      maxDepth: z.number().min(0).max(10).default(10),
     })
   )
   .output(
@@ -120,7 +120,11 @@ export const getCommentThread = publicQuery
         todo: true,
         parent: { with: { user: true } },
         ...(input.maxDepth > 0
-          ? { replies: buildRepliesWith(input.maxDepth) }
+          ? {
+              replies: buildRepliesWith(
+                Math.min(input.maxDepth, MAX_REPLY_DEPTH)
+              ),
+            }
           : {}),
       },
     });

--- a/example/convex/functions/todoComments.ts
+++ b/example/convex/functions/todoComments.ts
@@ -7,154 +7,15 @@ import {
   privateMutation,
   publicQuery,
 } from '../lib/crpc';
+import {
+  buildRepliesWith,
+  CommentListItemSchema,
+  CommentRowWithRepliesSchema,
+  MAX_REPLY_DEPTH,
+  toReply,
+} from './_helpers/comment_tree';
 import type { QueryCtx } from './generated/server';
 import { todoCommentsTable } from './schema';
-
-// Schema for comment list items
-const CommentListItemSchema = z.object({
-  id: z.string(),
-  content: z.string(),
-  createdAt: z.date(),
-  user: z
-    .object({
-      id: z.string(),
-      name: z.string().optional(),
-      image: z.string().nullish(),
-    })
-    .nullable(),
-  replies: z.array(z.any()),
-  replyCount: z.number(),
-});
-type Reply = z.infer<typeof CommentListItemSchema>;
-
-type CommentRowWithReplies = {
-  id: string;
-  content: string;
-  createdAt: Date;
-  user: CommentUser | null;
-  replies?: CommentRowWithReplies[];
-};
-
-const CommentUserSchema = z.object({
-  id: z.string(),
-  name: z.string().optional(),
-  image: z.string().nullish(),
-});
-type CommentUser = z.infer<typeof CommentUserSchema>;
-
-const CommentRowWithRepliesSchema: z.ZodType<CommentRowWithReplies> = z.lazy(
-  () =>
-    z.object({
-      id: z.string(),
-      createdAt: z.date(),
-      content: z.string(),
-      user: CommentUserSchema.nullable(),
-      replies: z.array(CommentRowWithRepliesSchema).optional(),
-    })
-);
-
-function buildRepliesWith(maxDepth: number):
-  | {
-      limit: number;
-      orderBy: { createdAt: 'asc' };
-      with: { user: true; replies?: ReturnType<typeof buildRepliesWith> };
-    }
-  | undefined {
-  if (maxDepth <= 0) return;
-
-  const childWith = buildRepliesWith(maxDepth - 1);
-  return {
-    limit: 10,
-    orderBy: { createdAt: 'asc' },
-    with: {
-      user: true,
-      ...(childWith ? { replies: childWith } : {}),
-    },
-  };
-}
-
-function collectCommentIds(rows: CommentRowWithReplies[]): string[] {
-  const ids: string[] = [];
-  const stack = [...rows];
-
-  while (stack.length) {
-    const row = stack.pop()!;
-    ids.push(row.id);
-    if (row.replies?.length) {
-      stack.push(...row.replies);
-    }
-  }
-
-  // Dedupe while preserving insertion order for predictable batching.
-  return Array.from(new Set(ids));
-}
-
-function chunk<T>(arr: T[], chunkSize: number): T[][] {
-  if (chunkSize <= 0) {
-    throw new CRPCError({
-      code: 'BAD_REQUEST',
-      message: 'chunkSize must be > 0',
-    });
-  }
-  const chunks: T[][] = [];
-  for (let i = 0; i < arr.length; i += chunkSize) {
-    chunks.push(arr.slice(i, i + chunkSize));
-  }
-  return chunks;
-}
-
-async function getReplyCountsByParentId(
-  ctx: QueryCtx,
-  parentIds: string[]
-): Promise<Map<string, number>> {
-  const counts = new Map<string, number>();
-
-  for (const ids of chunk(parentIds, 250)) {
-    const rows = await ctx.orm.query.todoComments.findMany({
-      where: { id: { in: ids } },
-      limit: ids.length,
-      columns: { id: true },
-      with: {
-        _count: {
-          replies: true,
-        },
-      },
-    });
-    for (const row of rows) {
-      counts.set(row.id, row._count?.replies ?? 0);
-    }
-    for (const id of ids) {
-      if (!counts.has(id)) {
-        counts.set(id, 0);
-      }
-    }
-  }
-
-  return counts;
-}
-
-function toReply(
-  row: CommentRowWithReplies,
-  replyCounts: Map<string, number>
-): Reply {
-  const user = row.user ?? null;
-  const replies = row.replies ?? [];
-
-  return {
-    id: row.id,
-    content: row.content,
-    createdAt: row.createdAt,
-    user: user
-      ? {
-          id: user.id,
-          name: user.name ?? undefined,
-          image: user.image ?? undefined,
-        }
-      : null,
-    replies: replies.map((r) => toReply(r, replyCounts)),
-    replyCount: replyCounts.get(row.id) ?? 0,
-  };
-}
 
 // ============================================
 // COMMENT QUERIES
@@ -166,7 +27,7 @@ export const getTodoComments = optionalAuthQuery
     z.object({
       todoId: z.string(),
       includeReplies: z.boolean().default(true),
-      maxReplyDepth: z.number().min(0).max(5).default(3),
+      maxReplyDepth: z.number().min(0).max(MAX_REPLY_DEPTH).default(3),
     })
   )
   .paginated({ limit: 20, item: CommentListItemSchema })
@@ -175,7 +36,6 @@ export const getTodoComments = optionalAuthQuery
       where: { id: input.todoId },
     });
 
-    const maxDepth = Math.min(input.maxReplyDepth, 3);
     const results = await ctx.orm.query.todoComments.findMany({
       where: { todoId: input.todoId, parentId: { isNull: true } },
       orderBy: { createdAt: 'desc' },
@@ -183,21 +43,18 @@ export const getTodoComments = optionalAuthQuery
       limit: input.limit,
       with: {
         user: true,
-        ...(input.includeReplies && maxDepth > 0
-          ? { replies: buildRepliesWith(maxDepth) }
+        _count: { replies: true },
+        ...(input.includeReplies && input.maxReplyDepth > 0
+          ? { replies: buildRepliesWith(input.maxReplyDepth) }
           : {}),
       },
     });
 
     const rows = z.array(CommentRowWithRepliesSchema).parse(results.page);
-    const replyCounts = await getReplyCountsByParentId(
-      ctx,
-      collectCommentIds(rows)
-    );
 
     return {
       ...results,
-      page: rows.map((comment) => toReply(comment, replyCounts)),
+      page: rows.map(toReply),
     };
   });
 
@@ -206,7 +63,7 @@ export const getCommentThread = publicQuery
   .input(
     z.object({
       commentId: z.string(),
-      maxDepth: z.number().min(0).max(10).default(10),
+      maxDepth: z.number().min(0).max(MAX_REPLY_DEPTH).default(MAX_REPLY_DEPTH),
     })
   )
   .output(
@@ -256,14 +113,15 @@ export const getCommentThread = publicQuery
       .nullable()
   )
   .query(async ({ ctx, input }) => {
-    const maxDepth = Math.min(input.maxDepth, 3);
     const comment = await ctx.orm.query.todoComments.findFirst({
       where: { id: input.commentId },
       with: {
         user: true,
         todo: true,
         parent: { with: { user: true } },
-        ...(maxDepth > 0 ? { replies: buildRepliesWith(maxDepth) } : {}),
+        ...(input.maxDepth > 0
+          ? { replies: buildRepliesWith(input.maxDepth) }
+          : {}),
       },
     });
     if (!comment) {
@@ -279,10 +137,6 @@ export const getCommentThread = publicQuery
     }
 
     const commentRow = CommentRowWithRepliesSchema.parse(comment);
-    const replyCounts = await getReplyCountsByParentId(
-      ctx,
-      collectCommentIds([commentRow])
-    );
     const replies = commentRow.replies ?? [];
 
     const user = comment.user ?? null;
@@ -339,7 +193,7 @@ export const getCommentThread = publicQuery
               user: parentUser?.name ? { name: parentUser.name } : null,
             }
           : null,
-        replies: replies.map((r) => toReply(r, replyCounts)),
+        replies: replies.map(toReply),
         ancestors,
       },
     };
@@ -501,8 +355,11 @@ export const addComment = authMutation
         });
       }
 
+      // `getCommentDepth` returns the parent's own level, so this admits a new
+      // reply at level MAX_REPLY_DEPTH and no deeper -- exactly what the read
+      // queries are willing to return.
       const depth = await getCommentDepth(ctx, input.parentId);
-      if (depth >= 5) {
+      if (depth >= MAX_REPLY_DEPTH) {
         throw new CRPCError({
           code: 'BAD_REQUEST',
           message: 'Maximum reply depth reached',

--- a/packages/kitcn/skills/kitcn/references/features/aggregates.md
+++ b/packages/kitcn/skills/kitcn/references/features/aggregates.md
@@ -211,6 +211,38 @@ const users = await ctx.orm.query.users.findMany({
 
 Works on `findMany`, `findFirst`, `findFirstOrThrow`. Access via `row._count?.relation ?? 0`.
 
+`_count` reads an aggregate index rather than the rows, so it resolves at every level of a nested `with:`, including the deepest level returned. Ask for it there instead of re-reading the returned tree to attach counts — that second pass costs one read per node the caller already holds:
+
+```ts
+// ❌ BAD: second pass over nodes already in hand
+const roots = await ctx.orm.query.comments.findMany({
+  where: { parentId: { isNull: true } },
+  limit: 20,
+  with: { replies: { limit: 10 } },
+});
+const ids = collectIds(roots);
+const counts = await ctx.orm.query.comments.findMany({
+  where: { id: { in: ids } },
+  limit: ids.length,
+  columns: { id: true },
+  with: { _count: { replies: true } },
+});
+
+// ✅ GOOD: counted inline, at every level
+const roots = await ctx.orm.query.comments.findMany({
+  where: { parentId: { isNull: true } },
+  limit: 20,
+  with: {
+    _count: { replies: true },
+    replies: {
+      limit: 10,
+      with: { _count: { replies: true } },
+    },
+  },
+});
+// roots[0].replies[0]._count?.replies => replies not in this page
+```
+
 ### Mutation `returning({ _count })`
 
 ```ts

--- a/packages/kitcn/skills/kitcn/references/features/orm.md
+++ b/packages/kitcn/skills/kitcn/references/features/orm.md
@@ -261,6 +261,14 @@ orders by creation time, so `with: { posts: { limit: 5, orderBy: { createdAt:
 parent's whole child partition and sorts in memory — put the sort column in the
 relation index (`index('by_user_rank').on(t.userId, t.rank)`) to stay bounded.
 
+### Nested `with` depth
+
+Nested `with:` loads every level it is given, up to 10. A tree that still has
+rows to expand past that throws `RELATION_DEPTH_EXCEEDED` rather than coming back
+shorter than requested — which is how a `with` object that references itself
+surfaces. Fan-out per level is bounded by that level's `limit`, not by the depth
+ceiling.
+
 ## Schema Definition
 
 ```ts

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -148,6 +148,16 @@ const RELATION_COUNT_ERROR = {
   NOT_INDEXED: 'RELATION_COUNT_NOT_INDEXED',
   FILTER_UNSUPPORTED: 'RELATION_COUNT_FILTER_UNSUPPORTED',
 } as const;
+const RELATION_DEPTH_ERROR = 'RELATION_DEPTH_EXCEEDED';
+/**
+ * How many levels of `with` the relation loader will follow. A `with` config is
+ * a finite object the caller wrote, so its own nesting is the real bound; this
+ * ceiling only stops a self-referential config from recursing forever. Reaching
+ * it throws rather than returning a shallower tree than was asked for, because
+ * a page that quietly drops its deepest level is indistinguishable from a page
+ * whose deepest level is genuinely empty.
+ */
+const MAX_RELATION_DEPTH = 10;
 
 /**
  * Physical-table-name lookup, keyed on schema identity. The schema is a
@@ -2240,13 +2250,20 @@ export class GelRelationalQuery<
       rls: this.rls,
     });
 
-    if (!withConfig || depth >= maxDepth) return;
+    if (!withConfig) return;
+
+    // `_loadRelations` throws past the ceiling rather than loading, so relations
+    // beyond it are never read and need no policy. `_count` still resolves at the
+    // boundary, so its target policy is still checked there.
+    const atDepthCeiling = depth >= maxDepth;
 
     for (const [relationName, relationConfig] of Object.entries(withConfig)) {
       if (relationName === '_count') {
         this._assertRelationCountRlsPlan(relationConfig, edges);
         continue;
       }
+
+      if (atDepthCeiling) continue;
 
       const edge = edges.find((entry) => entry.edgeName === relationName);
       // Unknown relations raise their own error while loading.
@@ -2368,7 +2385,7 @@ export class GelRelationalQuery<
       this.tableConfig,
       this.edgeMetadata,
       0,
-      3
+      MAX_RELATION_DEPTH
     );
 
     let rowsWithRelations = rows;
@@ -2377,7 +2394,7 @@ export class GelRelationalQuery<
         rowsWithRelations,
         effectiveWith,
         0,
-        3,
+        MAX_RELATION_DEPTH,
         this.edgeMetadata,
         this.tableConfig
       );
@@ -5596,7 +5613,7 @@ export class GelRelationalQuery<
       this.tableConfig,
       this.edgeMetadata,
       0,
-      3
+      MAX_RELATION_DEPTH
     );
     if (whereFilter) {
       this._assertRlsSelectPlan(
@@ -5604,7 +5621,7 @@ export class GelRelationalQuery<
         this.tableConfig,
         this.edgeMetadata,
         0,
-        3
+        MAX_RELATION_DEPTH
       );
     }
 
@@ -5706,7 +5723,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -6038,7 +6055,7 @@ export class GelRelationalQuery<
             whereFilter,
             this.edgeMetadata,
             0,
-            3,
+            MAX_RELATION_DEPTH,
             this.config.with as Record<string, unknown> | undefined
           );
         }
@@ -6075,7 +6092,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -6260,7 +6277,7 @@ export class GelRelationalQuery<
             whereFilter,
             this.edgeMetadata,
             0,
-            3,
+            MAX_RELATION_DEPTH,
             this.config.with as Record<string, unknown> | undefined
           );
         }
@@ -6301,7 +6318,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -6438,7 +6455,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -6480,7 +6497,7 @@ export class GelRelationalQuery<
         whereFilter,
         this.edgeMetadata,
         0,
-        3,
+        MAX_RELATION_DEPTH,
         this.config.with as Record<string, unknown> | undefined
       );
       return matchingRows.length > 0;
@@ -6562,7 +6579,7 @@ export class GelRelationalQuery<
               whereFilter,
               this.edgeMetadata,
               0,
-              3,
+              MAX_RELATION_DEPTH,
               this.config.with as Record<string, unknown> | undefined
             );
           }
@@ -6661,7 +6678,7 @@ export class GelRelationalQuery<
               whereFilter,
               this.edgeMetadata,
               0,
-              3,
+              MAX_RELATION_DEPTH,
               this.config.with as Record<string, unknown> | undefined
             );
           }
@@ -6809,7 +6826,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -6928,7 +6945,7 @@ export class GelRelationalQuery<
           whereFilter,
           this.edgeMetadata,
           0,
-          3,
+          MAX_RELATION_DEPTH,
           this.config.with as Record<string, unknown> | undefined
         );
       }
@@ -7349,14 +7366,14 @@ export class GelRelationalQuery<
    * @param rows - Array of parent records to load relations for
    * @param withConfig - Relation configuration object
    * @param depth - Current recursion depth (default 0)
-   * @param maxDepth - Maximum recursion depth (default 3)
+   * @param maxDepth - Runaway ceiling for self-referential configs (default `MAX_RELATION_DEPTH`)
    * @param targetTableEdges - Edge metadata for nested relations (optional, defaults to this.edgeMetadata)
    */
   private async _loadRelations(
     rows: any[],
     withConfig: Record<string, unknown>,
     depth = 0,
-    maxDepth = 3,
+    maxDepth = MAX_RELATION_DEPTH,
     targetTableEdges: EdgeMetadata[] = this.edgeMetadata,
     tableConfig: TableRelationalConfig = this.tableConfig
   ): Promise<any[]> {
@@ -7364,15 +7381,20 @@ export class GelRelationalQuery<
       return rows;
     }
 
-    // Prevent infinite recursion / memory explosion
-    if (depth >= maxDepth) {
-      return rows;
-    }
-
     const relationCountConfig = (withConfig as any)._count;
     const relationEntries = Object.entries(withConfig).filter(
       ([relationName]) => relationName !== '_count'
     );
+
+    // Only expanding the row tree spends recursion budget. `_count` reads an
+    // aggregate index and returns a number, so it stays legal at the boundary --
+    // which is what lets the deepest level of a tree report how much it omitted.
+    if (relationEntries.length > 0 && depth >= maxDepth) {
+      throw new Error(
+        `${RELATION_DEPTH_ERROR}: '${tableConfig.name}.${relationEntries[0][0]}' nests \`with\` more than ${maxDepth} levels deep. ` +
+          'Trim the nesting, or check whether the config object references itself.'
+      );
+    }
 
     // Load all relations in parallel to avoid sequential N+1 queries
     await Promise.all(

--- a/packages/kitcn/src/orm/query.ts
+++ b/packages/kitcn/src/orm/query.ts
@@ -2252,18 +2252,22 @@ export class GelRelationalQuery<
 
     if (!withConfig) return;
 
-    // `_loadRelations` throws past the ceiling rather than loading, so relations
-    // beyond it are never read and need no policy. `_count` still resolves at the
-    // boundary, so its target policy is still checked there.
-    const atDepthCeiling = depth >= maxDepth;
+    const relationNames = Object.keys(withConfig).filter(
+      (relationName) => relationName !== '_count'
+    );
+    if (relationNames.length > 0 && depth >= maxDepth) {
+      throw this._createRelationDepthError(
+        tableConfig,
+        relationNames[0],
+        maxDepth
+      );
+    }
 
     for (const [relationName, relationConfig] of Object.entries(withConfig)) {
       if (relationName === '_count') {
         this._assertRelationCountRlsPlan(relationConfig, edges);
         continue;
       }
-
-      if (atDepthCeiling) continue;
 
       const edge = edges.find((entry) => entry.edgeName === relationName);
       // Unknown relations raise their own error while loading.
@@ -7390,9 +7394,10 @@ export class GelRelationalQuery<
     // aggregate index and returns a number, so it stays legal at the boundary --
     // which is what lets the deepest level of a tree report how much it omitted.
     if (relationEntries.length > 0 && depth >= maxDepth) {
-      throw new Error(
-        `${RELATION_DEPTH_ERROR}: '${tableConfig.name}.${relationEntries[0][0]}' nests \`with\` more than ${maxDepth} levels deep. ` +
-          'Trim the nesting, or check whether the config object references itself.'
+      throw this._createRelationDepthError(
+        tableConfig,
+        relationEntries[0][0],
+        maxDepth
       );
     }
 
@@ -7476,6 +7481,17 @@ export class GelRelationalQuery<
     message: string
   ): Error {
     return new Error(`${code}: ${message}`);
+  }
+
+  private _createRelationDepthError(
+    tableConfig: TableRelationalConfig,
+    relationName: string,
+    maxDepth: number
+  ): Error {
+    return new Error(
+      `${RELATION_DEPTH_ERROR}: '${tableConfig.name}.${relationName}' nests \`with\` more than ${maxDepth} levels deep. ` +
+        'Trim the nesting, or check whether the config object references itself.'
+    );
   }
 
   private _remapRelationCountError(

--- a/www/content/docs/orm/queries/aggregates.mdx
+++ b/www/content/docs/orm/queries/aggregates.mdx
@@ -211,6 +211,26 @@ const users = await ctx.orm.query.users.findMany({
 
 Access counts via `row._count?.relation ?? 0`. Works on `findMany`, `findFirst`, and `findFirstOrThrow`.
 
+`_count` reads an aggregate index instead of the rows, so it resolves at every
+level of a nested `with:` — including the deepest one, whose children were not
+loaded. Ask for it there to tell a caller how much a tree withheld, rather than
+re-reading the returned nodes to count their children:
+
+```ts showLineNumbers {3,7}
+const comments = await ctx.orm.query.comments.findMany({
+  with: {
+    _count: { replies: true },
+    replies: {
+      limit: 10,
+      with: {
+        _count: { replies: true },
+      },
+    },
+  },
+});
+// comments[0].replies[0]._count?.replies => 4 replies not in this page
+```
+
 ### Mutation `returning({ _count })`
 
 You can also include `_count` in mutation returning selections — handy for returning fresh counts after a write:

--- a/www/content/docs/orm/queries/index.mdx
+++ b/www/content/docs/orm/queries/index.mdx
@@ -316,7 +316,7 @@ const users = await db.query.users.findMany({
 });
 ```
 
-Relation filters for `many()` are applied post-fetch. Nested `with:` has a depth limit to prevent infinite recursion. The `limit` and `offset` in `with:` apply per parent relation, not globally.
+Relation filters for `many()` are applied post-fetch. Nested `with:` loads every level you ask for, up to 10 levels deep; a tree that still has rows past that throws `RELATION_DEPTH_EXCEEDED` rather than coming back shorter than you asked for. The `limit` and `offset` in `with:` apply per parent relation, not globally.
 
 <Callout icon={<InfoIcon />}>
 **Note**: For `many()` relations, provide `with.<relation>.limit` or set `defineSchema(..., { defaults: { defaultLimit } })`. Otherwise, use `allowFullScan` on the parent query.

--- a/www/content/docs/orm/schema/relations.mdx
+++ b/www/content/docs/orm/schema/relations.mdx
@@ -9,7 +9,7 @@ import { InfoIcon, AlertTriangle } from "lucide-react"
 
 Relations in the ORM use the same API as Drizzle for **defining** and **loading** relationships. The `with:` option is type-safe, with a few nested constraints noted below.
 
-Relation loading via `with:` works end-to-end. Nested `with` has a depth limit, and per-relation filters for `many()` relations are applied post-fetch.
+Relation loading via `with:` works end-to-end. Nested `with` loads up to 10 levels deep, and per-relation filters for `many()` relations are applied post-fetch.
 
 Relation loading requires indexes on relation fields (e.g. `posts.userId`). Missing indexes throw unless you opt in with `allowFullScan`. You can use `defineSchema(..., { strict: false })` to downgrade throws to warnings when `allowFullScan` is set.
 
@@ -674,7 +674,7 @@ memory; add that column to the relation index (`index('by_user_rank').on(t.userI
 to keep the read bounded.
 
 <Callout icon={<InfoIcon />}>
-**Note**: `limit`, `orderBy`, and `where` apply to `many()` relations. If `limit` is omitted, configure `defineSchema(..., { defaults: { defaultLimit } })` or use `allowFullScan` on the parent query. Relation loading also fail-fasts when unique lookup keys exceed `defineSchema(..., { defaults: { relationFanOutMaxKeys } })` (default `1000`) unless `allowFullScan` is set. Nested `with:` works with a depth limit to prevent infinite recursion.
+**Note**: `limit`, `orderBy`, and `where` apply to `many()` relations. If `limit` is omitted, configure `defineSchema(..., { defaults: { defaultLimit } })` or use `allowFullScan` on the parent query. Relation loading also fail-fasts when unique lookup keys exceed `defineSchema(..., { defaults: { relationFanOutMaxKeys } })` (default `1000`) unless `allowFullScan` is set. Nested `with:` loads every level it is given, up to 10. A tree with rows still to expand past that throws `RELATION_DEPTH_EXCEEDED` instead of coming back shorter than requested — which is how a `with` object that references itself surfaces.
 </Callout>
 
 ### Column Selection Semantics

--- a/www/public/orm/api-catalog.json
+++ b/www/public/orm/api-catalog.json
@@ -262,7 +262,7 @@
     },
     "nestedLoading": {
       "signature": "{ with: { relation: { with: { nestedRelation: true } } } }",
-      "description": "Load nested relations up to 3 levels deep",
+      "description": "Load nested relations up to 10 levels deep",
       "example": "{ with: { posts: { with: { comments: { with: { author: true } } } } } }",
       "docUrl": "/docs/orm/relations-deep-dive#nested-loading",
       "category": "relations"


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes #391
🧭 Task plan: docs/plans/2026-08-21-391-fix-todocomments-double-reads-via-orm-relation-depth.md
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Relation-depth and read-count regressions | ➖ N/A |
| Verified | 🟢 52 focused tests and full `bun check` | ➖ N/A |

**✅ Outcome**
- Nested `with` loads every requested level up to the ORM ceiling.
- Over-depth plans fail before relation expansion instead of silently truncating or reading the full chain first.
- `_count` resolves at the deepest returned level without a second count pass.
- Comment-tree reads are reduced while the public `maxDepth: 0..10` contract stays intact; relation expansion remains capped at the five-level write limit.

**⚠️ Caveat**
- Self-referential relation configs are capped at 10 levels.
- Per-level relation fan-out remains bounded by its configured `limit`.
- `countDocumentReads` must be installed before ORM construction.

**🏗️ Design**
- `MAX_RELATION_DEPTH` is shared by relation loading and RLS plan preflight.
- Preflight rejects over-depth relation expansion; boundary-only `_count` remains valid.
- The example owns a finite reply tree through `buildRepliesWith` and `MAX_REPLY_DEPTH`.

**🧪 Verified**
- 52 focused relation-depth, comment-tree, and relation-loading tests; no type errors.
- Full `bun check`, including fixture parity and runtime scenarios.
- Published skill sources match installed mirrors; Intent validation is clean.
- Exact-head P1 autoreview clean at 0.90 confidence.
