### PR TITLE
fix(auth-start): resolve Convex token once per request

### DIFF
--- a/.agents/skills/kitcn/references/setup/start.md
+++ b/.agents/skills/kitcn/references/setup/start.md
@@ -34,19 +34,27 @@ export const {
 **Create:** `src/lib/convex/auth-server.ts`
 
 ```ts
+import { api } from "@convex/api";
 import { convexBetterAuthReactStart } from "kitcn/auth/start/server";
 
 export const {
   handler,
   getToken,
+  createCaller,
+  createContext,
   fetchAuthQuery,
   fetchAuthMutation,
   fetchAuthAction,
 } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });
 ```
+
+`getToken` fetches the Convex token from the auth route. `auth.jwtCache: true`
+reads it from the session cookie instead. Leave it off when the browser Convex
+client is primed from `getToken()`.
 
 For client-side route loaders that fetch protected Convex queries through the
 router `queryClient`, prime the shared Convex client in the root `beforeLoad`
@@ -78,7 +86,7 @@ export const Route = createRootRouteWithContext<{
 });
 ```
 
-Use `runServerCall` or `fetchAuthQuery` for server-side loaders. Use
+Use the request-scoped `caller` or `fetchAuthQuery` for server-side loaders. Use
 `syncConvexAuthForStartLoader` only for client/router loaders that execute
 shared `ConvexQueryClient` queries before `ConvexAuthProvider` mounts.
 
@@ -105,42 +113,20 @@ export const Route = createFileRoute("/api/auth/$" as never)({
 **Create:** `src/lib/convex/server.ts`
 
 ```ts
-import { api } from "@convex/api";
-import { getRequestHeaders } from "@tanstack/react-start/server";
-import { createCallerFactory } from "kitcn/server";
+import { createCaller } from "@/lib/convex/auth-server";
 
-import { getToken } from "@/lib/convex/auth-server";
-
-const { createContext, createCaller } = createCallerFactory({
-  api,
-  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
-  auth: {
-    getToken: async () => {
-      return {
-        token: await getToken(),
-      };
-    },
-  },
-});
-
-type ServerCaller = ReturnType<typeof createCaller>;
-
-async function makeContext() {
-  const headers = await getRequestHeaders();
-  return createContext({ headers });
-}
-
-function createServerCaller(): ServerCaller {
-  return createCaller(async () => {
-    return await makeContext();
-  });
-}
-
-export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
-  const caller = createServerCaller();
-  return fn(caller);
-}
+export const caller = createCaller();
 ```
+
+`createCaller()` binds to the current request, so every procedure call in a
+request shares one Convex auth token fetch. The module-scope `caller` holds no
+request state; it resolves the current request on each call. Pass a context
+factory (`createCaller(() => createContext({ headers }))`) only to call Convex
+with headers other than the current request's.
+
+Reach `caller` from a `createServerFn` handler or a server route. A route
+`loader` also runs in the browser on client-side navigation, where there is no
+request scope.
 
 Use the docs pattern from `tanstack-start.mdx` for:
 

--- a/.changeset/eighty-moons-invent.md
+++ b/.changeset/eighty-moons-invent.md
@@ -1,0 +1,72 @@
+---
+"kitcn": minor
+---
+
+## Breaking changes
+
+- Require `api` on `convexBetterAuthReactStart`, which now returns `createCaller`
+  and `createContext` alongside the auth helpers.
+
+```ts
+// Before
+export const { handler, getToken } = convexBetterAuthReactStart({
+  convexUrl: import.meta.env.VITE_CONVEX_URL!,
+  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
+});
+
+// After
+export const { handler, getToken, createCaller, createContext } =
+  convexBetterAuthReactStart({
+    api,
+    convexUrl: import.meta.env.VITE_CONVEX_URL!,
+    convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
+  });
+```
+
+- Drop `runServerCall` from the TanStack Start scaffold. Call procedures on a
+  caller bound once with `createCaller()`.
+
+```ts
+// Before
+export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
+  const caller = createServerCaller();
+  return fn(caller);
+}
+await runServerCall((caller) => caller.user.getSessionUser({}));
+
+// After
+export const caller = createCaller();
+await caller.user.getSessionUser({});
+```
+
+- Move TanStack Start JWT caching under `auth.jwtCache`, a boolean.
+
+```ts
+// Before
+convexBetterAuthReactStart({
+  jwtCache: { enabled: true, isAuthError },
+  // ...
+});
+
+// After
+convexBetterAuthReactStart({
+  auth: { jwtCache: true, isUnauthorized: isAuthError },
+  // ...
+});
+```
+
+## Patches
+
+- Fetch the Convex auth token once per request on TanStack Start. Every
+  procedure call, `getToken()`, and `fetchAuthQuery`/`fetchAuthMutation`/
+  `fetchAuthAction` in a request now share one token, instead of each paying its
+  own round trip.
+- Stop replaying a rejected auth token for the rest of a request. After a
+  refresh, the remaining calls sharing that context use the new token instead of
+  re-failing and re-running non-idempotent mutations and actions.
+- Refresh expired TanStack Start tokens instead of failing. Forced refresh and
+  token freshness now reach the token layer, so a stale token retries once and a
+  fresh one is no longer replayed on an authorization error.
+
+Existing TanStack Start apps: re-run `kitcn add auth --overwrite` to update
+`src/lib/convex/auth-server.ts` and `src/lib/convex/server.ts`.

--- a/docs/plans/387-start-scaffold-per-request-caller-memo.md
+++ b/docs/plans/387-start-scaffold-per-request-caller-memo.md
@@ -46,6 +46,8 @@ Completion threshold:
   request, proven by a bun test that counts token fetches and by a mutation test
   proving the guard is load-bearing; cross-request isolation proven by an
   identity assertion that a module-scope memo fails; repo gates green.
+- PR #401 is open with the task-style body, `Fixes #387`, and this plan named
+  at the PR head.
 - Task closure is legal only when the source-of-truth acceptance criteria are
   satisfied or explicitly narrowed, required verification evidence is recorded,
   code-review and release-artifact gates are closed when applicable, verified
@@ -90,8 +92,8 @@ Boundaries:
   `.changeset/**`.
 - Browser surface: N/A — server-side request/token plumbing, no rendered output
   changes. Proof is the built client bundle, not a rendered page.
-- GitHub issue sync: N/A — user standing preference forbids PRs, so there is no
-  PR to reference; no issue comment posted.
+- GitHub issue sync: PR #401 opened at the user's explicit request; it carries
+  `Fixes #387`, so the issue closes on merge. No separate issue comment.
 - Non-goals: enabling `jwtCache` by default on Start (rejected with evidence,
   see Decisions); unifying `convex/browser` vs `convex/nextjs`; changing Next's
   always-swallow `isUnauthorized` semantics; memoizing inside `createLazyCaller`.
@@ -220,9 +222,9 @@ Start Gates:
 | Release artifact decision | yes | .changeset/eighty-moons-invent.md (minor) |
 | Browser tool decision for browser surface | no | N/A: no browser-rendered output; proof is the built client bundle |
 | Commit / PR expectation decision | partial | commit yes; push/PR N/A by explicit standing user preference |
-| Task-style PR body decision | no | N/A: no PR created |
-| Task-plan PR body evidence | no | N/A: no PR created |
-| GitHub issue sync expectation decision | no | N/A: no PR to reference; no comment posted |
+| Task-style PR body decision | yes | PR #270 emoji task-style body used |
+| Task-plan PR body evidence | yes | Body carries `🧭 Task plan: docs/plans/387-start-scaffold-per-request-caller-memo.md`; plan is at the PR head and names PR #401 |
+| GitHub issue sync expectation decision | yes | `Fixes #387` in the PR body; no separate comment needed |
 | Output budget strategy recorded | yes | see Output budget strategy |
 | Package/API pack selected | yes | --with package-api |
 | Public surface or package boundary identified | yes | `kitcn/auth/start/server` (convexBetterAuthReactStart) and `kitcn/server` retry path |
@@ -283,6 +285,7 @@ Work Checklist:
 - [x] Commit/PR handling recorded for code-changing work: commit and PR
       completed, no local patch, user explicitly declined, or blocker recorded.
       "User did not separately ask for a PR" is not a valid blocker.
+      (commit + push + PR #401 completed after the user requested a PR)
 - [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason (N/A: no PR created)
       recorded, or blocker recorded.
 - [x] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan (N/A: no PR created)
@@ -325,7 +328,7 @@ Completion Gates:
 | Gate | Applies | Required action | Evidence |
 |------|---------|-----------------|----------|
 | Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | all commands under Verification surface run; results under Verification evidence |
-| Exact per-PR task ownership | no | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | N/A: no PR in scope |
+| Exact per-PR task ownership | yes | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | PR #401, this plan |
 | Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | partially valid; pivoted to the library boundary |
 | Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level repro sufficient; higher rungs N/A (no rendered surface) |
 | Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | 3/3 cases reproduced before edits |
@@ -345,12 +348,12 @@ Completion Gates:
 | High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | public API + runtime change; see High-risk note |
 | Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: only the generated kitcn skill mirror changed, from its package source; no hooks/commands/prompts/user-action tooling touched |
 | Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption signals; the two infra flakes were network/link races, resolved by retry |
-| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | committed on issue-387 |
-| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: explicit standing user preference forbids PRs |
-| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR created |
-| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR created |
-| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR and no images |
-| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR to reference; user preference forbids PR creation |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | `8502bfeb` + plan-sync commit on `fix/start-request-scoped-convex-token` |
+| PR create or update | yes | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | `bun check` green across every lane, pushed, PR #401 created |
+| Task-style PR body verified | yes | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | `gh pr view 401 --json body` read back; auto-release block present, no self-link, all required sections present |
+| PR task evidence verified | yes | Verify body plan line, plan at PR head, and exact PR ownership | Plan line present; plan committed at PR head naming PR #401 |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no images; no browser-rendered output changed |
+| GitHub issue sync-back | yes | Post concise issue sync after PR exists, or record N/A/blocker | `Fixes #387` in PR #401 body links and closes the issue on merge |
 | Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | see Final handoff / sync |
 | Final lint | yes | Run `bun lint:fix` or scoped equivalent | bun lint:fix then bun lint: 936 files, clean |
 | Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | one oversized toContain failure dump; assertion narrowed immediately |
@@ -377,7 +380,7 @@ Phase / pass table:
 | Intake and source read | complete | issue + comments fetched; repro built | implementation |
 | Implementation | complete | library memo, scaffold hard cut, retry write-back, docs, changeset | verification |
 | Verification | complete | see Verification evidence | closeout |
-| Commit / PR / GitHub sync | complete | committed locally; PR/issue sync declined by standing user preference | closeout |
+| Commit / PR / GitHub sync | complete | branch renamed to `fix/start-request-scoped-convex-token`, pushed, PR #401 opened with the task-style body | closeout |
 | Closeout | complete | autoreview run; findings resolved | final response |
 
 Findings:
@@ -545,11 +548,12 @@ Task-style PR body contract:
   of that output.
 
 Final handoff / sync:
-- Commit: created locally on `issue-387`.
-- PR: N/A — the user's standing preference is "Do not create PR under any
-  circumstances, unless user prompts to." Explicit user decline, not a blocker.
-  Not pushed for the same reason.
-- Issue: N/A — no PR exists to reference; no comment posted.
+- Commit: `8502bfeb` plus a plan-sync commit, on `fix/start-request-scoped-convex-token`
+  (renamed from `issue-387` before the first push, per the user's branch convention).
+- PR: https://github.com/udecode/kitcn/pull/401 —
+  `fix(auth-start): resolve Convex token once per request`. Opened after the
+  user explicitly requested a PR, which overrode their standing default.
+- Issue: #387 closes on merge via `Fixes #387` in the PR body.
 - Browser proof: N/A — no browser-rendered output changed. Replaced by a built
   client/server bundle audit.
 - Caveats: `jwtCache` deliberately stays off by default on Start; a very

--- a/docs/plans/387-start-scaffold-per-request-caller-memo.md
+++ b/docs/plans/387-start-scaffold-per-request-caller-memo.md
@@ -35,11 +35,11 @@ Task source:
   issue claims)
 
 Timed checkpoint:
-- requested duration: pending
-- semantics: pending
-- initial confidence score: pending
-- improvement loop: pending
-- final score / loop closure: pending
+- requested duration: N/A; none requested
+- semantics: N/A
+- initial confidence score: 95%
+- improvement loop: P1 autoreview, red-green regression, full repo gate
+- final score / loop closure: 98%; P1 review and full repo gate clean
 
 Completion threshold:
 - `kitcn init -t start` + auth apps fetch the Convex auth token at most once per
@@ -209,7 +209,7 @@ Start Gates:
 | Skill analysis before edits | yes | task + autogoal (task template, package-api + docs packs); changeset and autoreview loaded at closeout |
 | Active goal checked or created | yes | this plan, created via create-goal-scratchpad.mjs |
 | Source of truth read before edits | yes | attachment + `gh issue view 387` (body and comments) read before any edit |
-| Exact per-PR task ownership | no | N/A: user standing preference forbids PRs; no PR in scope |
+| Exact per-PR task ownership | yes | This plan owns PR #401 and exists at its exact head |
 | GitHub comments and attachments read | yes | attachment read; `gh issue view 387 --json comments` returned none |
 | Video transcript evidence required | no | N/A: no video or screen recording in the source |
 | Pre-solution issue challenge required | yes | see Pre-solution issue challenge: verdict partially valid |
@@ -221,7 +221,7 @@ Start Gates:
 | Branch decision for code-changing task | yes | already on dedicated branch `issue-387`; not main |
 | Release artifact decision | yes | .changeset/eighty-moons-invent.md (minor) |
 | Browser tool decision for browser surface | no | N/A: no browser-rendered output; proof is the built client bundle |
-| Commit / PR expectation decision | partial | commit yes; push/PR N/A by explicit standing user preference |
+| Commit / PR expectation decision | yes | Autoclosure requires commit, push, exact-head proof, receipt, and merge |
 | Task-style PR body decision | yes | PR #270 emoji task-style body used |
 | Task-plan PR body evidence | yes | Body carries `🧭 Task plan: docs/plans/387-start-scaffold-per-request-caller-memo.md`; plan is at the PR head and names PR #401 |
 | GitHub issue sync expectation decision | yes | `Fixes #387` in the PR body; no separate comment needed |
@@ -249,7 +249,7 @@ Work Checklist:
 - [x] Task source classified with source type, id/link, title, task type,
       acceptance criteria, caveats, likely files/routes/packages, browser
       surface, and root-cause layer.
-- [x] Every GitHub PR in scope has its own task plan. This plan owns one exact (N/A: no PR in scope (user preference forbids PRs))
+- [x] Every GitHub PR in scope has its own task plan. This plan owns PR #401.
       PR, owns a not-yet-created PR slice, or records N/A because no PR is in
       scope; a batch plan is not used as a substitute.
 - [x] Required video or screen-recording evidence is cached/read as normalized (N/A: no video in the source)
@@ -459,6 +459,15 @@ Review fixes:
   It contradicted both the implementation and `AuthOptions.jwtCache`. Removed.
 - Recorded its residual `isFresh` write-back note under Open risks rather than
   patching: it is the documented retry contract, not a defect.
+- Autoclosure P1 review found that `fetchAuth*` replaced the request memo after
+  refresh while an existing caller retained the old token object. The shipped
+  cross-path test failed with three token fetches. `callWithToken` now mutates
+  the shared result, so the caller uses the fresh token without another replay.
+
+Autoclosure feedback ledger:
+| Source | Priority | Rationale | Verdict | Proof | Reply / resolution |
+| --- | --- | --- | --- | --- | --- |
+| local autoreview at PR #401 head `80329e00` | P1 | Existing request callers could replay a mutation or action with a rejected token after a fetch-helper refresh | fixed | red `index.retry.test.ts`: 3 fetches; green: 2 fetches and one caller mutation | local finding; terminal PR receipt records the fix |
 
 Error attempts:
 | Error / failed attempt | Count | Next different move | Resolution |
@@ -474,6 +483,14 @@ Verification evidence:
   `[A] 3 separate runServerCall -> tokenFetches=3`, `[B] 3 calls on one caller
   -> tokenFetches=3`, `[C] 3 getToken() -> tokenFetches=3`.
 - `bun test packages/kitcn/src/auth-start/ packages/kitcn/src/server/` → 189 pass, 0 fail.
+- Cross-path refresh regression: `caller.getToken()` captures the stale shared
+  result, `fetchAuthQuery` refreshes it, then `caller.todos.create` uses the
+  fresh token directly. Red: 3 token fetches. Green: 2 token fetches, one caller
+  mutation, no second replay.
+- Final local P1 autoreview after the fix: clean; patch-correct confidence 0.93.
+- Final `bun lint:fix`, package build, and `bun check`: exit 0. The gate covered
+  lint, typecheck, Bun/Vitest/CLI tests, Concave smoke, all scaffold fixtures,
+  and runtime scenarios.
 - `bun test` (whole repo) → 1297 pass, 0 fail, 146 files.
 - `CI=1 bun test ./packages/kitcn/src/cli/cli.commands.ts` → 124 pass, 0 fail.
 - `bun typecheck` → 5/5 packages. `bun lint` → 936 files, clean.
@@ -509,22 +526,26 @@ Source-listed case matrix:
 | Memo must not leak across requests | derived safety requirement | "SECURITY" test | n/a | alice never sees bob's token | pass; module-scope mutant fails only this test | done |
 
 Final handoff contract:
-- Commit line: pending
-- PR line: pending
-- Issue line: pending
-- Confidence line: pending
+- Commit line: PR #401 contributor commits plus the autoclosure P1 fix
+- PR line: https://github.com/udecode/kitcn/pull/401
+- Issue line: #387 closes through `Fixes #387` on merge
+- Confidence line: 98%
 - Flow table:
-  - Reproduced: tests pending, browser pending
-  - Verified: tests pending, browser pending
-- Browser check: pending
-- Outcome: pending
-- Caveat: pending
+  - Reproduced: token refresh crossed helper/caller paths with 3 token fetches;
+    browser N/A
+  - Verified: 2 token fetches, one caller mutation, full repo gate green;
+    browser N/A
+- Browser check: N/A; server-only token plumbing
+- Outcome: one request-scoped token result is shared and refreshed in place
+- Caveat: `jwtCache` remains opt-in on Start
 - Design:
-  - Chosen boundary: pending
-  - Why not quick patch: pending
-  - Why not broader change: pending
-- Verified: pending
-- PR body verified: pending
+  - Chosen boundary: Start request identity plus a shared mutable token result
+  - Why not quick patch: caller-only memoization leaves helper paths stale
+  - Why not broader change: Next and unrelated auth behavior are outside #387
+- Verified: lint, package build, focused tests, full `bun check`, fixtures, and
+  runtime scenarios pass
+- PR body verified: task plan line, `Fixes #387`, final behavior, and proof are
+  present
 
 Task-style PR body contract:
 - Preserve any existing `<!-- auto-release:start -->` block. If a changeset is

--- a/docs/plans/387-start-scaffold-per-request-caller-memo.md
+++ b/docs/plans/387-start-scaffold-per-request-caller-memo.md
@@ -1,0 +1,616 @@
+# 387 start scaffold per-request caller memo
+
+Objective:
+Give the TanStack Start auth scaffold Next-parity request-scoped auth: one Convex token fetch per request instead of one per procedure call, with proven cross-request isolation.
+
+Goal plan:
+docs/plans/387-start-scaffold-per-request-caller-memo.md
+
+Template:
+docs/plans/templates/task.md
+
+Primary template:
+docs/plans/templates/task.md
+
+Applied packs:
+- package-api (docs/plans/templates/packs/package-api.md)
+- docs (docs/plans/templates/packs/docs.md)
+
+Task source:
+- type: GitHub issue (public bug report with technical diagnosis + suggested fix)
+- id / link: #387 https://github.com/udecode/kitcn/issues/387
+- title: Start scaffold: `runServerCall` builds a fresh caller per call, so K
+  procedure calls cost K token fetches — the Next scaffold caches, Start does not
+- comments: none (verified via `gh issue view 387 --json comments`)
+- acceptance criteria: K procedure calls inside one Start request cost 1 token
+  fetch, not K; Start reaches Next parity; per-request memo must not leak across
+  requests.
+- likely files/packages: `packages/kitcn/src/auth-start/server.ts`,
+  `packages/kitcn/src/cli/registry/items/auth/auth-start-server-call.template.ts`,
+  `packages/kitcn/src/server/lazy-caller.ts`, `fixtures/start-auth/**`,
+  `www/content/docs/tanstack-start.mdx`,
+  `packages/kitcn/skills/kitcn/references/setup/start.md`
+- browser surface: none (server-side request/token plumbing, no rendered output)
+- root-cause layer: library runtime + scaffold template (NOT scaffold-only as the
+  issue claims)
+
+Timed checkpoint:
+- requested duration: pending
+- semantics: pending
+- initial confidence score: pending
+- improvement loop: pending
+- final score / loop closure: pending
+
+Completion threshold:
+- `kitcn init -t start` + auth apps fetch the Convex auth token at most once per
+  request, proven by a bun test that counts token fetches and by a mutation test
+  proving the guard is load-bearing; cross-request isolation proven by an
+  identity assertion that a module-scope memo fails; repo gates green.
+- Task closure is legal only when the source-of-truth acceptance criteria are
+  satisfied or explicitly narrowed, required verification evidence is recorded,
+  code-review and release-artifact gates are closed when applicable, verified
+  code changes are committed and PR'd unless explicitly declined or blocked,
+  task-style PR body sync is complete or marked N/A with reason,
+  GitHub issue/PR sync is complete or marked N/A with reason, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/387-start-scaffold-per-request-caller-memo.md` passes.
+
+Verification surface:
+- `bun test packages/kitcn/src/auth-start/ packages/kitcn/src/server/` (189 pass)
+- `bun test` full suite (1297 pass, 0 fail)
+- `CI=1 bun test ./packages/kitcn/src/cli/cli.commands.ts` (124 pass)
+- `bun typecheck` (5/5 packages), `bun lint` (936 files, clean)
+- `bun run fixtures:check` (8/8 fixtures match)
+- Real client-bundle proof: `bun run scenario:prepare start-auth` then
+  `bun run build` in `tmp/scenarios/start-auth/project`
+- Mutation tests killing each new guard (recorded under Verification evidence)
+
+Constraints:
+- Preserve existing user-facing behavior outside the task scope.
+- Prefer the durable ownership boundary over caller-by-caller patches.
+- When a GitHub PR is in scope, this plan owns exactly one PR. A coordinating
+  batch plan must link a separate task plan for every PR an agent processes.
+- Verified code changes must be committed and PR'd because the task skill
+  requires that path unless the user explicitly says not to, the work has no
+  local patch, or a real blocker is recorded.
+- The absence of a separate "open a PR" sentence from the user is not a valid
+  N/A reason for verified code-changing task work.
+- A PR created by this task must use the PR #270 emoji task-style PR body
+  contract below, not a generic summary/body from a git helper skill.
+- A task-run PR body must include
+  `🧭 Task plan: docs/plans/<plan>.md`; the plan must exist at the PR head and
+  identify the exact PR before autoclosure.
+- Do not add broad ceremony when the task is trivial or docs-only.
+
+Boundaries:
+- Source of truth: GitHub issue #387.
+- Allowed edit scope: `packages/kitcn/src/auth-start/**`,
+  `packages/kitcn/src/server/caller-factory*`, Start auth scaffold templates and
+  their CLI assertions, `fixtures/start-auth/**` (generated), Start docs in
+  `www/**` + `packages/kitcn/skills/kitcn/**`, `tooling/test-setup.ts`,
+  `.changeset/**`.
+- Browser surface: N/A — server-side request/token plumbing, no rendered output
+  changes. Proof is the built client bundle, not a rendered page.
+- GitHub issue sync: N/A — user standing preference forbids PRs, so there is no
+  PR to reference; no issue comment posted.
+- Non-goals: enabling `jwtCache` by default on Start (rejected with evidence,
+  see Decisions); unifying `convex/browser` vs `convex/nextjs`; changing Next's
+  always-swallow `isUnauthorized` semantics; memoizing inside `createLazyCaller`.
+
+Output budget strategy:
+- Workflow agent reports written to `/tmp/wf387-reports.md` and
+  `/tmp/wf387-challenges.md` and read in bounded slices, never streamed whole.
+- Test runs filtered through `tail`/`grep` to pass/fail summaries.
+- One accidental large output: a `toContain` failure dumped the whole source
+  file; assertion narrowed immediately after.
+
+Blocked condition:
+- None encountered. `fixtures:check` infra flakes (shadcn clone reset, bun
+  `cssesc` link EEXIST) were retried to a clean pass rather than treated as
+  blockers.
+
+Task state:
+- task_type: bug (library runtime + scaffold)
+- task_complexity: non-trivial
+- current_phase: closeout
+- current_phase_status: complete
+- next_phase: final response
+- goal_status: complete
+
+Current verdict:
+- verdict: fixed
+- confidence: 95-100%
+- next owner: task
+- reason: every source-listed case has a passing test, each new guard is
+  mutation-proven, and the runtime claim is verified against a real built
+  client/server bundle.
+
+Implementation readiness:
+- verdict: ready (after pivot from the issue's suggested fix)
+- exact owner: `packages/kitcn/src/auth-start/server.ts` (library), with a
+  shared-retry correction in `packages/kitcn/src/server/caller-factory.ts`.
+- contradiction status: resolved. The issue says "scaffold parity gap, not a
+  library runtime defect"; the repro proves the opposite. Settled by building
+  the harness and reading React's own `cache` implementation.
+- source-listed cases complete: yes (see case matrix)
+
+Pre-solution issue challenge:
+- reporter claim (falsifiable): "In a TanStack Start app scaffolded by
+  `kitcn init -t start` + auth, K procedure calls in one request perform K
+  Convex auth-token fetches; the Next scaffold performs 1."
+- suggested diagnosis: `runServerCall` calls `createServerCaller()` per call, so
+  the caller (and its context) is rebuilt each time.
+- suggested fix: memoize the request context; Start has no React `cache()`
+  equivalent so use a Start-appropriate per-request mechanism.
+- repro ladder:
+  - tests / source-level repro: DONE. `bun test` scratch harness reproducing the
+    exact two scaffold templates. Results:
+    `[A] 3 separate runServerCall -> tokenFetches=3 convexFetches=3`
+    `[B] 1 runServerCall, 3 procedure calls on ONE caller -> tokenFetches=3`
+    `[C] 3 direct getToken() -> tokenFetches=3`
+  - repo-owned automated browser or integration proof: N/A — server-side token
+    plumbing has no browser-observable surface; the bun test harness is the
+    honest lowest layer.
+  - Browser plugin: N/A — no browser-rendered output changes.
+  - screenshot / visual proof: N/A — no visual output.
+- reproduction verdict: valid — symptom reproduced exactly.
+- validity verdict: **partially valid**. The symptom and the impact are real. The
+  reporter's *diagnosis is incomplete* and the *suggested fix is insufficient*:
+  1. Case [B] proves that building the caller once does NOT fix it.
+     `packages/kitcn/src/server/lazy-caller.ts:92` calls `createContext()` on
+     EVERY procedure invocation, so a single shared caller still costs K token
+     fetches. The memo must live on the context function, not the caller.
+  2. Case [C] proves a defect the issue never mentions:
+     `packages/kitcn/src/auth-start/server.ts:26-30` memoizes `getToken` with
+     `React.cache`, but React `cache()` is a **pass-through outside an RSC
+     request scope**, and TanStack Start SSR is not RSC. Verified empirically on
+     react 19.2.4: `Promise.all([f(o), f(o), f(o)])` => 3 executions. So
+     `convexBetterAuthReactStart`'s advertised caching is a no-op in the only
+     framework it exists for, and `fetchAuthQuery`/`Mutation`/`Action` pay it too.
+  3. The issue's open question about `jwtCache` resolves to a real gap: the Start
+     scaffold passes no `jwtCache`, so `packages/kitcn/src/auth/internal/token.ts:38`
+     always network-fetches, while `packages/kitcn/src/auth-nextjs/index.ts:108`
+     defaults it on (`jwtCache !== false`).
+  4. Separate latent defect found while reading: the scaffold adapts `getToken`
+     to `async () => ({ token: await getToken() })`, dropping `isFresh` and the
+     `(siteUrl, headers, opts)` signature, so `forceRefresh` from
+     `caller-factory.ts:168` cannot reach the token layer — the expired-token
+     retry path is dead on Start.
+- best long-term fix boundary: TanStack Start already runs every request inside
+  an `AsyncLocalStorage<{h3Event}>` (`@tanstack/start-server-core`
+  `dist/esm/request-response.js:6,42` — `requestHandler()` enters the store) and
+  exports `getRequest(): Request` (`request-response.d.ts:8`), whose identity is
+  stable for the request. That makes a `WeakMap` keyed on the request object a
+  correct, dependency-free, request-isolated memo. Ownership belongs in
+  `packages/kitcn/src/auth-start/server.ts` (library), not in the scaffold
+  template, so hand-written Start callers get the fix too.
+- harsh honest feedback: the issue's framing ("This is a scaffold parity gap, not
+  a library runtime defect") is wrong. It is primarily a library runtime defect —
+  `React.cache` in `auth-start/server.ts` never worked. Fixing only the scaffold
+  as suggested would leave both case [B] and case [C] broken.
+- hard-stop decision: proceed — reproduced and valid; pivot from the suggested
+  scaffold-only patch to the library ownership fix.
+
+Completion rule:
+- Do not call `update_goal(status: complete)` while any required checklist item
+  remains unchecked. If an item does not apply, check it and add `N/A: <reason>`.
+- Do not call `update_goal(status: complete)` until every completion threshold
+  above is satisfied, final handoff evidence is recorded, and
+  `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/387-start-scaffold-per-request-caller-memo.md` passes.
+- Do not create hook state for this goal. This file plus the active goal are the
+  durable state.
+
+Start Gates:
+| Gate | Applies | Evidence |
+|------|---------|----------|
+| Timed checkpoint parsed | no | N/A: no duration requested |
+| Walkthrough baseline for possible UI change | no | N/A: server-side token plumbing; no UI or rendered output can change |
+| Skill analysis before edits | yes | task + autogoal (task template, package-api + docs packs); changeset and autoreview loaded at closeout |
+| Active goal checked or created | yes | this plan, created via create-goal-scratchpad.mjs |
+| Source of truth read before edits | yes | attachment + `gh issue view 387` (body and comments) read before any edit |
+| Exact per-PR task ownership | no | N/A: user standing preference forbids PRs; no PR in scope |
+| GitHub comments and attachments read | yes | attachment read; `gh issue view 387 --json comments` returned none |
+| Video transcript evidence required | no | N/A: no video or screen recording in the source |
+| Pre-solution issue challenge required | yes | see Pre-solution issue challenge: verdict partially valid |
+| Reproduction verdict before implementation | yes | reproduced 3/3 source cases before any edit |
+| Repro escalation ladder selected | yes | source-level bun test harness; browser/native rungs N/A (no rendered output) |
+| Suggested fix reviewed against durable boundary | yes | suggested scaffold-only fix rejected; case [B] proves it insufficient |
+| `docs/solutions` checked for non-trivial existing-code work | yes | found and updated start-loader-auth-must-prime-convex-query-client-before-provider-20260519.md |
+| TDD decision before behavior change or bug fix | yes | repro-first, then shipped tests; each guard mutation-proven |
+| Branch decision for code-changing task | yes | already on dedicated branch `issue-387`; not main |
+| Release artifact decision | yes | .changeset/eighty-moons-invent.md (minor) |
+| Browser tool decision for browser surface | no | N/A: no browser-rendered output; proof is the built client bundle |
+| Commit / PR expectation decision | partial | commit yes; push/PR N/A by explicit standing user preference |
+| Task-style PR body decision | no | N/A: no PR created |
+| Task-plan PR body evidence | no | N/A: no PR created |
+| GitHub issue sync expectation decision | no | N/A: no PR to reference; no comment posted |
+| Output budget strategy recorded | yes | see Output budget strategy |
+| Package/API pack selected | yes | --with package-api |
+| Public surface or package boundary identified | yes | `kitcn/auth/start/server` (convexBetterAuthReactStart) and `kitcn/server` retry path |
+| Convex entry/import graph impact identified | yes | none: nothing under convex/** imports kitcn/auth/start/server; kitcn/server gained no import |
+| CLI/scaffold/generated impact identified | yes | both Start auth templates, their CLI assertions, and fixtures/start-auth |
+| Release artifact path selected | yes | .changeset |
+| `changeset` skill loaded when `.changeset` is required | yes | .agents/rules/changeset.mdc read before writing |
+| Package build / fixture impact decision recorded | yes | bun --cwd packages/kitcn build + fixtures sync/check required and run |
+| Docs pack selected | yes | --with docs (supporting surface) |
+| Docs guidance loaded | yes | doc-guidelines / no-changelog-voice rule from AGENTS.md |
+| Docs lane selected | yes | supporting: Start setup docs + mirrored kitcn skill |
+| Target docs and nearest sibling docs read | yes | tanstack-start.mdx, migrations/auth.mdx, skills setup/start.md, nextjs sibling for parity |
+| Docs style doctrine read | yes | current-state reference voice; no migration/changelog narrative in www |
+| Documented source owner identified | yes | convexBetterAuthReactStart in packages/kitcn/src/auth-start/server.ts |
+
+Work Checklist:
+- [x] If a duration was requested, it is recorded as minimum active work unless (N/A: no duration requested)
+      explicitly marked hard stop; when no better metric exists, initial and
+      final confidence scores are recorded.
+- [x] Objective includes outcome, completion threshold, verification surface,
+      constraints, boundaries, and blocked condition.
+- [x] Task source classified with source type, id/link, title, task type,
+      acceptance criteria, caveats, likely files/routes/packages, browser
+      surface, and root-cause layer.
+- [x] Every GitHub PR in scope has its own task plan. This plan owns one exact (N/A: no PR in scope (user preference forbids PRs))
+      PR, owns a not-yet-created PR slice, or records N/A because no PR is in
+      scope; a batch plan is not used as a substitute.
+- [x] Required video or screen-recording evidence is cached/read as normalized (N/A: no video in the source)
+      `<video-transcripts>` XML, or marked N/A with reason.
+- [x] For public GitHub bug reports, behavior claims, technical diagnoses, or
+      suggested fixes, reporter claims are challenged before implementation
+      with a recorded verdict: `valid`, `not reproduced`, `invalid`,
+      `wont-fix`, `partially valid`, or `platform limitation`. Feature, docs,
+      support, or cleanup requests with no bug claim may mark reproduction
+      `N/A` with reason.
+- [x] Repro escalation ladder followed for bug/behavior claims: focused
+      test/source-level repro first when applicable; existing repo-owned
+      automated browser or integration proof next when available and useful as
+      executable coverage; the repo-approved Browser tool next when tests or
+      automation cannot reproduce or cannot model the surface honestly;
+      screenshot or explicit visual-proof waiver when visual/native state
+      matters.
+- [x] Hard-stop rule followed for bug/behavior claims: no code when the issue
+      is not reproduced, invalid, or won't-fix; partial validity pivots to the
+      best long-term fix and records what was wrong or incomplete in the
+      issue's proposed path.
+- [x] Nearby repo instructions and implementation patterns read before edits.
+- [x] Source-listed case matrix is complete and every contradiction has an
+      owner, harness, and verdict before mutation.
+- [x] Readiness is classified `ready`, `repair-source`, `major`, `blocked`, or
+      `invalid` with evidence.
+- [x] Implementation fixes the right ownership boundary, or the narrower choice
+      is recorded with reason.
+- [x] Release artifact requirement recorded: active changeset, new changeset, or
+      N/A with reason.
+- [x] Final handoff shape decided: bug/feature/testing/batch/review/GitHub
+      requirements, PR body sync, and issue sync when applicable.
+- [x] Commit/PR handling recorded for code-changing work: commit and PR
+      completed, no local patch, user explicitly declined, or blocker recorded.
+      "User did not separately ask for a PR" is not a valid blocker.
+- [x] PR body shape recorded: PR #270 emoji task-style body used, N/A reason (N/A: no PR created)
+      recorded, or blocker recorded.
+- [x] PR task evidence recorded: body includes `🧭 Task plan: ...`, the plan (N/A: no PR created)
+      exists at the PR head, and it identifies the exact PR before autoclosure.
+- [x] Branch handling recorded for code-changing work: dedicated branch used,
+      new branch needed, or N/A with reason.
+- [x] Local-env-rot retry policy recorded for any surprising repo-wide failure: (N/A: no corruption signals; infra flakes were network/link races)
+      reinstall/rerun evidence or N/A with reason.
+- [x] Workspace authority recorded: every proof command names the cwd/tool that
+      owns the changed behavior.
+- [x] Output budget discipline recorded and followed: broad searches are
+      scoped, capped, counted, or artifacted instead of streamed into goal
+      context.
+- [x] High-risk note recorded for public API, runtime, package-boundary,
+      browser behavior, agent-action, or command-contract changes, or marked
+      N/A with reason.
+- [x] Review/autoreview target selected from actual diff state for non-trivial
+      implementation work, or marked N/A with reason.
+- [x] Agent-native review decision recorded for `.agents/**`, `.claude/**`, (N/A: only the generated kitcn skill mirror changed, from its package source)
+      `.codex/**`, skills, hooks, commands, prompts, or user-action tooling.
+- [x] Package/API pack: public API, package boundary, export, and release-artifact impact are recorded.
+- [x] Package/API pack: release artifact matrix is applied: `.changeset` or explicit no-artifact reason.
+- [x] Package/API pack: `.changeset` work loads `changeset` and follows its package/version/prose rules.
+- [x] Package/API pack: no-artifact decisions state why the diff has no published package user-visible delta from `main`. (N/A: a changeset was added)
+- [x] Package/API pack: compatibility, migration, or hard-cut decision is explicit when public shape changes.
+- [x] Package/API pack: affected Convex static import graphs stay narrow and
+      plugin/per-module boundaries are used where appropriate.
+- [x] Package/API pack: CLI commands remain deterministic, `--json` capable, (N/A: no CLI command contract changed)
+      and non-interactive with explicit confirmation bypass when relevant.
+- [x] Package/API pack: docs and `packages/kitcn/skills/kitcn/**` stay
+      current-state synchronized when public guidance changes.
+- [x] Package/API pack: package-owned typecheck/build/test proof is recorded or marked N/A with reason.
+- [x] Package/API pack: `packages/kitcn` build, fixture sync/check, or other owning package proof is recorded when required.
+- [x] Docs pack: docs lane, target docs, nearest sibling docs, and source owner are recorded.
+- [x] Docs pack: every named API, import, option, route, component, transform, demo, and preview is source-backed or marked N/A with reason.
+- [x] Docs pack: docs use current-state reference voice, not changelog voice.
+- [x] Docs pack: links, anchors, and previews target real leaf pages or are marked N/A with reason. (N/A: no links, anchors, or previews added)
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+|------|---------|-----------------|----------|
+| Named verification threshold | yes | Run the command, proof, source audit, or artifact check named in this plan | all commands under Verification surface run; results under Verification evidence |
+| Exact per-PR task ownership | no | Record the exact PR and dedicated plan, or the not-yet-created single-PR slice | N/A: no PR in scope |
+| Pre-solution issue challenge verdict | yes | Record reporter claim, suggested fix, repro verdict, validity verdict, durable boundary, and hard-stop/pivot decision before implementation | partially valid; pivoted to the library boundary |
+| Repro escalation ladder | yes | For bug/behavior claims, record test/source-level, automated browser/integration, Browser, and screenshot/visual-proof outcomes or N/A/blocker reasons before `not reproduced` | source-level repro sufficient; higher rungs N/A (no rendered surface) |
+| Bug reproduced before fix | yes | Record failing test/repro or N/A with reason | 3/3 cases reproduced before edits |
+| Targeted behavior verification | yes | Run focused test/proof for changed behavior or record N/A | 189 pass across auth-start + server; 4 mutation tests kill each guard |
+| TypeScript or typed config changed | yes | Run relevant typecheck | bun typecheck 5/5 packages |
+| Package exports or file layout changed | no | Run the relevant package build before final verification and keep generated updates | N/A: no export-map change; ran bun --cwd packages/kitcn build anyway |
+| Package manifests, lockfile, or install graph changed | no | Run `bun install` and relevant package checks | N/A: no manifest or lockfile change |
+| Agent rules or skills changed | yes | Run `bun install` and verify generated skill sync | packages/kitcn/skills/kitcn edited; regenerated .agents mirror via sync-kitcn-skill.ts; intent:validate + intent:stale clean |
+| Workspace authority proof | yes | Run verification in the owning repo/package/app/route/tool and record cwd; do not count the wrong workspace as proof | repo root for tests/typecheck/lint/fixtures; tmp/scenarios/start-auth/project for the bundle build |
+| Browser surface changed | no | Capture Browser Use proof or record explicit waiver/blocker | N/A: no browser-rendered output |
+| Browser final proof | no | Attach screenshot or exact browser verification caveat when browser proof applies | N/A: replaced by a built client/server bundle audit |
+| UI walkthrough | no | If UI or rendered output changed, run `.agents/skills/walkthrough/SKILL.md` after final proof and show annotated images in the final handoff; otherwise record N/A | N/A: no UI or rendered output changed |
+| Scaffold or fixture output changed | yes | Run `bun run fixtures:sync` and `bun run fixtures:check`, or record N/A | fixtures:sync then fixtures:check: 8/8 fixtures match |
+| Package behavior or public API changed | yes | Add a changeset or record why no changeset applies | .changeset/eighty-moons-invent.md (minor, with Before/After per breaking change) |
+| Docs and kitcn skill sync changed | yes | Keep `www/**` and `packages/kitcn/skills/kitcn/**` in sync, or record N/A | www + packages/kitcn/skills/kitcn edited together; .agents mirror regenerated |
+| Docs or content changed | yes | For docs-heavy work, use `--template docs`; for incidental docs, verify source-backed claims, links, examples, and rendered output or record N/A | source-backed against the new API; Callout type="warn" verified valid in fumadocs-ui |
+| High-risk mini gate | yes | For public API/runtime/package-boundary/browser/agent-action/command-contract changes, record realistic failure mode, proof plan, and why the chosen boundary is right; otherwise N/A | public API + runtime change; see High-risk note |
+| Agent-native review for agent/tooling changes | no | For `.agents/**`, `.claude/**`, `.codex/**`, skills, hooks, commands, prompts, or user-action tooling, load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted/actionable findings, or record N/A | N/A: only the generated kitcn skill mirror changed, from its package source; no hooks/commands/prompts/user-action tooling touched |
+| Local install corruption suspected | no | Run `bun install` once, rerun the exact failing command, or record N/A | N/A: no corruption signals; the two infra flakes were network/link races, resolved by retry |
+| Commit created | yes | For verified code-changing work, stage the entire current checkout per repo policy and create a commit; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | committed on issue-387 |
+| PR create or update | no | For verified code-changing work, run `check`, push, create or update the PR, and sync PR body to the task-style final handoff; N/A only for no local patch, explicit user decline, analytical/blocked/inconclusive work, or recorded external blocker | N/A: explicit standing user preference forbids PRs |
+| Task-style PR body verified | no | Verify the PR body with `gh pr view --json body`; it must preserve auto-release blocks when applicable, must not include a current-PR self-link, and must use the PR #270 emoji format: `🐛 Fixes ...`, `🟢 95-100% confidence`, `Phase / 🧪 Tests / 🌐 Browser` table, and bold emoji Outcome/Caveat/Design/Verified sections | N/A: no PR created |
+| PR task evidence verified | no | Verify body plan line, plan at PR head, and exact PR ownership | N/A: no PR created |
+| PR proof image hosting | no | If PR body needs browser proof, replace local image paths with hosted GitHub URLs or record N/A | N/A: no PR and no images |
+| GitHub issue sync-back | no | Post concise issue sync after PR exists, or record N/A/blocker | N/A: no PR to reference; user preference forbids PR creation |
+| Final handoff contract | yes | Fill the final handoff fields below with exact PR/issue/confidence/tests/browser/outcome/caveats/design/verification content or N/A reason | see Final handoff / sync |
+| Final lint | yes | Run `bun lint:fix` or scoped equivalent | bun lint:fix then bun lint: 936 files, clean |
+| Output budget discipline | yes | Verify no unbounded high-volume command output was streamed, or record the accidental output and recovery | one oversized toContain failure dump; assertion narrowed immediately |
+| Timed checkpoint | no | If duration was requested, keep improving until elapsed, then finish the current loop cleanly; otherwise N/A | N/A: no duration requested |
+| Autoreview for non-trivial implementation changes | yes | Load `.agents/skills/autoreview/SKILL.md`; use dirty local `--mode local`, branch/PR `--mode branch --base <base>`, or committed slice `--mode commit --commit <ref>` until no accepted/actionable findings, or record N/A for docs-only/trivial/no local patch | --mode local --engine claude: clean, no accepted/actionable findings; its one sub-threshold doc finding applied |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/387-start-scaffold-per-request-caller-memo.md` | check-complete.mjs run at closeout |
+| Public API / package boundary proof | yes | Source-audit public API, exports, and package boundary impact | convexBetterAuthReactStart surface audited; kitcn/server barrel unchanged |
+| Convex bundle/import proof | yes | Audit affected function-entry static graphs or record N/A | no convex/** entry imports kitcn/auth/start/server; kitcn/server gained no import |
+| CLI/scaffold/generated proof | yes | Prove command contract and regenerate owned output or record N/A | test:cli 124 pass; fixtures:check 8/8; scenario build of the generated app succeeds |
+| Release artifact classification | yes | Record whether the change is published package behavior/API/types/config/runtime or no published user-visible delta | published package API + runtime behavior change |
+| Published package changeset | yes | If published package users see a delta, load `changeset` and add/update one `.changeset/*.md` per package | .changeset/eighty-moons-invent.md |
+| No release artifact | no | If no artifact is needed, record the exact reason: internal-only, docs-only, agent-only, test-only, or no user-visible delta from `main` | N/A: a changeset was added |
+| Package typecheck/build/test | yes | Run owning package checks or record N/A with reason | bun --cwd packages/kitcn build; bun typecheck; bun test 1297 pass |
+| Fixture/scaffold generation | yes | Run `bun run fixtures:sync` and `bun run fixtures:check` when scaffold output changed, otherwise N/A | fixtures:sync + fixtures:check clean |
+| Docs/package skill sync | yes | Synchronize current-state public guidance or record N/A | skill mirror regenerated; intent:validate + intent:stale clean |
+| Docs source-backed claim audit | yes | Verify docs claims against current source or record N/A | every snippet matches the emitted template and the fixture byte-for-byte |
+| Docs links / routes / previews | no | Verify leaf links, routes, anchors, and preview names or record N/A | N/A: no links, routes, or previews added |
+| Docs MDX/content parser | yes | Run the relevant `www` docs parser/build for MDX/content changes, or record N/A | Callout type="warn" confirmed a valid CalloutType in fumadocs-ui |
+| Kitcn docs sync | yes | If `www/**` changed, update matching `packages/kitcn/skills/kitcn/**` content or record N/A | www/** and packages/kitcn/skills/kitcn/** changed in the same diff |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+|-------|--------|----------|------|
+| Intake and source read | complete | issue + comments fetched; repro built | implementation |
+| Implementation | complete | library memo, scaffold hard cut, retry write-back, docs, changeset | verification |
+| Verification | complete | see Verification evidence | closeout |
+| Commit / PR / GitHub sync | complete | committed locally; PR/issue sync declined by standing user preference | closeout |
+| Closeout | complete | autoreview run; findings resolved | final response |
+
+Findings:
+- React `cache()` is a **pass-through outside an RSC render**, so the memo in
+  `auth-start/server.ts` never worked. React's default build (`react/cjs/react.development.js`)
+  ships `cache` as a hardcoded identity wrapper with no dispatcher at all;
+  the `react-server` build checks a dispatcher that only a live Flight render
+  sets. TanStack Start resolves the default build.
+- `createLazyCaller` calls `createContext()` on **every** procedure invocation
+  (`lazy-caller.ts:92`), so the issue's suggested fix (build the caller once)
+  would not have fixed anything. The memo must live on the context function.
+- TanStack Start runs every request inside an `AsyncLocalStorage`
+  (`@tanstack/start-server-core` `request-response.js`, `requestHandler` →
+  `eventStorage.run({h3Event}, ...)`) and exports `getRequest(): Request`, whose
+  identity is stable per request and distinct across requests. That is a sound,
+  dependency-free `WeakMap` key.
+- `getRequestHeaders()` is **not** identity-stable within a request. srvx serves
+  a lazy header view until anything materializes the native Request, then swaps
+  in that Request's `Headers` and drops the old one
+  (`srvx/dist/adapters/node.mjs:230-232,281`); `start-server-core`'s
+  server-function handler calls `await request.formData()`. An adversarial probe
+  against a real `node:http` + srvx server saw the swap on 8 of 24 requests.
+- The Start scaffold's `getToken` adapter dropped `isFresh`, which made
+  `canRefreshToken` always true (`caller-factory.ts:153`) — so a legitimate
+  `UNAUTHORIZED` from `requireAuth` re-ran the procedure, double-executing
+  non-idempotent mutations and actions.
+- `callWithTokenAndRetry` never wrote the refreshed token back into the shared
+  `tokenResult`, so any memoized context replays the rejected token on every
+  later call. Latent on Next today; my memo would have made it reachable on
+  Start.
+- `tooling/test-setup.ts` left `import('@testing-library/react')` floating, so
+  Testing Library's module-scope `beforeAll` could land inside a running test.
+  Reproduced at ~1 run in 5 once the auth-start suite grew.
+
+Decisions and tradeoffs:
+- **Ownership: the library, not the scaffold.** `kitcn/auth/start/server` owns
+  request scoping because it is the only layer that knows what a Start request
+  is. A scaffold-owned memo is a correctness invariant every app would have to
+  reimplement, and getting it wrong is invisible — a module-scope memo scores
+  *better* on every dedupe metric while serving one user's token to another.
+- **Not `kitcn/server`.** That barrel is statically imported by Convex function
+  entries, which run in a V8 isolate with no Node builtins and no dynamic
+  imports. Start request-scope code there is a push-time failure.
+- **Keep both scaffold files.** `auth-server.ts` is Start's analogue of Next's
+  `server.ts` (the factory); `server.ts` is Start's analogue of Next's
+  `rsc.tsx` (the request-bound caller). Preserves the documented import paths
+  and mirrors Next's structure.
+- **Hard-cut `runServerCall`.** With a request-scoped caller, a callback that
+  receives a caller has no reason to exist. No alias, no shim (repo doctrine).
+- **Rejected: `jwtCache` on by default** (the issue's open question). Two
+  independent adversarial reviews found it is a separate parity gap that (a)
+  ships an untested cookie path whose name depends on `cookiePrefix`, and (b)
+  regresses the browser: `syncConvexAuthForStartLoader` captures the token
+  string for the socket's lifetime, and a cookie JWT can be ~61s from expiry
+  and cannot be renewed from that callback. Answer recorded: not by default.
+  The option is exposed as `auth.jwtCache` with the hazard documented.
+- **Rejected: memoizing inside `createLazyCaller`.** The Start caller is
+  module-scope and outlives requests, so a caller-level memo is exactly the
+  cross-user leak. Context-per-invocation is the right contract there.
+- **Accepted asymmetry:** Start passes `isUnauthorized: auth.isUnauthorized`
+  (undefined unless opted in) rather than Next's
+  `?? defaultIsUnauthorized`, which makes Next always swallow UNAUTHORIZED to
+  null. Preserving Start's current throw behavior beats importing a Next quirk;
+  reconciling Next is out of scope.
+- **Fixed the shared retry write-back** even though it is a pre-existing Next
+  bug, because exposing `auth.jwtCache` would otherwise ship a footgun with it.
+
+Implementation notes:
+- None yet.
+
+Review fixes:
+- Autoreview (`--mode local --engine claude`, `claude-fable-5`): clean, no
+  accepted/actionable P0 findings; verdict "patch is correct (0.78)".
+- Applied its one sub-threshold finding: the `auth` option JSDoc still claimed
+  "JWT caching is enabled by default", left over from the reverted default flip.
+  It contradicted both the implementation and `AuthOptions.jwtCache`. Removed.
+- Recorded its residual `isFresh` write-back note under Open risks rather than
+  patching: it is the documented retry contract, not a defect.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+|------------------------|-------|---------------------|------------|
+| `auth-start` suite failed ~1 run in 5 with Testing Library `beforeAll() inside a test` | ~4 | Check whether `main` flakes the same way before touching product code | Baseline was 10/10 clean, so the flake was mine to fix: `tooling/test-setup.ts` left `import('@testing-library/react')` floating and it could resolve mid-test. Awaited it. 12/12 clean after. |
+| `bun test packages/kitcn/src/auth-start/` failed with `Export named 'getRequest' not found` only in directory runs | 1 | Suspect `mock.module` cross-file pollution, not the real module | `index.retry.test.ts` mocked `@tanstack/react-start/server` with only `getRequestHeaders`; updated its mock to the new module surface. |
+| Header-churn regression test passed against a deliberately broken mutant | 1 | Reorder the test so the context is built *after* the swap | Rewrote it to resolve the ambient token first; mutant now dies with `Expected: 1 Received: 2`. |
+| `fixtures:check` aborted: shadcn clone `Connection reset by peer`, then bun `Failed to link cssesc: EEXIST` | 2 | Retry rather than fall back; these are network/link races, not drift | Third run clean: 8/8 fixtures match. |
+| Full `bun test` reported `1294 pass / 1 fail` once, running 1295 of 1297 tests | 1 | Try to reproduce before dismissing; compare against baseline | Not reproduced in 11 consecutive full runs afterwards; `main` baseline also 6/6 clean. Two tests not running (rather than an assertion failing) points at a module-load/mock-registry hiccup. Recorded as unreproduced, not claimed as fixed. |
+
+Verification evidence:
+- Pre-fix repro (scratch harness, since replaced by shipped tests):
+  `[A] 3 separate runServerCall -> tokenFetches=3`, `[B] 3 calls on one caller
+  -> tokenFetches=3`, `[C] 3 getToken() -> tokenFetches=3`.
+- `bun test packages/kitcn/src/auth-start/ packages/kitcn/src/server/` → 189 pass, 0 fail.
+- `bun test` (whole repo) → 1297 pass, 0 fail, 146 files.
+- `CI=1 bun test ./packages/kitcn/src/cli/cli.commands.ts` → 124 pass, 0 fail.
+- `bun typecheck` → 5/5 packages. `bun lint` → 936 files, clean.
+- `bun run fixtures:check` → all 8 fixtures match fresh scaffold output.
+  (Two infra flakes first: shadcn clone connection reset, then a bun
+  `cssesc` link EEXIST. Retried to a clean pass; neither touched repo code.)
+- Client-bundle proof, cwd `tmp/scenarios/start-auth/project` after
+  `bun run scenario:prepare start-auth`: `bun run build` succeeded (client +
+  SSR). Client bundle contains 0 files matching `node:async_hooks`,
+  `async_hooks`, `convex/nextjs`, `getRequest`, `convexBetterAuthReactStart`,
+  `createCallerFactory`; server bundle contains `getRequest` and `createCaller`.
+  This is the gate that `scenario:check start-auth` does not cover.
+- Mutation tests (each new guard proven load-bearing):
+  | Mutation | Expected kill | Result |
+  | --- | --- | --- |
+  | Disable the per-request memo entirely | dedupe tests fail | 4 of 6 failed |
+  | Module-scope memo key (cross-user leak) | SECURITY test fails | only the identity test failed — dedupe counts all passed, confirming a count-only suite cannot catch the leak |
+  | Compare the live `request.headers` accessor instead of the snapshot | churn test fails | `Expected: 1  Received: 2` |
+  | Remove the retry token write-back | reuse test fails | `Expected: 4  Received: 6` |
+- Harness flake fix verified: auth-start suite 12/12 clean runs after awaiting
+  the Testing Library import (was ~1 failure in 5 before; `main` baseline was
+  10/10 clean, so the flake was introduced by suite growth, not pre-existing
+  redness).
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| K calls cost K token fetches | issue title/summary | `server.request-scope.test.ts` "K procedure calls in one request cost 1 token fetch" | 3 fetches for 3 calls | 1 | pass; memo-disabled mutant fails | done |
+| Next caches, Start does not | issue summary | same file, concurrent + shared-surface tests | Start had no working memo | 1 fetch shared by caller, `getToken()`, `fetchAuth*` | pass | done |
+| Fix = build the caller once | issue suggested fix | repro case [B] | 3 calls on ONE caller still cost 3 fetches | n/a — claim disproven | recorded in Findings | rejected |
+| Start has no React `cache()` equivalent | issue root cause | React source read + execution probe | `cache()` silently no-ops in Start | replaced by `getRequest()` + WeakMap | `index.test.ts` "keeps react out of the server entry" | done |
+| Should Start enable jwtCache by default? | issue open question | two adversarial reviews + `token.ts` read | off | stays off; exposed as `auth.jwtCache` with hazard documented | Decisions | answered |
+| Memo must not leak across requests | derived safety requirement | "SECURITY" test | n/a | alice never sees bob's token | pass; module-scope mutant fails only this test | done |
+
+Final handoff contract:
+- Commit line: pending
+- PR line: pending
+- Issue line: pending
+- Confidence line: pending
+- Flow table:
+  - Reproduced: tests pending, browser pending
+  - Verified: tests pending, browser pending
+- Browser check: pending
+- Outcome: pending
+- Caveat: pending
+- Design:
+  - Chosen boundary: pending
+  - Why not quick patch: pending
+  - Why not broader change: pending
+- Verified: pending
+- PR body verified: pending
+
+Task-style PR body contract:
+- Preserve any existing `<!-- auto-release:start -->` block. If a changeset is
+  part of the diff and repo policy expects auto release, include that block.
+- Use the accepted PR #270 visual format. The body starts with an emoji
+  issue/fix line, for example `🐛 Fixes #123` or `🐛 Fixes ➖ N/A`, then
+  `🧭 Task plan: docs/plans/<plan>.md`, then an emoji confidence line like
+  `🟢 95-100% confidence`.
+- Use this exact table header: `| Phase | 🧪 Tests | 🌐 Browser |`.
+- Use `Reproduced` and `Verified` rows. Mark passing proof with `🟢`, repro or
+  failing proof with `🔴`, and non-applicable cells with `➖ N/A`.
+- Use bold emoji section headings: `**✅ Outcome**`, `**⚠️ Caveat**`,
+  `**🏗️ Design**`, and `**🧪 Verified**`.
+- Never include a line that links to the current PR itself. The current PR URL
+  belongs in the final response, not in its own description.
+- Do not replace this with a generic `Summary` / `Verification` PR body, an
+  adaptive prose body from a git helper skill, plain `## Outcome` sections, or
+  an unrelated generated badge footer unless the caller or repo template
+  explicitly asks for it.
+- Proof is `gh pr view --json body` output or a concise source-backed summary
+  of that output.
+
+Final handoff / sync:
+- Commit: created locally on `issue-387`.
+- PR: N/A — the user's standing preference is "Do not create PR under any
+  circumstances, unless user prompts to." Explicit user decline, not a blocker.
+  Not pushed for the same reason.
+- Issue: N/A — no PR exists to reference; no comment posted.
+- Browser proof: N/A — no browser-rendered output changed. Replaced by a built
+  client/server bundle audit.
+- Caveats: `jwtCache` deliberately stays off by default on Start; a very
+  long-lived request that starts with no session cookie holds one freshly
+  minted token for its lifetime (same semantics as Next under `React.cache`).
+
+Timeline:
+- 2026-08-21T14:13:41.645Z Task goal plan created.
+
+Reboot status:
+| Question | Answer |
+|----------|--------|
+| Where am I? | Closeout complete |
+| Where am I going? | Final response |
+| What is the goal? | One Convex token fetch per Start request, with proven cross-request isolation |
+| What have I learned? | See Findings |
+| What have I done? | See Timeline |
+
+High-risk note:
+- Surface: public API (`convexBetterAuthReactStart` now requires `api` and
+  returns `createCaller`/`createContext`) plus a runtime change to how the
+  Convex auth token is resolved on every TanStack Start server call, and a
+  shared change to `callWithTokenAndRetry` that also affects Next.
+- Realistic failure mode: a per-request memo that is not actually per-request
+  serves one user's Convex token to another. This fails silently and looks
+  *better* on every performance metric, which is why a dedupe-count test suite
+  is not adequate proof.
+- Proof plan, executed: key the memo on `getRequest()`, whose identity comes
+  from TanStack Start's own per-request `AsyncLocalStorage` and which throws
+  (fails closed) outside a request; assert token *identity* per request, not
+  just fetch counts; mutate the implementation to a module-scope memo and
+  confirm only the identity assertion catches it; build the generated app and
+  confirm no server-only symbol reaches the client bundle.
+- Why this boundary is right: request scoping is a framework-correctness
+  invariant, not a user preference. The library entry is the only layer that
+  knows what a Start request is; `kitcn/server` cannot hold it (Convex isolates
+  have no Node builtins), and the scaffold must not, because every app would
+  reimplement it and a wrong implementation is invisible.
+
+Open risks:
+- `getRequest()` identity is an internal of a 0.x-cadence dependency. It fails
+  closed (throws) outside a request scope, and node/srvx was probed directly,
+  but Bun/Deno/CF/Vercel-edge adapters were not. A cheap future hardening is to
+  fingerprint the memo entry with the request's `cookie` value and treat a
+  mismatch as a miss.
+- Suspense boundaries that resolve after the first SSR flush were not proven to
+  retain the Start request scope. Not a regression — the previous code had the
+  identical requirement via `getRequestHeaders()` — but `getRequest()` now runs
+  on every procedure invocation including memo hits.
+- After a forced refresh publishes `isFresh: true`, a later call in the same
+  request that hits a genuine authorization failure surfaces it instead of
+  refreshing again. That is the intended `isFresh` contract (a freshly minted
+  token cannot be stale, and replaying is unsafe for mutations/actions), but it
+  narrows the retry window at a token-expiry boundary.
+- Follow-ups worth their own issue: `GetTokenOptions.jwtCache.isAuthError` is
+  now dead config; Next's `convexBetterAuth` always swallows UNAUTHORIZED to
+  null, contradicting `caller-factory`'s documented opt-in intent; `cache()` in
+  a Next **route handler** is also a no-op, which silently voids
+  `getQueryClient` hydration for any handler importing `@/lib/convex/rsc`.
+
+Hard closeout guard:
+- A local-only final response for verified code-changing work is invalid unless
+  this plan records an explicit user decline, no local patch, analytical/
+  blocked/inconclusive outcome, or a real commit/PR blocker.

--- a/docs/solutions/integration-issues/start-loader-auth-must-prime-convex-query-client-before-provider-20260519.md
+++ b/docs/solutions/integration-issues/start-loader-auth-must-prime-convex-query-client-before-provider-20260519.md
@@ -69,7 +69,8 @@ It does four things in one public API:
 
 The TanStack Start docs now split the supported paths:
 
-- server loaders and server functions use `runServerCall` or `fetchAuthQuery`
+- server loaders and server functions use the request-scoped `caller` or
+  `fetchAuthQuery`
 - client/router loaders use `syncConvexAuthForStartLoader` before protected
   `ConvexQueryClient` queries run
 - components keep using `ConvexAuthProvider`

--- a/fixtures/start-auth/src/lib/convex/auth-server.ts
+++ b/fixtures/start-auth/src/lib/convex/auth-server.ts
@@ -1,12 +1,16 @@
+import { api } from '@convex/api';
 import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';
 
 export const {
   handler,
   getToken,
+  createCaller,
+  createContext,
   fetchAuthQuery,
   fetchAuthMutation,
   fetchAuthAction,
 } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });

--- a/fixtures/start-auth/src/lib/convex/server.ts
+++ b/fixtures/start-auth/src/lib/convex/server.ts
@@ -1,35 +1,3 @@
-import { api } from '@convex/api';
-import { getRequestHeaders } from '@tanstack/react-start/server';
-import { createCallerFactory } from 'kitcn/server';
+import { createCaller } from '@/lib/convex/auth-server';
 
-import { getToken } from '@/lib/convex/auth-server';
-
-const { createContext, createCaller } = createCallerFactory({
-  api,
-  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
-  auth: {
-    getToken: async () => {
-      return {
-        token: await getToken(),
-      };
-    },
-  },
-});
-
-type ServerCaller = ReturnType<typeof createCaller>;
-
-async function makeContext() {
-  const headers = await getRequestHeaders();
-  return createContext({ headers });
-}
-
-function createServerCaller(): ServerCaller {
-  return createCaller(async () => {
-    return await makeContext();
-  });
-}
-
-export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
-  const caller = createServerCaller();
-  return fn(caller);
-}
+export const caller = createCaller();

--- a/packages/kitcn/skills/kitcn/references/setup/start.md
+++ b/packages/kitcn/skills/kitcn/references/setup/start.md
@@ -34,19 +34,27 @@ export const {
 **Create:** `src/lib/convex/auth-server.ts`
 
 ```ts
+import { api } from "@convex/api";
 import { convexBetterAuthReactStart } from "kitcn/auth/start/server";
 
 export const {
   handler,
   getToken,
+  createCaller,
+  createContext,
   fetchAuthQuery,
   fetchAuthMutation,
   fetchAuthAction,
 } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });
 ```
+
+`getToken` fetches the Convex token from the auth route. `auth.jwtCache: true`
+reads it from the session cookie instead. Leave it off when the browser Convex
+client is primed from `getToken()`.
 
 For client-side route loaders that fetch protected Convex queries through the
 router `queryClient`, prime the shared Convex client in the root `beforeLoad`
@@ -78,7 +86,7 @@ export const Route = createRootRouteWithContext<{
 });
 ```
 
-Use `runServerCall` or `fetchAuthQuery` for server-side loaders. Use
+Use the request-scoped `caller` or `fetchAuthQuery` for server-side loaders. Use
 `syncConvexAuthForStartLoader` only for client/router loaders that execute
 shared `ConvexQueryClient` queries before `ConvexAuthProvider` mounts.
 
@@ -105,42 +113,20 @@ export const Route = createFileRoute("/api/auth/$" as never)({
 **Create:** `src/lib/convex/server.ts`
 
 ```ts
-import { api } from "@convex/api";
-import { getRequestHeaders } from "@tanstack/react-start/server";
-import { createCallerFactory } from "kitcn/server";
+import { createCaller } from "@/lib/convex/auth-server";
 
-import { getToken } from "@/lib/convex/auth-server";
-
-const { createContext, createCaller } = createCallerFactory({
-  api,
-  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
-  auth: {
-    getToken: async () => {
-      return {
-        token: await getToken(),
-      };
-    },
-  },
-});
-
-type ServerCaller = ReturnType<typeof createCaller>;
-
-async function makeContext() {
-  const headers = await getRequestHeaders();
-  return createContext({ headers });
-}
-
-function createServerCaller(): ServerCaller {
-  return createCaller(async () => {
-    return await makeContext();
-  });
-}
-
-export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
-  const caller = createServerCaller();
-  return fn(caller);
-}
+export const caller = createCaller();
 ```
+
+`createCaller()` binds to the current request, so every procedure call in a
+request shares one Convex auth token fetch. The module-scope `caller` holds no
+request state; it resolves the current request on each call. Pass a context
+factory (`createCaller(() => createContext({ headers }))`) only to call Convex
+with headers other than the current request's.
+
+Reach `caller` from a `createServerFn` handler or a server route. A route
+`loader` also runs in the browser on client-side navigation, where there is no
+request scope.
 
 Use the docs pattern from `tanstack-start.mdx` for:
 

--- a/packages/kitcn/src/auth-start/index.retry.test.ts
+++ b/packages/kitcn/src/auth-start/index.retry.test.ts
@@ -43,20 +43,22 @@ describe('auth/start token refresh', () => {
       getToken,
     }));
 
+    const request = new Request('https://app.example.com/');
     mock.module('@tanstack/react-start/server', () => ({
-      getRequestHeaders: () => new Headers(),
+      getRequest: () => request,
+      getRequestHeaders: () => request.headers,
     }));
 
     const { convexBetterAuthReactStart } = await import('./server');
 
     const auth = convexBetterAuthReactStart({
-      convexSiteUrl: 'https://app.convex.site',
-      convexUrl: 'https://app.convex.cloud',
-      jwtCache: {
-        enabled: true,
-        isAuthError: (error) =>
+      api: {},
+      auth: {
+        isUnauthorized: (error) =>
           (error as { code?: string } | undefined)?.code === 'UNAUTHORIZED',
       },
+      convexSiteUrl: 'https://app.convex.site',
+      convexUrl: 'https://app.convex.cloud',
     });
 
     await expect(auth.fetchAuthQuery({} as never)).resolves.toBe('ok');

--- a/packages/kitcn/src/auth-start/index.retry.test.ts
+++ b/packages/kitcn/src/auth-start/index.retry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { makeFunctionReference } from 'convex/server';
 
 describe('auth/start token refresh', () => {
   afterEach(() => {
@@ -49,10 +50,37 @@ describe('auth/start token refresh', () => {
       getRequestHeaders: () => request.headers,
     }));
 
+    const serverMutation = mock(
+      async (_ref: unknown, _args: unknown, options?: { token?: string }) => {
+        if (options?.token === 'stale-token') {
+          const error = new Error('unauthorized');
+          (error as Error & { code?: string }).code = 'UNAUTHORIZED';
+          throw error;
+        }
+        return 'ok';
+      }
+    );
+
+    mock.module('convex/nextjs', () => ({
+      fetchAction: serverMutation,
+      fetchMutation: serverMutation,
+      fetchQuery: serverMutation,
+    }));
+
+    const mutationRef = makeFunctionReference<'mutation'>('todos:create');
+    const api = {
+      todos: {
+        create: Object.assign(mutationRef, {
+          functionRef: mutationRef,
+          type: 'mutation',
+        }),
+      },
+    } as const;
+
     const { convexBetterAuthReactStart } = await import('./server');
 
     const auth = convexBetterAuthReactStart({
-      api: {},
+      api,
       auth: {
         isUnauthorized: (error) =>
           (error as { code?: string } | undefined)?.code === 'UNAUTHORIZED',
@@ -61,8 +89,13 @@ describe('auth/start token refresh', () => {
       convexUrl: 'https://app.convex.cloud',
     });
 
+    const caller = auth.createCaller();
+    await expect(caller.getToken()).resolves.toBe('stale-token');
     await expect(auth.fetchAuthQuery({} as never)).resolves.toBe('ok');
+    await expect(caller.todos.create({})).resolves.toBe('ok');
+
     expect(getToken).toHaveBeenCalledTimes(2);
     expect(query).toHaveBeenCalledTimes(2);
+    expect(serverMutation).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/kitcn/src/auth-start/index.test.ts
+++ b/packages/kitcn/src/auth-start/index.test.ts
@@ -20,6 +20,19 @@ describe('auth/start', () => {
     expect(serverSource).toContain("from '@tanstack/react-start/server'");
   });
 
+  test('keeps react out of the server entry', () => {
+    const serverSource = readFileSync(
+      path.join(import.meta.dir, 'server.ts'),
+      'utf8'
+    );
+
+    // React `cache()` is a pass-through outside an RSC request scope, so it can
+    // never memoize anything in TanStack Start. Request scoping comes from
+    // `getRequest()` instead, and this server-only entry must not pull in React.
+    expect(serverSource).not.toContain("from 'react'");
+    expect(serverSource).toContain('getRequest');
+  });
+
   test('keeps the shared loader entry browser-bundleable', async () => {
     const result = await build({
       bundle: true,
@@ -64,6 +77,7 @@ describe('auth/start', () => {
 
     try {
       const auth = convexBetterAuthReactStart({
+        api: {},
         convexSiteUrl: 'https://my-app.convex.site',
         convexUrl: 'https://my-app.convex.cloud',
       });

--- a/packages/kitcn/src/auth-start/server.request-scope.test.ts
+++ b/packages/kitcn/src/auth-start/server.request-scope.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { makeFunctionReference } from 'convex/server';
+
+// The real `getRequest`/`getRequestHeaders` read TanStack Start's per-request
+// AsyncLocalStorage, which only a live server runtime enters. Faking the two
+// accessors lets the test own request boundaries explicitly, and keeps it
+// immune to `mock.module` state leaking in from sibling files.
+let currentRequest: Request;
+
+const enterRequest = (cookie: string) => {
+  currentRequest = new Request('https://app.example.com/');
+  // happy-dom (registered by tooling/test-setup.ts) drops `cookie` when passed
+  // through the Request constructor init, so set it after construction.
+  currentRequest.headers.set('cookie', cookie);
+};
+
+mock.module('@tanstack/react-start/server', () => ({
+  getRequest: () => currentRequest,
+  getRequestHeaders: () => currentRequest.headers,
+}));
+
+let tokenFetches = 0;
+
+mock.module('../auth/internal/token', () => ({
+  getToken: async (_siteUrl: string, headers: Headers) => {
+    tokenFetches++;
+    return { isFresh: true, token: `jwt-for-${headers.get('cookie')}` };
+  },
+}));
+
+let convexCalls = 0;
+let lastConvexToken: string | undefined;
+
+mock.module('convex/nextjs', () => ({
+  fetchAction: async () => 'ok',
+  fetchMutation: async () => 'ok',
+  fetchQuery: async (
+    _query: unknown,
+    _args: unknown,
+    options?: { token?: string }
+  ) => {
+    convexCalls++;
+    lastConvexToken = options?.token;
+    return 'ok';
+  },
+}));
+
+const listRef = makeFunctionReference<'query'>('posts:list');
+const api = {
+  posts: {
+    list: Object.assign(listRef, { functionRef: listRef, type: 'query' }),
+  },
+};
+
+const createAuth = async () => {
+  const { convexBetterAuthReactStart } = await import('./server');
+
+  return convexBetterAuthReactStart({
+    api,
+    convexSiteUrl: 'https://app.convex.site',
+    convexUrl: 'https://app.convex.cloud',
+  });
+};
+
+describe('auth/start request-scoped auth', () => {
+  beforeEach(() => {
+    tokenFetches = 0;
+    convexCalls = 0;
+    lastConvexToken = undefined;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('K procedure calls in one request cost 1 token fetch', async () => {
+    const { createCaller } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+
+    await caller.posts.list({});
+    await caller.posts.list({});
+    await caller.posts.list({});
+
+    expect(convexCalls).toBe(3);
+    expect(tokenFetches).toBe(1);
+  });
+
+  test('concurrent procedure calls share one in-flight token fetch', async () => {
+    const { createCaller } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+
+    await Promise.all([
+      caller.posts.list({}),
+      caller.posts.list({}),
+      caller.posts.list({}),
+    ]);
+
+    expect(convexCalls).toBe(3);
+    expect(tokenFetches).toBe(1);
+  });
+
+  test('caller, getToken, and fetchAuthQuery share one token fetch', async () => {
+    const { createCaller, getToken } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+
+    await caller.posts.list({});
+    const token = await getToken();
+    await caller.posts.list({});
+
+    expect(token).toBe('jwt-for-session=alice');
+    expect(tokenFetches).toBe(1);
+  });
+
+  test('SECURITY: the per-request memo never serves one request the other request token', async () => {
+    const { createCaller, getToken } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+    await caller.posts.list({});
+    const aliceCallerToken = lastConvexToken;
+    const aliceToken = await getToken();
+    const fetchesAfterAlice = tokenFetches;
+
+    enterRequest('session=bob');
+    await caller.posts.list({});
+    const bobCallerToken = lastConvexToken;
+    const bobToken = await getToken();
+
+    // A module-scope memo would satisfy every dedupe count below while handing
+    // bob alice's token, so these identity assertions are the real guard.
+    expect(aliceCallerToken).toBe('jwt-for-session=alice');
+    expect(aliceToken).toBe('jwt-for-session=alice');
+    expect(bobCallerToken).toBe('jwt-for-session=bob');
+    expect(bobToken).toBe('jwt-for-session=bob');
+
+    expect(fetchesAfterAlice).toBe(1);
+    expect(tokenFetches).toBe(2);
+  });
+
+  test('an explicit createContext mints its own token instead of reusing the request memo', async () => {
+    const { createCaller, createContext } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+    await caller.posts.list({});
+    expect(tokenFetches).toBe(1);
+
+    const otherHeaders = new Headers();
+    otherHeaders.set('cookie', 'session=carol');
+    const ctx = await createContext({ headers: otherHeaders });
+
+    expect(ctx.token).toBe('jwt-for-session=carol');
+    expect(tokenFetches).toBe(2);
+  });
+
+  test('survives the request swapping its Headers object mid-request', async () => {
+    // srvx serves a lazy header view until something materializes the native
+    // Request (a server function reading `formData()`), then swaps in that
+    // Request's own Headers. Values survive, identity does not. Anything that
+    // compares against the live accessor stops matching after the swap.
+    const headersA = new Headers();
+    headersA.set('cookie', 'session=alice');
+    const headersB = new Headers();
+    headersB.set('cookie', 'session=alice');
+
+    let swapped = false;
+    currentRequest = {
+      get headers() {
+        return swapped ? headersB : headersA;
+      },
+    } as unknown as Request;
+
+    const { createCaller, getToken } = await createAuth();
+    const caller = createCaller();
+
+    // Resolve the ambient token first, so the request's headers are captured
+    // before the swap and the caller's context is built after it.
+    await expect(getToken()).resolves.toBe('jwt-for-session=alice');
+    expect(tokenFetches).toBe(1);
+
+    swapped = true;
+
+    await caller.posts.list({});
+    await caller.posts.list({});
+
+    expect(headersA).not.toBe(headersB);
+    expect(convexCalls).toBe(2);
+    expect(tokenFetches).toBe(1);
+  });
+
+  test('a failed token fetch is evicted so the next call retries', async () => {
+    let shouldFail = true;
+    mock.module('../auth/internal/token', () => ({
+      getToken: async (_siteUrl: string, headers: Headers) => {
+        tokenFetches++;
+        if (shouldFail) {
+          throw new Error('token endpoint down');
+        }
+        return { isFresh: true, token: `jwt-for-${headers.get('cookie')}` };
+      },
+    }));
+
+    const { createCaller } = await createAuth();
+    const caller = createCaller();
+
+    enterRequest('session=alice');
+
+    await expect(caller.posts.list({})).rejects.toThrow('token endpoint down');
+    expect(tokenFetches).toBe(1);
+
+    shouldFail = false;
+    await expect(caller.posts.list({})).resolves.toBe('ok');
+    expect(tokenFetches).toBe(2);
+  });
+});

--- a/packages/kitcn/src/auth-start/server.ts
+++ b/packages/kitcn/src/auth-start/server.ts
@@ -345,7 +345,8 @@ export const convexBetterAuthReactStart = <
       const refreshed = await fetchTokenFor(requestHeaders(getRequest()), true);
       // Share the refreshed token with the rest of this request so later calls
       // do not each replay against the same rejected token.
-      tokenByRequest.set(getRequest(), Promise.resolve(refreshed));
+      token.token = refreshed.token;
+      token.isFresh = refreshed.isFresh;
       return await fn(refreshed.token);
     }
   };

--- a/packages/kitcn/src/auth-start/server.ts
+++ b/packages/kitcn/src/auth-start/server.ts
@@ -1,4 +1,4 @@
-import { getRequestHeaders } from '@tanstack/react-start/server';
+import { getRequest } from '@tanstack/react-start/server';
 import { stripIndent } from 'common-tags';
 import { ConvexHttpClient } from 'convex/browser';
 import type {
@@ -6,8 +6,12 @@ import type {
   FunctionReturnType,
   OptionalRestArgs,
 } from 'convex/server';
-import React from 'react';
 import { type GetTokenOptions, getToken } from '../auth/internal/token';
+import { defaultIsUnauthorized } from '../crpc/error';
+import {
+  type ConvexContext,
+  createCallerFactory,
+} from '../server/caller-factory';
 
 type ClientOptions = {
   convexSiteUrl: string;
@@ -15,19 +19,43 @@ type ClientOptions = {
   token?: string;
 };
 
-type ConvexBetterAuthReactStartOptions = Omit<
-  GetTokenOptions,
-  'forceRefresh'
-> & {
-  convexSiteUrl: string;
-  convexUrl: string;
+type TokenResult = {
+  token?: string;
+  isFresh?: boolean;
 };
 
-type ReactCache = <T extends (...args: never[]) => unknown>(fn: T) => T;
+/** Auth options for server-side calls. */
+type AuthOptions = {
+  /** Better Auth auth route base path. Defaults to `/api/auth`. */
+  basePath?: string;
+  /**
+   * Read the Convex JWT from the session cookie instead of fetching it.
+   * Default: false.
+   *
+   * The token this saves a round trip on is also the token
+   * `syncConvexAuthForStartLoader` hands the browser Convex client, which
+   * captures it for the lifetime of the socket. A cookie JWT can be within
+   * seconds of expiry and cannot be renewed from that callback, so enable this
+   * only for apps that do not prime the browser client from `getToken()`.
+   */
+  jwtCache?: boolean;
+  /** Custom function to detect UNAUTHORIZED errors. Default checks code property. */
+  isUnauthorized?: (error: unknown) => boolean;
+  /** Expiration tolerance in seconds. */
+  expirationToleranceSeconds?: number;
+};
 
-const fallbackCache: ReactCache = (fn) => fn;
-const cache =
-  (React as typeof React & { cache?: ReactCache }).cache ?? fallbackCache;
+type ConvexBetterAuthReactStartOptions<TApi> = Omit<
+  GetTokenOptions,
+  'forceRefresh' | 'jwtCache'
+> & {
+  /** Your Convex API object. */
+  api: TApi;
+  convexSiteUrl: string;
+  convexUrl: string;
+  /** Auth options. */
+  auth?: AuthOptions;
+};
 
 const TRAILING_COLON_RE = /:$/;
 
@@ -139,18 +167,162 @@ const handler = async (
   });
 };
 
-export const convexBetterAuthReactStart = (
-  opts: ConvexBetterAuthReactStartOptions
+/**
+ * Create Convex caller factory with Better Auth integration for TanStack Start.
+ *
+ * Every request resolves its Convex token once. TanStack Start runs each request
+ * inside an `AsyncLocalStorage` scope, so `getRequest()` returns an object whose
+ * identity is stable for that request and distinct across requests. Keying the
+ * memos on it makes them request-scoped by construction: nothing auth-related is
+ * ever held at module scope, and entries are collected with the request.
+ *
+ * @example
+ * ```ts
+ * // auth-server.ts
+ * export const { createCaller, handler, getToken } = convexBetterAuthReactStart({
+ *   api,
+ *   convexUrl: import.meta.env.VITE_CONVEX_URL!,
+ *   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
+ * });
+ *
+ * // server.ts
+ * export const caller = createCaller();
+ *
+ * // any server function or server route - single token fetch per request
+ * const user = await caller.user.getSessionUser();
+ * const posts = await caller.posts.list();
+ * ```
+ */
+export const convexBetterAuthReactStart = <
+  TApi extends Record<string, unknown>,
+>(
+  opts: ConvexBetterAuthReactStartOptions<TApi>
 ) => {
   const siteUrl = parseConvexSiteUrl(opts.convexSiteUrl);
+  const auth = opts.auth ?? {};
+  const jwtCacheEnabled = auth.jwtCache === true;
 
-  const cachedGetToken = cache(async (opts: GetTokenOptions) => {
-    const headers = getRequestHeaders();
+  const fetchTokenFor = (
+    headers: Headers,
+    forceRefresh?: boolean
+  ): Promise<TokenResult> => {
     const mutableHeaders = new Headers(headers);
     stripHopByHopHeaders(mutableHeaders);
     mutableHeaders.set('accept-encoding', 'identity');
-    return getToken(siteUrl, mutableHeaders, opts);
+
+    return getToken(siteUrl, mutableHeaders, {
+      basePath: auth.basePath ?? opts.basePath,
+      cookiePrefix: opts.cookiePrefix,
+      forceRefresh,
+      jwtCache: {
+        enabled: jwtCacheEnabled,
+        expirationToleranceSeconds: auth.expirationToleranceSeconds,
+        isAuthError: auth.isUnauthorized ?? defaultIsUnauthorized,
+      },
+    });
+  };
+
+  const headersByRequest = new WeakMap<Request, Headers>();
+  const tokenByRequest = new WeakMap<Request, Promise<TokenResult>>();
+  const contextByRequest = new WeakMap<Request, Promise<ConvexContext<TApi>>>();
+
+  /**
+   * Snapshot the current request's headers once.
+   *
+   * `getRequestHeaders()` is not identity-stable within a request: srvx serves a
+   * lazy header view until anything materializes the native Request (a server
+   * function reading `formData()`, for example), then swaps in that Request's
+   * own `Headers` and drops the old one. Header *values* survive the swap, so a
+   * snapshot taken at any point is correct, but comparing or keying on the live
+   * accessor would silently stop matching mid-request.
+   */
+  const requestHeaders = (request: Request): Headers => {
+    const cached = headersByRequest.get(request);
+    if (cached) {
+      return cached;
+    }
+
+    const snapshot = new Headers(request.headers);
+    headersByRequest.set(request, snapshot);
+
+    return snapshot;
+  };
+
+  /**
+   * Memoize `create` for the lifetime of the current request. The pending
+   * promise is stored before it settles so concurrent callers share one
+   * in-flight fetch, and a rejection is evicted so the next caller can retry.
+   */
+  const perRequest = <T>(
+    store: WeakMap<Request, Promise<T>>,
+    create: (request: Request) => Promise<T>
+  ): Promise<T> => {
+    const request = getRequest();
+    const cached = store.get(request);
+    if (cached) {
+      return cached;
+    }
+
+    const pending = create(request).catch((error: unknown) => {
+      if (store.get(request) === pending) {
+        store.delete(request);
+      }
+      throw error;
+    });
+    store.set(request, pending);
+
+    return pending;
+  };
+
+  /**
+   * The current request, or `undefined` outside a Start request scope.
+   * `getRequest()` throws there, and an explicit `createContext({ headers })`
+   * is allowed to run with no ambient request at all.
+   */
+  const currentRequest = (): Request | undefined => {
+    try {
+      return getRequest();
+    } catch {
+      return;
+    }
+  };
+
+  /** Ambient token for the current request, resolved at most once. */
+  const requestToken = () =>
+    perRequest(tokenByRequest, (request) =>
+      fetchTokenFor(requestHeaders(request))
+    );
+
+  const { createContext, createCaller } = createCallerFactory({
+    api: opts.api,
+    auth: {
+      getToken: (_tokenSiteUrl, headers, getTokenOpts) => {
+        const forceRefresh = (getTokenOpts as GetTokenOptions | undefined)
+          ?.forceRefresh;
+        const request = currentRequest();
+        // Share the per-request token only when this context was built from the
+        // request's own header snapshot. An explicit `createContext({ headers })`
+        // must mint its own token, and a forced refresh bypasses the memo.
+        if (
+          !forceRefresh &&
+          request &&
+          headers === headersByRequest.get(request)
+        ) {
+          return requestToken();
+        }
+        return fetchTokenFor(headers, forceRefresh);
+      },
+      isUnauthorized: auth.isUnauthorized,
+    },
+    convexSiteUrl: opts.convexSiteUrl,
+    convexUrl: opts.convexUrl,
   });
+
+  /** Request-scoped context. One context, one token, per request. */
+  const createRequestContext = () =>
+    perRequest(contextByRequest, (request) =>
+      createContext({ headers: requestHeaders(request) })
+    );
 
   const callWithToken = async <
     FnType extends 'query' | 'mutation' | 'action',
@@ -158,28 +330,37 @@ export const convexBetterAuthReactStart = (
   >(
     fn: (token?: string) => Promise<FunctionReturnType<Fn>>
   ): Promise<FunctionReturnType<Fn>> => {
-    const token = (await cachedGetToken(opts)) ?? {};
+    const token = await requestToken();
     try {
-      return await fn(token?.token);
+      return await fn(token.token);
     } catch (error) {
+      // Only replay when a cached token may be the cause. A freshly fetched
+      // token cannot be stale, and replaying is unsafe for mutations/actions.
       if (
-        !opts?.jwtCache?.enabled ||
         token.isFresh ||
-        !opts.jwtCache?.isAuthError(error)
+        !(auth.isUnauthorized ?? defaultIsUnauthorized)(error)
       ) {
         throw error;
       }
-      const newToken = await cachedGetToken({
-        ...opts,
-        forceRefresh: true,
-      });
-      return await fn(newToken.token);
+      const refreshed = await fetchTokenFor(requestHeaders(getRequest()), true);
+      // Share the refreshed token with the rest of this request so later calls
+      // do not each replay against the same rejected token.
+      tokenByRequest.set(getRequest(), Promise.resolve(refreshed));
+      return await fn(refreshed.token);
     }
   };
 
   return {
+    /**
+     * Bind a cRPC caller. Defaults to the request-scoped context, so every
+     * procedure call in a request shares one token fetch.
+     */
+    createCaller: (
+      ctxFn: () => Promise<ConvexContext<TApi>> = createRequestContext
+    ) => createCaller(ctxFn),
+    createContext,
     getToken: async () => {
-      const token = await cachedGetToken(opts);
+      const token = await requestToken();
       return token.token;
     },
     handler: async (request: Request) =>

--- a/packages/kitcn/src/cli/cli.commands.ts
+++ b/packages/kitcn/src/cli/cli.commands.ts
@@ -2430,16 +2430,21 @@ describe('cli/cli', () => {
       expect(authServerSource).toContain(
         "import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';"
       );
+      expect(authServerSource).toContain("import { api } from '@convex/api';");
+      expect(authServerSource).toContain('createCaller');
 
       const serverSource = fs.readFileSync(
         path.join(dir, 'src', 'lib', 'convex', 'server.ts'),
         'utf8'
       );
-      expect(serverSource).toContain('createCallerFactory');
-      expect(serverSource).toContain('@tanstack/react-start/server');
       expect(serverSource).toContain(
-        "import { getToken } from '@/lib/convex/auth-server';"
+        "import { createCaller } from '@/lib/convex/auth-server';"
       );
+      expect(serverSource).toContain('export const caller = createCaller();');
+      // The caller is request-scoped by the library, so app code must not
+      // rebuild it (or its context) per call.
+      expect(serverSource).not.toContain('runServerCall');
+      expect(serverSource).not.toContain('createCallerFactory');
 
       const routeSource = fs.readFileSync(
         path.join(dir, 'src', 'routes', 'api', 'auth', '$.ts'),

--- a/packages/kitcn/src/cli/registry/items/auth/auth-start-server-call.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-start-server-call.template.ts
@@ -1,36 +1,4 @@
-export const AUTH_START_SERVER_CALL_TEMPLATE = `import { api } from '@convex/api';
-import { getRequestHeaders } from '@tanstack/react-start/server';
-import { createCallerFactory } from 'kitcn/server';
+export const AUTH_START_SERVER_CALL_TEMPLATE = `import { createCaller } from '@/lib/convex/auth-server';
 
-import { getToken } from '@/lib/convex/auth-server';
-
-const { createContext, createCaller } = createCallerFactory({
-  api,
-  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
-  auth: {
-    getToken: async () => {
-      return {
-        token: await getToken(),
-      };
-    },
-  },
-});
-
-type ServerCaller = ReturnType<typeof createCaller>;
-
-async function makeContext() {
-  const headers = await getRequestHeaders();
-  return createContext({ headers });
-}
-
-function createServerCaller(): ServerCaller {
-  return createCaller(async () => {
-    return await makeContext();
-  });
-}
-
-export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
-  const caller = createServerCaller();
-  return fn(caller);
-}
+export const caller = createCaller();
 `;

--- a/packages/kitcn/src/cli/registry/items/auth/auth-start-server.template.ts
+++ b/packages/kitcn/src/cli/registry/items/auth/auth-start-server.template.ts
@@ -1,12 +1,16 @@
-export const AUTH_START_SERVER_TEMPLATE = `import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';
+export const AUTH_START_SERVER_TEMPLATE = `import { api } from '@convex/api';
+import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';
 
 export const {
   handler,
   getToken,
+  createCaller,
+  createContext,
   fetchAuthQuery,
   fetchAuthMutation,
   fetchAuthAction,
 } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });

--- a/packages/kitcn/src/server/caller-factory.test.ts
+++ b/packages/kitcn/src/server/caller-factory.test.ts
@@ -490,6 +490,71 @@ describe('server/caller-factory', () => {
     expect(getToken.mock.calls[1]?.[2]?.forceRefresh).toBe(true);
   });
 
+  test('a refreshed token is reused by later calls on the same context', async () => {
+    const fetchMutationSpy = spyOn(
+      convexNextjs,
+      'fetchMutation'
+    ).mockImplementation(async (_fn: any, _args: any, opts: any) => {
+      if (opts?.token === 't0') {
+        throw Object.assign(new Error('unauthorized'), {
+          code: 'UNAUTHORIZED',
+        });
+      }
+      return 'ok';
+    });
+
+    const ref = makeFunctionReference<'mutation'>('todos:create');
+    const apiWithMeta = {
+      todos: {
+        create: Object.assign(ref, { functionRef: ref, type: 'mutation' }),
+      },
+    } as const;
+
+    const getToken = mock(
+      async (_siteUrl: string, _headers: Headers, opts?: any) => {
+        if (opts?.forceRefresh) return { isFresh: true, token: 't1' };
+        return { isFresh: false, token: 't0' };
+      }
+    );
+
+    const { createContext } = createCallerFactory({
+      api: apiWithMeta as any,
+      auth: {
+        getToken,
+        isUnauthorized: (e) =>
+          !!e &&
+          typeof e === 'object' &&
+          'code' in e &&
+          (e as any).code === 'UNAUTHORIZED',
+      },
+      convexSiteUrl: 'https://example.convex.site',
+    });
+
+    // A memoized context is shared by every call in a request (the Next RSC and
+    // TanStack Start callers are both wired that way), so the refresh from the
+    // first call must not be re-derived — and the rejected token must not be
+    // replayed — by the calls after it.
+    const ctx = await createContext({ headers: new Headers() });
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'first' })
+    ).resolves.toBe('ok');
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'second' })
+    ).resolves.toBe('ok');
+    await expect(
+      (ctx.caller as any).todos.create({ title: 'third' })
+    ).resolves.toBe('ok');
+
+    // 2 for the first call (rejected + replayed), then 1 each with the good token.
+    expect(fetchMutationSpy.mock.calls.length).toBe(4);
+    expect(getToken.mock.calls.length).toBe(2);
+    expect(
+      fetchMutationSpy.mock.calls.slice(2).every((call) => {
+        return (call[2] as any)?.token === 't1';
+      })
+    ).toBe(true);
+  });
+
   test('refreshes token and retries once on unauthorized errors when token is not fresh', async () => {
     const fetchQuerySpy = spyOn(convexNextjs, 'fetchQuery').mockImplementation(
       async (_fn: any, _args: any, opts: any) => {

--- a/packages/kitcn/src/server/caller-factory.ts
+++ b/packages/kitcn/src/server/caller-factory.ts
@@ -169,6 +169,13 @@ export function createCallerFactory<TApi extends Record<string, unknown>>(
         ...opts,
         forceRefresh: true,
       });
+      // Publish the refreshed token back to the context every call in this
+      // request shares. Without this, a context that outlives a single call —
+      // any memoized `createContext`, which is how both the Next RSC caller and
+      // the Start caller are wired — replays the same rejected token on every
+      // later call, re-executing non-idempotent mutations and actions.
+      tokenResult.token = newToken.token;
+      tokenResult.isFresh = newToken.isFresh;
       try {
         return await fn(newToken.token);
       } catch (retryError) {

--- a/tooling/test-setup.ts
+++ b/tooling/test-setup.ts
@@ -19,13 +19,12 @@ if (globalThis.document && !globalThis.document.body) {
 expect.extend(matchers);
 
 // Import after DOM globals are registered so Testing Library binds `screen` correctly.
-// Load at setup-time, not inside a running test hook, to avoid Bun 1.3+ hook-context errors.
-const cleanupPromise = import('@testing-library/react').then(
-  ({ cleanup }) => cleanup
-);
+// Awaited here rather than left floating: Testing Library registers its own
+// `beforeAll` at module scope, and Bun 1.3+ rejects that if the import happens to
+// resolve while a test is running.
+const { cleanup } = await import('@testing-library/react');
 
 // Cleanup DOM between tests to avoid cross-test contamination.
-afterEach(async () => {
-  const cleanup = await cleanupPromise;
+afterEach(() => {
   cleanup();
 });

--- a/www/content/docs/migrations/auth.mdx
+++ b/www/content/docs/migrations/auth.mdx
@@ -848,9 +848,11 @@ loop. There is no separate `auth:generate` step on this path.
 Create server-side auth helpers using `kitcn/auth/start/server`:
 
 ```ts showLineNumbers title="src/lib/auth-server.ts"
+import { api } from '@convex/api';
 import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';
 
-export const { handler, getToken } = convexBetterAuthReactStart({
+export const { handler, getToken, createCaller } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });

--- a/www/content/docs/tanstack-start.mdx
+++ b/www/content/docs/tanstack-start.mdx
@@ -107,23 +107,33 @@ export const {
 ### Auth Server
 
 ```ts showLineNumbers title="src/lib/convex/auth-server.ts"
+import { api } from '@convex/api';
 import { convexBetterAuthReactStart } from 'kitcn/auth/start/server';
 
 export const {
   handler,
   getToken,
+  createCaller,
+  createContext,
   fetchAuthQuery,
   fetchAuthMutation,
   fetchAuthAction,
 } = convexBetterAuthReactStart({
+  api,
   convexUrl: import.meta.env.VITE_CONVEX_URL!,
   convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
 });
 ```
 
+`getToken` fetches the Convex token from your auth route. Set
+`auth.jwtCache: true` to read it from the session cookie instead, saving the
+round trip. Leave it off when you prime the browser Convex client from
+`getToken()` — a cookie token can be close to expiry, and the browser client
+cannot renew the value it captures.
+
 ### Loader Auth
 
-Server functions and server loaders should call Convex through `runServerCall`
+Server functions and server loaders should call Convex through the `caller`
 or the `fetchAuthQuery` helper from `auth-server.ts`. Client-side route loaders
 that use the shared TanStack Query client can prime the shared Convex client
 before child loaders run:
@@ -262,57 +272,44 @@ export function AppConvexProvider({
 
 ### Server Caller
 
-Use `runServerCall` to call cRPC procedures from TanStack Start server functions:
+`createCaller()` binds a caller to the current request. Every procedure call in
+a request shares one Convex auth token, so the token is fetched at most once per
+request no matter how many procedures you call:
 
 ```ts showLineNumbers title="src/lib/convex/server.ts"
-import { api } from '@convex/api';
-import { getRequestHeaders } from '@tanstack/react-start/server';
-import { createCallerFactory } from 'kitcn/server';
+import { createCaller } from '@/lib/convex/auth-server';
 
-import { getToken } from '@/lib/convex/auth-server';
-
-const { createContext, createCaller } = createCallerFactory({
-  api,
-  convexSiteUrl: import.meta.env.VITE_CONVEX_SITE_URL!,
-  auth: {
-    getToken: async () => {
-      return {
-        token: await getToken(),
-      };
-    },
-  },
-});
-
-type ServerCaller = ReturnType<typeof createCaller>;
-
-async function makeContext() {
-  const headers = await getRequestHeaders();
-  return createContext({ headers });
-}
-
-function createServerCaller(): ServerCaller {
-  return createCaller(async () => {
-    return await makeContext();
-  });
-}
-
-export function runServerCall<T>(fn: (caller: ServerCaller) => Promise<T> | T) {
-  const caller = createServerCaller();
-  return fn(caller);
-}
+export const caller = createCaller();
 ```
 
 Usage:
 
 ```ts showLineNumbers title="src/functions/get-current-user.ts"
-import { runServerCall } from '@/lib/convex/server';
+import { caller } from '@/lib/convex/server';
 import { createServerFn } from '@tanstack/react-start';
 
 export const getCurrentUser = createServerFn({ method: 'GET' }).handler(
   async () => {
-    return await runServerCall((caller) => caller.user.getSessionUser({}));
+    return await caller.user.getSessionUser({});
   },
 );
+```
+
+The module-scope `caller` holds no request state. It resolves the current
+request through TanStack Start's request scope on each call, so tokens are never
+shared between requests.
+
+<Callout type="warn">
+Reach `caller` from a `createServerFn` handler or a server route. A route
+`loader` also runs in the browser on client-side navigation, where there is no
+request scope.
+</Callout>
+
+To call Convex with headers other than the current request's, pass your own
+context factory:
+
+```ts
+const caller = createCaller(() => createContext({ headers }));
 ```
 
 ### Root Route


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes #387
🧭 Task plan: docs/plans/387-start-scaffold-per-request-caller-memo.md
🟢 95-100% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 3 Start calls in one request cost 3 token fetches | ➖ N/A |
| Verified | 🟢 `bun check`, 189 focused tests, mutation tests, bundle audit | ➖ N/A |

**✅ Outcome**
- TanStack Start resolves one Convex auth token per request across callers and auth fetch helpers.
- Refreshed tokens update the shared request result before later mutations or actions run.
- `convexBetterAuthReactStart` owns the request-scoped context and exposes `createCaller` and `createContext`.

**⚠️ Caveat**
- JWT caching stays opt-in because a browser connection cannot renew an expiring cookie JWT by itself.
- A long-lived request keeps its freshly minted token for the request lifetime.

**🏗️ Design**
- The memo is keyed by TanStack Start's request identity, which is stable within one request and distinct across requests.
- The library owns request scoping so generated and hand-written Start callers use the same isolation contract.
- The shared token result is updated in place so already-created caller contexts observe a refresh.

**🧪 Verified**
- `bun check`
- `bun test packages/kitcn/src/auth-start/ packages/kitcn/src/server/` (189 pass)
- Cross-request identity and token-refresh mutation tests
- Generated Start client/server bundle audit
