### PR TITLE
fix(react): preserve SSR queries during auth confirmation

### DIFF
--- a/.changeset/lucky-cups-shine.md
+++ b/.changeset/lucky-cups-shine.md
@@ -1,0 +1,15 @@
+---
+"kitcn": patch
+---
+
+## Patches
+
+- Fix `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a
+  token the client already held. The automatic reset compared `isAuthenticated`
+  as well as the token identity. That flag turns from false to true on every
+  server-rendered page once Convex validates the token in the HTML, so the
+  provider dropped hydrated data on load and the screen lost the rows it had
+  rendered. The reset now compares the identity only. Signing out, switching
+  accounts, an opaque token becoming a JWT, and a change to any non-volatile
+  claim still reset. Routine rotation still does not, and calling
+  `resetAuthQueries()` directly is unchanged.

--- a/.changeset/lucky-cups-shine.md
+++ b/.changeset/lucky-cups-shine.md
@@ -1,8 +1,0 @@
----
-"kitcn": patch
----
-
-## Patches
-
-- Fix authenticated cRPC query results disappearing when a server-rendered page
-  hydrates.

--- a/.changeset/lucky-cups-shine.md
+++ b/.changeset/lucky-cups-shine.md
@@ -4,12 +4,5 @@
 
 ## Patches
 
-- Fix `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a
-  token the client already held. The automatic reset compared `isAuthenticated`
-  as well as the token identity. That flag turns from false to true on every
-  server-rendered page once Convex validates the token in the HTML, so the
-  provider dropped hydrated data on load and the screen lost the rows it had
-  rendered. The reset now compares the identity only. Signing out, switching
-  accounts, an opaque token becoming a JWT, and a change to any non-volatile
-  claim still reset. Routine rotation still does not, and calling
-  `resetAuthQueries()` directly is unchanged.
+- Fix authenticated cRPC query results disappearing when a server-rendered page
+  hydrates.

--- a/.changeset/wide-index-union-stays-indexed.md
+++ b/.changeset/wide-index-union-stays-indexed.md
@@ -27,6 +27,8 @@ const page = await db.query.users.withIndex("by_status").findMany({
 
 ## Patches
 
+- Fix authenticated cRPC query results disappearing when a server-rendered page
+  hydrates.
 - Fix unnecessary full-table reads for `select()` filters containing more than 64 values.
 - Fix unnecessary full-table reads for long `in` lists combined with another condition, such as `name: { contains: 'x' }`.
 - Improve limited reads with additional conditions so they stop after enough matching rows are found when index order satisfies the requested sort.

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -1,7 +1,9 @@
 # Fix React SSR auth query hydration
 
 Objective:
-Stop `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a token the client already held; done when a server-rendered authenticated query survives hydration and the React suite passes; plan docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md.
+Stop `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a
+token the client already held; done when React tests, lint, release note, and
+task-plan checks pass, with the known upstream build failure recorded.
 
 Goal plan:
 docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -10,38 +12,246 @@ Template:
 docs/plans/templates/task.md
 
 Task source:
-- type: single-PR task
+- type: single-PR bug fix
 - id / link: #459 https://github.com/udecode/kitcn/pull/459
-- title: authenticated SSR cRPC hydration is cleared when Convex confirms the same token
+- title: authenticated SSR cRPC hydration is cleared when Convex confirms the
+  same token
+- acceptance criteria: preserve hydrated authenticated queries during same-token
+  confirmation; retain resets for rejection, sign-out, and identity changes;
+  preserve explicit reset behavior; pass focused verification.
+- caveat: commit, push, PR replies, and thread resolution are user-owned.
+- likely owner: `packages/kitcn/src/react/context.tsx` and its focused test.
+- browser surface: provider hydration behavior; covered at the React lifecycle
+  boundary without changing rendered UI.
+- root-cause layer: auth-state transition handling in `CRPCProviderInner`.
 
 Task PR:
 #459 https://github.com/udecode/kitcn/pull/459
 
+Timed checkpoint:
+- requested duration: N/A; no duration requested.
+- semantics: N/A.
+- initial confidence score: N/A; direct regression coverage is the threshold.
+- improvement loop: N/A.
+- final score / loop closure: N/A.
+
+Completion threshold:
+- The same-identity false-to-true auth confirmation leaves hydrated queries
+  intact.
+- Token rejection, sign-out, and identity changes still reset auth queries;
+  explicit `resetAuthQueries()` remains unchanged.
+- Focused React tests, lint, the release artifact, and this plan's completion
+  checker pass; the package build is run and any upstream-baseline failure is
+  recorded honestly.
+- Review feedback has source-backed dispositions. The user explicitly owns the
+  resulting commit, push, replies, and resolution.
+
+Verification surface:
+- `bun test packages/kitcn/src/react/`
+- `bun --cwd packages/kitcn build`
+- `bun lint:fix`
+- `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md`
+- Source audit of the PR diff, existing unreleased changesets, and the two review
+  findings supplied for PR #459.
+
+Constraints:
+- Preserve auth-query clearing for actual identity changes and rejected tokens.
+- Do not replace or intercept explicit `resetAuthQueries()` calls.
+- Keep the fix in the shared React provider rather than patching downstream apps.
+- Reuse an existing unreleased `kitcn` changeset.
+- Do not stage, commit, push, reply, resolve threads, or otherwise mutate the PR;
+  the user explicitly retained those actions.
+
+Boundaries:
+- Source of truth: PR #459, the supplied review comments, current branch diff,
+  `CRPCProviderInner`, and its focused React tests.
+- Allowed edit scope: the task plan and existing release changeset for this
+  feedback pass; the existing runtime fix and tests remain unchanged.
+- Browser surface: no rendered component changed; provider state transitions are
+  exercised by React tests.
+- GitHub issue sync: N/A; this task is PR-backed with no separate issue.
+- Non-goals: redesigning auth, changing cRPC APIs, touching example scaffolds, or
+  broad query-cache invalidation changes.
+
+Output budget strategy:
+- Read exact instruction, plan, changeset, provider, and test files; use capped
+  diffs and focused commands rather than broad repository output.
+
+Blocked condition:
+- Stop if the requested feedback conflicts with runtime behavior, the existing
+  release draft cannot represent a patch entry, or focused verification exposes
+  a regression requiring product/API direction.
+
+Task state:
+- task_type: bug fix with PR-feedback repair
+- task_complexity: non-trivial behavior fix; feedback repair is bounded
+- current_phase: closeout
+- current_phase_status: complete locally
+- next_phase: user commit, push, reply, and thread resolution
+- goal_status: locally complete
+
+Current verdict:
+- verdict: valid fix; both review findings accepted
+- confidence: high at the provider/test boundary
+- next owner: user
+- reason: runtime proof and required local artifacts are complete; remote Git
+  operations were explicitly declined for this assistant.
+
+Implementation readiness:
+- verdict: ready and implemented
+- exact owner: `CRPCProviderInner`
+- contradiction status: none
+- source-listed cases complete: yes
+
+Pre-solution issue challenge:
+- reporter claim: same-token SSR auth confirmation clears hydrated authenticated
+  cRPC queries.
+- suggested diagnosis or fix: avoid treating the false-to-true confirmation as
+  an identity transition.
+- repro ladder:
+  - tests / source-level repro: focused provider lifecycle test reproduces the
+    transition and observes `resetAuthQueries()`.
+  - repo-owned automated browser or integration proof: N/A; the React harness
+    directly owns the state transition.
+  - Browser plugin: N/A; no rendered UI implementation exists in this PR.
+  - screenshot / visual proof: N/A; cache reset is not a visual artifact.
+- reproduction verdict: reproduced at the provider boundary.
+- validity verdict: valid.
+- best long-term fix boundary: shared `CRPCProviderInner` transition logic.
+- harsh honest feedback: resetting on every `isAuthenticated` change confused
+  token validation state with reader identity.
+- hard-stop decision: proceed; the claim is reproduced and the owner is known.
+
+Completion rule:
+- Close locally only after every checklist item and gate below is resolved and
+  the plan checker passes. Commit/push/reply/resolve remain with the user.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Timed checkpoint parsed | no | No duration requested. |
+| Walkthrough baseline | no | No rendered UI files changed. |
+| Skill analysis before edits | yes | Root instructions, task, autogoal, PR-feedback, and changeset rules read. |
+| Active goal checked or created | yes | Existing per-PR plan retained and completed. |
+| Source of truth read before edits | yes | PR diff, provider, tests, plan, and changesets inspected. |
+| Exact per-PR task ownership | yes | This plan owns PR #459 only. |
+| GitHub comments and attachments read | yes | Two supplied inline comments were triaged; API fetch was unavailable. |
+| Video transcript evidence required | no | No video supplied. |
+| Pre-solution issue challenge required | yes | Behavior claim reproduced at provider boundary. |
+| Reproduction verdict before implementation | yes | Existing focused test records the failing transition. |
+| Repro escalation ladder selected | yes | React lifecycle harness is the smallest honest owner. |
+| Suggested fix reviewed against durable boundary | yes | Shared provider fix retained; no downstream workaround. |
+| `docs/solutions` checked | yes | Related timing solutions inspected; none owns this exact transition. |
+| TDD decision before behavior change | yes | Provider tests cover both auth transition directions. |
+| Branch decision | yes | Dedicated branch already owns PR #459. |
+| Release artifact decision | yes | Reuse `.changeset/wide-index-union-stays-indexed.md`. |
+| Browser tool decision | no | Provider transition is directly observable in React tests. |
+| Commit / PR expectation decision | yes | User explicitly declined assistant commit/push/PR mutations. |
+| Task-style PR body decision | yes | Existing PR body owns presentation; no mutation authorized. |
+| Task-plan PR body evidence | yes | PR review references this plan at the PR head. |
+| GitHub issue sync expectation | no | No separate issue. |
+| Output budget strategy recorded | yes | Exact files and capped output used. |
+
+Work Checklist:
+- [x] No duration was requested; timed work is N/A.
+- [x] Objective, threshold, verification, constraints, boundaries, and blocker
+      are concrete.
+- [x] Task source records PR, acceptance cases, owner, and browser surface.
+- [x] This plan owns exactly PR #459.
+- [x] Video evidence is N/A because none was supplied.
+- [x] The public behavior claim was challenged and reproduced.
+- [x] The repro ladder stops at the owning React lifecycle harness.
+- [x] The valid bug proceeded only after its owner was identified.
+- [x] Nearby instructions, implementation, tests, solutions, and release rules
+      were read.
+- [x] Every source-listed behavior case has an owner and proof row.
+- [x] Readiness is `ready` with no unresolved contradiction.
+- [x] The shared provider owns the fix; no downstream workaround was added.
+- [x] The release note reuses an existing unreleased changeset.
+- [x] Final handoff separates local edits from user-owned Git/PR actions.
+- [x] Commit and push are N/A because the user explicitly declined them.
+- [x] PR body mutation is N/A because the user retained remote actions.
+- [x] The plan exists at the PR head and identifies PR #459.
+- [x] The dedicated branch remains unchanged.
+- [x] Local install corruption was not indicated; reinstall is N/A.
+- [x] Verification runs in `/Users/tim/Repositories/kitcn`, the owning repo.
+- [x] Output remained scoped to exact files and capped diffs.
+- [x] High-risk note recorded: a false negative could retain another identity's
+      cache; identity-change and rejection tests guard that boundary.
+- [x] Additional autoreview is N/A for this feedback-only docs/release repair;
+      the runtime diff was already reviewed.
+- [x] Agent-native review is N/A; no agent workflow files changed.
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Named verification threshold | yes | Run focused tests, package build, lint, and plan checker. | 143 tests pass; lint and checker pass; build reaches documented upstream dependency gate. |
+| Exact per-PR task ownership | yes | Name one PR and plan. | PR #459 and this plan. |
+| Pre-solution issue challenge verdict | yes | Record claim, repro, validity, and boundary. | Valid; reproduced in provider harness. |
+| Repro escalation ladder | yes | Record each applicable layer. | React harness applies; browser/visual layers are N/A. |
+| Bug reproduced before fix | yes | Exercise same-token false-to-true transition. | Focused test covers it. |
+| Targeted behavior verification | yes | Run React suite. | 143 pass, 0 fail. |
+| TypeScript changed | yes | Run focused tests and package build. | Tests pass; build reaches known `better-call`/`rou3` gate. |
+| Package exports or file layout changed | no | N/A. | Neither changed. |
+| Package manifests or install graph changed | no | N/A. | Neither changed. |
+| Agent rules or skills changed | no | N/A. | None changed. |
+| Workspace authority proof | yes | Run commands in kitcn repo/package. | Tests and lint ran at root; build ran in `packages/kitcn`. |
+| Browser surface changed | no | N/A. | No rendered UI changed. |
+| Browser final proof | no | N/A. | Provider lifecycle is directly tested. |
+| UI walkthrough | no | N/A. | No UI output changed. |
+| Scaffold or fixture output changed | no | N/A. | No scaffold source changed. |
+| Package behavior or public API changed | yes | Reuse active changeset. | Existing draft updated; new duplicate removed. |
+| Docs and kitcn skill sync changed | no | N/A. | User docs and published skill docs unchanged. |
+| Docs or content changed | yes | Validate plan and release copy. | Plan checker passes; lint checks 970 files with no fixes. |
+| High-risk mini gate | yes | Guard identity isolation and rejection behavior. | Tests cover identity change, sign-out, and rejection. |
+| Agent-native reviewer | no | N/A. | No agent/tooling changes. |
+| Local install corruption suspected | no | N/A. | No corruption-shaped failure. |
+| Commit created | no | N/A. | User explicitly said not to commit. |
+| PR create or update | no | N/A. | PR exists; user owns push and update. |
+| Task-style PR body verified | no | N/A. | Remote read-back is outside this feedback pass. |
+| PR task evidence verified | yes | Plan identifies exact PR. | This file names #459. |
+| PR proof image hosting | no | N/A. | No proof image needed. |
+| GitHub issue sync-back | no | N/A. | No separate issue. |
+| Final handoff contract | yes | Record local result and user-owned next action. | Filled below. |
+| Final lint | yes | Run `bun lint:fix`. | 970 files checked; no fixes applied. |
+| Output budget discipline | yes | Keep reads and output bounded. | Exact-file reads used; one broad read was replaced with slices. |
+| Timed checkpoint | no | N/A. | No duration requested. |
+| Autoreview | no | N/A. | Feedback repair changes only plan and release metadata. |
+| Goal plan complete | yes | Run the mechanical checker. | `[autogoal] complete`. |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Intake and source read | complete | PR diff, instructions, plan, changesets, and comments inspected. | implementation |
+| Implementation | complete | Shared provider fix and tests present; review artifacts corrected locally. | verification |
+| Verification | complete | Focused commands recorded below. | closeout |
+| Commit / PR / GitHub sync | complete | Delegated to user; assistant made no Git or remote mutations. | user action |
+| Closeout | complete | Local diff and remaining user action reported. | user commit/push |
+
 ## Problem
 
-`CRPCProviderInner` resets every auth-bound query when either the token identity
-or `isAuthenticated` changes. The flag reports whether Convex has accepted the
+`CRPCProviderInner` reset every auth-bound query when either the token identity
+or `isAuthenticated` changed. The flag reports whether Convex has accepted the
 current token, not who holds it, so it turns from false to true on every
 server-rendered page once Convex validates the token that arrived in the HTML.
-The reset then erases the queries the same render hydrated, and the screen loses
-rows it had already shown.
+The reset erased the queries the same render hydrated.
 
 ## Canonical reproduction path
 
 `example/src/components/providers.tsx` prefetches
 `crpc.user.getCurrentUser.queryOptions(undefined, { skipUnauth: true })` and
-wraps the tree in `HydrateClient`, and
+wraps the tree in `HydrateClient`.
 `example/src/lib/convex/convex-provider.tsx` passes that request's token to
-`ConvexAuthProvider` and mounts `CRPCProvider` under it. Any client reading that
-query loses the hydrated result on load.
+`ConvexAuthProvider` and mounts `CRPCProvider` under it. A client reading that
+query used to lose the hydrated result on load.
 
 ## Fix
 
 `packages/kitcn/src/react/context.tsx` compares the token-derived identity and
 the direction of settled authentication changes. `resolveAuthIdentity` already
-collapses a JWT to its non-volatile claims, so routine rotation stays a no-op
-while signing out, switching accounts, an opaque token becoming a JWT, and a
-change to any other claim all produce a different identity. Convex confirming
+collapses a JWT to its non-volatile claims, so routine rotation stays a no-op.
+Signing out, switching accounts, an opaque token becoming a JWT, and changing
+another identity claim still produce a different identity. Convex confirming
 the same SSR token from false to true preserves hydrated data; Convex rejecting
 an accepted token from true to false clears auth-bound queries even when the
 token remains cached. Explicit `resetAuthQueries()` calls are untouched.
@@ -49,19 +259,116 @@ token remains cached. Explicit `resetAuthQueries()` calls are untouched.
 ## Tests
 
 `packages/kitcn/src/react/context.test.tsx` covers both directions explicitly: a
-JWT present on the first render survives the initial false-to-true confirmation,
+JWT present on the first render survives initial false-to-true confirmation,
 while a previously accepted token moving true to false resets auth-bound
-queries. The existing account-switch, claim-change, opaque-to-JWT and rotation
-cases stay as they are.
+queries. Existing account-switch, claim-change, opaque-to-JWT, sign-out,
+explicit-reset, and rotation cases remain.
 
-## Verification
+Findings:
+- The new release-note file violated the repository rule because multiple
+  unreleased `kitcn` drafts already exist.
+- The initial plan described the bug and fix but omitted the task template's
+  completion and evidence surfaces.
+- Related solution notes cover auth/query-client wiring and loader timing, not
+  this false-to-true provider transition.
 
-- `bun test packages/kitcn/src/react/`
-- `bun lint`
-- `bun run lint:fix`
+Decisions and tradeoffs:
+- Ignore same-identity false-to-true confirmation only; clearing on rejection
+  and identity change protects cache isolation.
+- Update the current minor release draft's `## Patches` section rather than
+  retaining a second patch changeset.
+- Keep browser proof N/A because the React provider harness directly exercises
+  the transition without a rendered UI change.
 
-`bun run build:pkg` and `bun typecheck` fail on `main` at 5b0bd5a1 for unrelated
-reasons: the package build stops on `better-call is located in node_modules but
-is not included in inlineOnly`, and the `test-convex` typecheck cannot resolve
-`kitcn/auth/*` without that build. Both reproduce on a pristine checkout of the
-same commit.
+Implementation notes:
+- Runtime behavior and tests were not changed during feedback repair.
+- `.changeset/lucky-cups-shine.md` was removed and its user-facing patch bullet
+  moved to `.changeset/wide-index-union-stays-indexed.md`.
+- The per-PR plan now records the complete task contract and evidence.
+
+Review fixes:
+- “Complete the task plan before treating it as PR evidence” -> accepted ->
+  completed threshold, verification, constraints, boundaries, blocker,
+  checklists, phases, evidence, and handoff state.
+- “Reuse an existing unreleased changeset” -> accepted -> merged the patch entry
+  into the active release draft and removed the duplicate file.
+
+Error attempts:
+| Error / failed attempt | Count | Next different move | Resolution |
+| --- | --- | --- | --- |
+| GitHub helper could not resolve fork as upstream repo | 1 | Use supplied comments | Supplied comments became the bounded feedback inventory. |
+| GitHub API unavailable in sandbox | 1 | Use local PR diff and screenshot | No remote mutations attempted. |
+| Initial broad instruction read was truncated | 1 | Read exact slices | Relevant instructions were read in bounded chunks. |
+
+Verification evidence:
+- `bun test packages/kitcn/src/react/` in `/Users/tim/Repositories/kitcn` ->
+  143 pass, 0 fail, 420 expectations.
+- `bun --cwd packages/kitcn build` -> React, Solid, and CLI bundles build; the
+  remaining entry stops at the documented upstream-main `better-call`/`rou3`
+  `inlineOnly` gate. The original task run reproduced the same failure on
+  pristine `5b0bd5a1`; this feedback pass does not alter package code.
+- `bun lint:fix` -> 970 files checked, no fixes applied.
+- `git diff --check` -> clean.
+- Plan checker -> `[autogoal] complete`.
+
+Source-listed case matrix:
+| Case | Source claim | Harness | Before | Expected after | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| SSR confirmation | Same-token false-to-true clears hydrated queries. | React provider test | reset called | no reset | focused React suite | covered |
+| Token rejection | True-to-false with retained token must clear. | React provider test | reset called | reset called | focused React suite | covered |
+| Sign-out | Removing the token must clear. | Existing provider test | reset called | reset called | focused React suite | covered |
+| Identity change | Account or stable claim change must clear. | Existing provider tests | reset called | reset called | focused React suite | covered |
+| Token rotation | Volatile JWT claims alone must not clear. | Existing provider test | no reset | no reset | focused React suite | covered |
+| Explicit reset | Direct reset remains effective. | Existing query-client behavior | effective | effective | method remains untouched | covered |
+
+Final handoff contract:
+- Commit line: N/A; user explicitly retained commit authority.
+- PR line: PR #459 exists; user owns pushing this local feedback repair.
+- Issue line: N/A; no separate issue.
+- Confidence line: high for the bounded local repair and provider behavior.
+- Flow table:
+  - Reproduced: React lifecycle tests; browser N/A.
+  - Verified: focused suite, lint, plan checker, and documented package-build
+    baseline failure.
+- Browser check: N/A; no rendered UI change in this repository.
+- Outcome: hydrated auth queries survive same-token confirmation while real auth
+  boundary changes still clear them.
+- Caveat: GitHub replies and thread resolution wait for the user's commit/push.
+- Design:
+  - Chosen boundary: shared `CRPCProviderInner` transition logic.
+  - Why not quick patch: downstream apps cannot safely own provider cache rules.
+  - Why not broader change: token identity normalization and explicit resets
+    already behave correctly.
+- Verified: see evidence section.
+- PR body verified: N/A for this local-only feedback pass.
+
+Final handoff / sync:
+- Commit: user-owned; no assistant commit.
+- PR: #459; no assistant push, reply, or resolution.
+- Issue: N/A.
+- Browser proof: N/A; provider lifecycle tests own proof.
+- Caveats: remote feedback remains open until the user performs remote steps.
+
+Timeline:
+- 2026-09-10: Task plan created for PR #459.
+- 2026-09-10: Runtime fix and provider regression tests implemented.
+- 2026-09-10: Review feedback accepted; plan completed and release note folded
+  into the existing unreleased draft.
+- 2026-09-10: Focused verification rerun after feedback edits.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Local feedback repair complete. |
+| Where am I going? | User reviews, commits, pushes, replies, and resolves PR threads. |
+| What is the goal? | Preserve SSR-hydrated auth queries during same-token confirmation. |
+| What have I learned? | Auth confirmation is validation state, not identity change. |
+| What have I done? | Corrected release metadata and completed per-PR evidence. |
+
+Open risks:
+- The local feedback corrections are uncommitted and the two GitHub threads
+  remain unresolved until the user performs the remote steps.
+
+Hard closeout guard:
+- Satisfied locally because the user explicitly declined assistant commit, push,
+  reply, and resolution authority.

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -37,20 +37,22 @@ query loses the hydrated result on load.
 
 ## Fix
 
-`packages/kitcn/src/react/context.tsx` compares the token-derived identity only.
-`resolveAuthIdentity` already collapses a JWT to its non-volatile claims, so
-routine rotation stays a no-op while signing out, switching accounts, an opaque
-token becoming a JWT, and a change to any other claim all produce a different
-identity. The unused `isAuthenticated` read, ref field and effect dependency are
-gone, and the ref is now `previousIdentityRef`. Explicit
-`resetAuthQueries()` calls are untouched.
+`packages/kitcn/src/react/context.tsx` compares the token-derived identity and
+the direction of settled authentication changes. `resolveAuthIdentity` already
+collapses a JWT to its non-volatile claims, so routine rotation stays a no-op
+while signing out, switching accounts, an opaque token becoming a JWT, and a
+change to any other claim all produce a different identity. Convex confirming
+the same SSR token from false to true preserves hydrated data; Convex rejecting
+an accepted token from true to false clears auth-bound queries even when the
+token remains cached. Explicit `resetAuthQueries()` calls are untouched.
 
 ## Tests
 
-`packages/kitcn/src/react/context.test.tsx` gains one case: a JWT present on the
-first render, the flag moving false to true, back to false, and to true again
-with no reset, then the token going null and resetting once. The existing
-account-switch, claim-change, opaque-to-JWT and rotation cases stay as they are.
+`packages/kitcn/src/react/context.test.tsx` covers both directions explicitly: a
+JWT present on the first render survives the initial false-to-true confirmation,
+while a previously accepted token moving true to false resets auth-bound
+queries. The existing account-switch, claim-change, opaque-to-JWT and rotation
+cases stay as they are.
 
 ## Verification
 

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -210,13 +210,13 @@ Completion Gates:
 | Targeted behavior verification | yes | Run React suite. | 143 pass, 0 fail. |
 | TypeScript changed | yes | Run focused tests and package build. | Tests pass; build reaches known `better-call`/`rou3` gate. |
 | Package exports or file layout changed | no | N/A. | Neither changed. |
-| Package manifests or install graph changed | no | N/A. | Neither changed. |
+| Package manifests or install graph changed | yes | Regenerate fixture manifests through the CLI and verify the generated applications. | Six next/start/vite fixture manifests, with and without auth, use lucide-react ^1.44.0; fixtures:sync and all eight fixtures:check comparisons pass within full bun check. |
 | Agent rules or skills changed | no | N/A. | None changed. |
 | Workspace authority proof | yes | Run commands in kitcn repo/package. | Tests and lint ran at root; build ran in `packages/kitcn`. |
 | Browser surface changed | no | N/A. | No rendered UI changed. |
 | Browser final proof | no | N/A. | Provider lifecycle is directly tested. |
 | UI walkthrough | no | N/A. | No UI output changed. |
-| Scaffold or fixture output changed | no | N/A. | No scaffold source changed. |
+| Scaffold or fixture output changed | yes | Run fixtures:sync and fixtures:check; never hand-edit generated output. | CLI regeneration changed six fixture manifests; all eight fixture comparisons and runtime lanes pass. Scaffold source remains unchanged. |
 | Package behavior or public API changed | yes | Reuse active changeset. | Existing draft updated; new duplicate removed. |
 | Docs and kitcn skill sync changed | no | N/A. | User docs and published skill docs unchanged. |
 | Docs or content changed | yes | Validate plan and release copy. | Plan checker passes; lint checks 970 files with no fixes. |

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -1,0 +1,65 @@
+# Fix React SSR auth query hydration
+
+Objective:
+Stop `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a token the client already held; done when a server-rendered authenticated query survives hydration and the React suite passes; plan docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md.
+
+Goal plan:
+docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+
+Template:
+docs/plans/templates/task.md
+
+Task source:
+- type: single-PR task
+- id / link: PR pending, fill in after opening
+- title: authenticated SSR cRPC hydration is cleared when Convex confirms the same token
+
+Task PR:
+pending, fill in after opening
+
+## Problem
+
+`CRPCProviderInner` resets every auth-bound query when either the token identity
+or `isAuthenticated` changes. The flag reports whether Convex has accepted the
+current token, not who holds it, so it turns from false to true on every
+server-rendered page once Convex validates the token that arrived in the HTML.
+The reset then erases the queries the same render hydrated, and the screen loses
+rows it had already shown.
+
+## Canonical reproduction path
+
+`example/src/components/providers.tsx` prefetches
+`crpc.user.getCurrentUser.queryOptions(undefined, { skipUnauth: true })` and
+wraps the tree in `HydrateClient`, and
+`example/src/lib/convex/convex-provider.tsx` passes that request's token to
+`ConvexAuthProvider` and mounts `CRPCProvider` under it. Any client reading that
+query loses the hydrated result on load.
+
+## Fix
+
+`packages/kitcn/src/react/context.tsx` compares the token-derived identity only.
+`resolveAuthIdentity` already collapses a JWT to its non-volatile claims, so
+routine rotation stays a no-op while signing out, switching accounts, an opaque
+token becoming a JWT, and a change to any other claim all produce a different
+identity. The unused `isAuthenticated` read, ref field and effect dependency are
+gone, and the ref is now `previousIdentityRef`. Explicit
+`resetAuthQueries()` calls are untouched.
+
+## Tests
+
+`packages/kitcn/src/react/context.test.tsx` gains one case: a JWT present on the
+first render, the flag moving false to true, back to false, and to true again
+with no reset, then the token going null and resetting once. The existing
+account-switch, claim-change, opaque-to-JWT and rotation cases stay as they are.
+
+## Verification
+
+- `bun test packages/kitcn/src/react/`
+- `bun lint`
+- `bun run lint:fix`
+
+`bun run build:pkg` and `bun typecheck` fail on `main` at 5b0bd5a1 for unrelated
+reasons: the package build stops on `better-call is located in node_modules but
+is not included in inlineOnly`, and the `test-convex` typecheck cannot resolve
+`kitcn/auth/*` without that build. Both reproduce on a pristine checkout of the
+same commit.

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -1,5 +1,22 @@
 # Fix React SSR auth query hydration
 
+Maintainer closeout (2026-09-10):
+- The owner explicitly invoked `kitcn:autoclosure` for PR #459. Commit, push,
+  feedback replies and delivery are authorized for this continuation; the
+  contributor's earlier user-owned Git boundary below describes that earlier
+  run only.
+- Current closure ledger: `docs/plans/2026-09-10-pr459-autoclosure.md`.
+- At e02ac1f39124e0adabb1d164ababb0e8024db312, this checkout independently passed
+  all 143 React tests, the kitcn package build and this plan's checker. The
+  contributor's earlier build failure does not reproduce locally.
+- CI failed on generated fixture manifests. `bun run fixtures:sync` regenerated
+  six manifests with lucide-react ^1.44.0; no hand edits to fixture outputs.
+- Full `bun check` passes locally, including regenerated fixture checks,
+  verify and runtime lanes. Independent review of the PR source found no P0/P1
+  defects. The previous local-complete verdict is not a merge-ready verdict:
+  Vercel fork-deployment authorization awaits the owner's confirmation, and
+  fixture-repair delivery is recorded in the closure ledger.
+
 Objective:
 Stop `CRPCProvider` clearing authenticated cRPC queries when Convex confirms a
 token the client already held; done when React tests, lint, release note, and

--- a/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
+++ b/docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
@@ -11,11 +11,11 @@ docs/plans/templates/task.md
 
 Task source:
 - type: single-PR task
-- id / link: PR pending, fill in after opening
+- id / link: #459 https://github.com/udecode/kitcn/pull/459
 - title: authenticated SSR cRPC hydration is cleared when Convex confirms the same token
 
 Task PR:
-pending, fill in after opening
+#459 https://github.com/udecode/kitcn/pull/459
 
 ## Problem
 

--- a/docs/plans/2026-09-10-pr459-autoclosure.md
+++ b/docs/plans/2026-09-10-pr459-autoclosure.md
@@ -1,0 +1,334 @@
+# PR459 autoclosure
+
+Objective:
+Close PR #459 with passing checks, replayed feedback proofs, and verified GitHub delivery.
+
+Flow mode:
+one-shot execution.
+
+Task invocation:
+Resume `kitcn:task https://github.com/udecode/kitcn/pull/459` through its dedicated
+`docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md` plan. This supporting
+autoclosure plan owns only this PR, not the earlier PR batch.
+
+User requirements:
+- Exact request: `$kitcn:autoclosure`, following PR #459.
+- Finish existing work, including required feedback replay, checks, review,
+  authorized commit/push/replies/resolution, exact-head receipt and delivery.
+- No new product scope; no P2/P3 waiver requested for this PR.
+- Preserve existing auto-release choice; do not claim release from merge alone.
+- Stop only at the skill's real external/authority/environment boundaries.
+
+Goal plan:
+docs/plans/2026-09-10-pr459-autoclosure.md
+
+Template:
+docs/plans/templates/autoclosure.md
+
+Primary template:
+docs/plans/templates/autoclosure.md
+
+Applied packs:
+- agent-native (docs/plans/templates/packs/agent-native.md)
+
+Completion threshold:
+- All matrix lanes pass or have concrete N/A evidence; zero actionable P1+
+  findings, exact-head terminal receipt, merge and release outcome read back.
+- No new product scope. Completion requires every applicable lane below to have
+  fresh evidence, `bun check` passing, review findings closed, authorized
+  GitHub delivery complete, and the goal checker passing.
+
+Verification surface:
+- `bun test packages/kitcn/src/react/`, package build, source-first typecheck,
+  fixture regeneration/check if required, `bun lint:fix`, `bun check`, plan
+  checkers, deslop, agent-native review, autoreview and GitHub read-back.
+
+Constraints:
+- Finish the intended delta; do not invent the next feature.
+- Preserve source/generated/package/docs ownership.
+- Use a different diagnostic after repeated failure signatures.
+
+Boundaries:
+- intended delta: SSR same-token auth confirmation preserves hydrated queries;
+  rejected tokens and changed identity still reset auth-bound cache.
+- allowed repairs: direct provider/test owners, release draft, plans and bounded
+  verification failures including generated fixture drift.
+- unrelated files: preserve; do not treat as blockers
+- non-goals: new auth APIs, PR452 repairs, new features, workflow redesign.
+
+Output budget strategy:
+- Exact owners and bounded reads; save noisy command output under /tmp and
+  inspect summaries. Do not stream full CI logs again.
+
+Blocked condition:
+- Missing fork push/access, required external authorization, failed live
+  feedback mutation/readback, or reproducible environment failure after
+  different relevant attempts. Never waive failed checks from an author claim.
+
+Start Gates:
+| Gate | Applies | Evidence |
+| --- | --- | --- |
+| Dedicated task invocation and plan for exact PR | yes | task resumed for #459 and its dedicated original plan |
+| Task evidence verified at PR head | yes | e02ac1f3 body/path/exact owner verified; checker passes |
+| Active source/plan reconstructed | yes | Original task plan, provider/tests and release draft read |
+| Intended delta and exclusions recorded | yes | Scope baseline and user requirements above |
+| Closure matrix classified | yes | Applicable source/build/fixtures/checks/feedback/delivery lanes identified |
+| Live PR feedback target resolved | conditional | exact compliant PR for full `resolve-pr-feedback` mode; N/A after verified noncompliant close |
+| Feedback proof checkout bound to PR head | conditional | local committed `HEAD` = fetched PR ref = live `headRefOid` for a compliant PR |
+| Unfiltered feedback inventory | conditional | raw top-level comments/reviews plus all resolved/unresolved inline threads compared with helper output for a compliant PR |
+| GitHub delivery expectation recorded | yes | User invokes autoclosure; fork permits maintainer edits; dry-run push succeeds |
+| Active goal checked or created | yes | Goal created for only #459 |
+| Agent-native pack selected | yes | Required by autoclosure; materialized here |
+| Agent-facing action surface identified | no | No new agent action or workflow behavior |
+| Source rule versus generated mirror boundary identified | no | No rule or skill modifications |
+| Installed-skill lock versus local-rule owner identified | no | No installed skill changes |
+| `agent-native-reviewer` loaded or waiver recorded | yes | Loaded and parity audit recorded below |
+
+Closure matrix:
+| Lane | Applies | Owner/proof | Status |
+| --- | --- | --- | --- |
+| per-PR task ownership | yes | exact PR + dedicated task plan at e02ac1f3 | pass |
+| noncompliant close | no | PR is compliant | N/A |
+| source behavior | yes | 143 React tests / 420 expectations | pass; post-push replay required |
+| package/API/build | yes | kitcn build exit 0; all five typechecks pass | pass |
+| generated output | yes | fixtures:sync regenerated six manifests from CLI | all eight fixtures pass |
+| fixtures/scenarios | yes | full bun check includes fixture and scenario lanes | pass |
+| docs/package skill | no | Existing React docs and published setup/react hydration config agree; no API change | N/A edits |
+| changeset | yes | Existing kitcn minor draft contains one hydration fix | pass |
+| agent workflow | no | No workflow source or lock change | N/A |
+| live PR feedback | conditional | compliant: `resolve-pr-feedback` + final P1 read-back; noncompliant: N/A with comment/CLOSED receipts | pending |
+| cleanup/review | yes | Deslop zero new findings; agent-native audit no gap; PR source autoreview clean | fixture-repair review next |
+| repository check | yes | `bun check` | pass, exit 0 |
+| GitHub delivery | yes | Fork update, full gate, exact-head receipt, CI, merge/release readback | Vercel approval requested |
+
+Feedback ledger:
+Full helper inventory is `/tmp/kitcn-pr459-feedback.json`; raw inventories are
+`/tmp/kitcn-pr459-{comments,reviews}.jsonl` and `threads.json` (same prefix).
+Raw: two top-level comments, two review bodies, four resolved threads with one
+comment each. All thread/comment pageInfo.hasNextPage=false. Helper: zero
+threads, one top-level comment, two review bodies. No item dismissed by author
+or resolved state. All original explicit P1 classifications retained.
+
+| Exact URL | Priority and rationale | Current owner / proof | Verdict / reply / resolution |
+| --- | --- | --- | --- |
+| https://github.com/udecode/kitcn/pull/459#discussion_r3978131388 | P1: retained rejected credentials must not keep auth cache | context.tsx tokenRejected; React rejection test passes at e02ac1f3 | fixed; proof reply required; already resolved |
+| https://github.com/udecode/kitcn/pull/459#discussion_r3978131400 | P1 explicit: release-note policy contract | wide-index-union-stays-indexed.md has one hydration outcome | fixed; proof reply required; already resolved |
+| https://github.com/udecode/kitcn/pull/459#discussion_r3978369526 | P1: required exact-PR evidence | dedicated task plan; check-complete passes at e02ac1f3 | fixed; proof reply required; already resolved |
+| https://github.com/udecode/kitcn/pull/459#discussion_r3978369548 | P1 explicit: existing release draft ownership | only existing wide-index draft modified; no lucky-cups file | fixed; proof reply required; already resolved |
+| https://github.com/udecode/kitcn/pull/459#issuecomment-5617146874 | P1 potential release contract: bot claims no release | existing draft has kitcn minor and hydration bullet; comment itself lists two pending package releases | not-addressing new-file suggestion; quoted evidence reply required |
+| https://github.com/udecode/kitcn/pull/459#issuecomment-5617146891 | P1 delivery: Vercel requests authorization | head status is failure authorization; no successful Preview proven | needs-human/access investigation; not waived |
+| https://github.com/udecode/kitcn/pull/459#pullrequestreview-5165962854 | N/A wrapper | body only describes Codex review mechanics; findings separately ledgered | non-actionable, no reply needed |
+| https://github.com/udecode/kitcn/pull/459#pullrequestreview-5166257859 | N/A wrapper | body only describes Codex review mechanics; findings separately ledgered | non-actionable, no reply needed |
+
+Scope baseline and review:
+- User requested autoclosure of #459, target fork branch
+  tjramage/fix/react-ssr-auth-query-hydration. Intended provider invariant and
+  direct cache-reset owners only; no new auth contract or sibling Solid rewrite.
+- Original delta: four files, provider 8 additions/10 removals, tests 89 added
+  lines, release draft 2 added lines, dedicated task plan. No API exports changed.
+- Deslop: three local lenses (rules, source/type ownership, simplification)
+  found no actionable source cleanup. Existing test casts match the harness;
+  introducing new mock abstractions would not improve this bounded fix.
+- `bun run lint:slop:delta`: 179 -> 179; no added/worsened occurrences.
+- Agent-native review: provider action has existing React test command and
+  source owner; no agent workflow/config/tool action changes. Generated fixture
+  repair follows fixtures:sync, not manual output patches. No parity gap found.
+- Behavior proof is provider lifecycle, not a UI layout change: tests observe
+  reset calls through the public provider; no screenshot claim made. Browser
+  visual lane is N/A for this bounded non-rendering source delta.
+
+Feedback replies (read back):
+- https://github.com/udecode/kitcn/pull/459#discussion_r3983829071 answers
+  3978131388 with exact-head rejection/confirmation test proof.
+- https://github.com/udecode/kitcn/pull/459#discussion_r3983829233 answers
+  3978131400 with the single user-facing release bullet.
+- https://github.com/udecode/kitcn/pull/459#discussion_r3983829416 answers
+  3978369526 with exact-head plan compliance/checker proof.
+- https://github.com/udecode/kitcn/pull/459#discussion_r3983829587 answers
+  3978369548 with release-draft reuse proof.
+- https://github.com/udecode/kitcn/pull/459#issuecomment-5625945122 answers the
+  changeset bot's no-release claim; publication still requires workflow proof.
+- All replies are evidence responses, not new actionable findings. Final raw
+  inventory must include them and any empty review wrappers GitHub creates.
+
+Vercel access:
+- Browser opens login; Chrome's existing zbeyens session reaches
+  `Authorize Fork Deployment` for exact e02ac1f3 and shows `Approve Deployment`.
+- Approval would allow fork code in the Preview environment. Requested explicit
+  action-time confirmation; no click performed, no broad security setting changed.
+
+Fixture repair:
+- `bun run fixtures:sync` exited 0. Exactly six manifest changes, each
+  lucide-react ^1.42.0 -> ^1.44.0 in next/start/vite with and without auth.
+- Source scaffold behavior is unchanged; regeneration repairs the current
+  deterministic fixture comparison against the external component registry.
+- `bun lint:fix` passes; all five workspace typechecks pass. `bun check` exits 0,
+  including fixture checks, verify lane and runtime scenarios.
+
+Raw review-body additions:
+- https://github.com/udecode/kitcn/pull/459#pullrequestreview-5172634378
+- https://github.com/udecode/kitcn/pull/459#pullrequestreview-5172634608
+- https://github.com/udecode/kitcn/pull/459#pullrequestreview-5172634899
+- https://github.com/udecode/kitcn/pull/459#pullrequestreview-5172635218
+All four bodies are exactly empty: non-actionable wrappers created for the
+replies, verified by raw API read-back. Raw inventory after replies: three
+top-level comments, six review bodies, four resolved threads/eight inline
+comments; all pagination flags false. No new actionable reviewer item.
+
+Independent review results:
+- `.agents/skills/autoreview/scripts/autoreview --mode branch --base 5b0bd5a1
+  --max-priority P1`: exit 0; gpt-5.6-sol/high; TruffleHog clean; findings [].
+  Scope is the committed PR delta, not the uncommitted fixture repair.
+  `/tmp/kitcn-pr459-autoreview.{json,md,log}`.
+- Local fixture/plan repair receives its own focused local review before push.
+- Local repair review completed: `autoreview --mode local --max-priority P1`,
+  exit 0, gpt-5.6-sol/high, TruffleHog clean, findings [], confidence 0.96.
+  `/tmp/kitcn-pr459-repair-review.{json,md,log}`. No source fixes requested.
+- The original PR plan is valid; this closure plan deliberately remains open
+  while fork-deployment confirmation and terminal delivery are outstanding.
+
+Work Checklist:
+- [ ] Every PR has its own `task` invocation and dedicated task plan; a batch
+      plan or aggregate autoclosure is not used as a substitute.
+- [ ] Task evidence was verified from the PR body, fetched head, and exact PR
+      ownership; otherwise the required comment and `CLOSED` state were read
+      back and no source review, repair, merge, or release work continued.
+- [ ] Intended behavior and exclusions are reconstructed from real sources.
+- [ ] Each lane is proven or N/A with a concrete reason.
+- [ ] Generated output was changed through its owner and regenerated.
+- [ ] Package/docs/skill/fixture/scenario/changeset contracts are synchronized.
+- [ ] Full `resolve-pr-feedback` ran for the exact compliant PR; every
+      actionable P1-or-higher finding was fixed, proved, replied to, and
+      resolved or received the required top-level reply receipt.
+- [ ] For a compliant PR, local committed `HEAD`, fetched PR ref, and live
+      `headRefOid` matched before proof/reply/resolution and after every push.
+      For a noncompliant PR, this and all feedback gates are N/A with the
+      required remediation-comment and `CLOSED` receipts.
+- [ ] Unfiltered top-level PR comments and review bodies were fetched through
+      the GitHub API, compared by ID/URL with helper output, and every excluded
+      bot/author item was ledgered; identity alone never dismissed feedback.
+      Only the exact terminal receipt produced/read back by this run is exempt
+      from the versioned ledger.
+- [ ] All inline review threads were fetched with GraphQL cursor pagination
+      without filtering resolved/outdated items; every thread has priority,
+      rationale, relocation, and proof state in the ledger.
+- [ ] Every actionable feedback item has a persisted P0-P3 priority and
+      one-sentence rationale from the autoclosure rubric; ambiguous P1-versus-
+      lower items fail closed as P1.
+- [ ] Every P1-or-higher proof reran after the final material branch push,
+      regardless of file type, including resolved or outdated threads that
+      disappear from the helper's unresolved-thread output.
+- [ ] Feedback was re-fetched after the last push/reply/resolution and shows
+      zero unresolved actionable P1-or-higher findings.
+- [ ] After all versioned plan/source updates were pushed, the exact-head P1
+      proof/read-back receipt was posted to the PR and read back; no terminal
+      receipt-only branch push was created. A post-comment `headRefOid` fetch
+      matches the OID recorded in that receipt, and a post-comment helper/raw
+      feedback fetch still shows zero actionable P1-or-higher items and no new
+      URL lacking a verdict or explicit deferral, except the verified receipt.
+- [ ] Any remaining P2-or-lower item has its exact URL plus the user's explicit
+      priority deferral recorded; no feedback was silently ignored.
+- [ ] Accepted cleanup and review findings are closed.
+- [ ] PR body and check state match the final evidence.
+- [ ] Residual blocker/waiver has exact evidence and next owner.
+- [ ] Agent-native pack: source-of-truth rule files are edited instead of generated skill mirrors.
+- [ ] Agent-native pack: the changed agent action is discoverable from the skill/rule text.
+- [ ] Agent-native pack: generated mirrors are synced when `.agents/rules/**` changed, or N/A reason is recorded.
+- [ ] Agent-native pack: installed skills are changed only through
+      `npx skills add/update/remove`; local rules/templates/helpers stay source-owned.
+- [ ] Agent-native pack: routing, required receipts, placeholder failure,
+      completion representability, and forbidden behavior have eval/smoke rows.
+- [ ] Agent-native pack: accepted agent-native review findings are fixed or explicitly rejected with reason.
+
+Error attempts:
+| Failure signature | Count | Next different move | Resolution |
+| --- | ---: | --- | --- |
+| Combined skill read and full CI output truncated | 1 | Read skills in slices; filter subsequent logs | Skill slices read; CI terminal failure identified |
+| Autoreview snapshot changed during bundle creation | 1 | Freeze source and plan while rerunning helper | Initial helper stopped safely before review; retry after plan checkpoint |
+
+Completion Gates:
+| Gate | Applies | Required action | Evidence |
+| --- | --- | --- | --- |
+| Per-PR task ownership | pending | Record exact PR and dedicated task-plan path | pending |
+| Noncompliant PR disposition | pending | Verify task evidence or comment then close and read back | pending |
+| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
+| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
+| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
+| Feedback proof checkout | conditional | Compliant PR only: require local committed `HEAD` = fetched PR ref = live `headRefOid` before proof/reply/resolution and at terminal verification | pending |
+| Live PR feedback resolution | conditional | Compliant PR only: run full `resolve-pr-feedback` and close every actionable P1-or-higher finding; otherwise N/A with noncompliant stop receipts | pending |
+| Feedback priority classification | conditional | Compliant PR only: persist P0-P3 plus rationale for every actionable item; classify ambiguous P1-versus-lower as P1 | pending |
+| Final P1 proof replay | conditional | Compliant PR only: after the final material branch push, rerun every P1-or-higher proof, including resolved/outdated items | pending |
+| Final live feedback read-back | conditional | Compliant PR only: re-fetch helper plus unfiltered top-level/all-thread inventories; require zero actionable P1-or-higher and explicit P2-or-lower deferrals | pending |
+| External terminal receipt | conditional | Compliant PR only: post/read exact-head receipt; require receipt/live/fetched/local OID equality and no unrecorded helper/raw URL except that verified receipt | pending |
+| Deslop | pending | Run bounded cleanup or N/A | pending |
+| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
+| Final lint | yes | Run `bun lint:fix` | pending |
+| Repository check | yes | Run `bun check` | pending |
+| GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-09-10-pr459-autoclosure.md` | pending |
+| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
+| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
+| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
+| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
+| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+
+Phase / pass table:
+| Phase | Status | Evidence | Next |
+| --- | --- | --- | --- |
+| Inventory | in_progress | plan created | missing proof |
+| Repair | pending | | review |
+| Review/checks | pending | | delivery |
+| Delivery | pending | | final audit |
+| Closeout | pending | | final |
+
+Verification evidence:
+- Compliance: OPEN e02ac1f39124e0adabb1d164ababb0e8024db312; exactly one body task
+  line, existing head plan, exact PR459 task source. Local committed HEAD equals
+  fetched refs/pr/459 and live head before proof.
+- Pre-existing PR452 evidence preserved in stash
+  9b7ec75b51a0e54c9c75de11d0f99a7af5fae530 before switching to exact PR459 head.
+  Those two files are this assistant's earlier evidence, not PR459 scope.
+- CI 34474347612 failed on generated next fixture lucide-react ^1.42.0 versus
+  generated ^1.44.0; local reproduction still required.
+- Exact-head React suite: 143 pass, 0 fail, 420 expectations across 14 files.
+  `/tmp/kitcn-pr459-react.log`.
+- Exact-head package build completed; reported better-call/rou3 failure did not
+  reproduce. `/tmp/kitcn-pr459-build.log`. Task checker passes.
+- Package build also rerun with direct exit capture: exit 0,
+  `/tmp/kitcn-pr459-build-exit.log`.
+- Full `bun check`: exit 0, `/tmp/kitcn-pr459-check.log`. Includes 1425 Bun
+  passes, 1047 Vitest passes (14 existing skips), 124 Concave passes, all eight
+  fixture matches, verify and runtime lanes. Both auth smoke scenarios passed.
+- Final lint after plan checkpoint: 970 files, zero changes. Diff whitespace
+  check passes. Fixture repair is ready to commit/push; no auth source change.
+
+Current checkpoint:
+- Local implementation, generated repair, full repository gate, and both
+  committed-source/local-repair reviews pass.
+- Authorized next step is push of the verified fixture/plan repair, then
+  exact-head focused and plan-proof replay plus CI/read-back.
+- Merge/release and the terminal zero-P1 receipt are blocked on Vercel
+  authorization. The owner has not yet answered the action-time approval
+  question. Do not click approval, waive this gate, or claim goal complete.
+- A goal-plan checker failure on the unchecked delivery gates is expected;
+  it correctly represents incomplete autoclosure, not missing PR task evidence.
+
+Timeline:
+- 2026-09-10T21:49:34.652Z Autoclosure plan created.
+
+Reboot status:
+| Question | Answer |
+| --- | --- |
+| Where am I? | Inventory |
+| Where am I going? | Repair, review/checks, delivery, final audit |
+| What is the goal? | Close only PR459 with honest proof and delivery |
+| What have I learned? | See closure matrix |
+| What have I done? | See timeline |
+
+Open risks:
+- Vercel Preview authorization requires explicit action-time confirmation.
+  Requested through the user-input UI; no answer received yet. This is not a
+  waiver or a code defect, and no deployment was approved.
+- Local fixture repair still needs review and push; exact-head feedback replay,
+  terminal receipt, green CI, merge and actual release readback remain undone.

--- a/docs/plans/2026-09-10-pr459-autoclosure.md
+++ b/docs/plans/2026-09-10-pr459-autoclosure.md
@@ -249,38 +249,38 @@ Error attempts:
 Completion Gates:
 | Gate | Applies | Required action | Evidence |
 | --- | --- | --- | --- |
-| Per-PR task ownership | pending | Record exact PR and dedicated task-plan path | pending |
-| Noncompliant PR disposition | pending | Verify task evidence or comment then close and read back | pending |
-| Targeted behavior proof | pending | Run smallest missing owning proof | pending |
-| Source/generated audit | pending | Prove correct source and regenerated mirrors | pending |
-| Package/docs/scenario closure | pending | Run every applicable local contract | pending |
+| Per-PR task ownership | yes | Record exact PR and dedicated task-plan path | Exact #459 body/head/owner and checker verified at 5e61afd5 |
+| Noncompliant PR disposition | no | Verify task evidence or comment then close and read back | PR is compliant; no close action applies |
+| Targeted behavior proof | yes | Run smallest missing owning proof | Post-push 143 React tests pass, zero failures |
+| Source/generated audit | yes | Prove correct source and regenerated mirrors | CLI regeneration; all eight fixture checks pass |
+| Package/docs/scenario closure | yes | Run every applicable local contract | Package build, typechecks, fixtures, verify and runtime lanes pass; no API/doc edits needed |
 | Feedback proof checkout | conditional | Compliant PR only: require local committed `HEAD` = fetched PR ref = live `headRefOid` before proof/reply/resolution and at terminal verification | pending |
 | Live PR feedback resolution | conditional | Compliant PR only: run full `resolve-pr-feedback` and close every actionable P1-or-higher finding; otherwise N/A with noncompliant stop receipts | pending |
-| Feedback priority classification | conditional | Compliant PR only: persist P0-P3 plus rationale for every actionable item; classify ambiguous P1-versus-lower as P1 | pending |
+| Feedback priority classification | yes | Persist P0-P3 and rationale | Six actionable originals retain P1; five addressed, Vercel authorization outstanding; wrapper/status items non-actionable by content |
 | Final P1 proof replay | conditional | Compliant PR only: after the final material branch push, rerun every P1-or-higher proof, including resolved/outdated items | pending |
 | Final live feedback read-back | conditional | Compliant PR only: re-fetch helper plus unfiltered top-level/all-thread inventories; require zero actionable P1-or-higher and explicit P2-or-lower deferrals | pending |
 | External terminal receipt | conditional | Compliant PR only: post/read exact-head receipt; require receipt/live/fetched/local OID equality and no unrecorded helper/raw URL except that verified receipt | pending |
-| Deslop | pending | Run bounded cleanup or N/A | pending |
-| Agent-native reviewer | pending | Run for workflow changes or N/A | pending |
-| Final lint | yes | Run `bun lint:fix` | pending |
-| Repository check | yes | Run `bun check` | pending |
+| Deslop | yes | Run bounded cleanup or N/A | Delta 179 to 179; zero added/worsened occurrences; three local lenses clean |
+| Agent-native reviewer | yes | Run for workflow changes or N/A | Loaded and audited owner/route/proof; no agent action changes or parity gaps |
+| Final lint | yes | Run `bun lint:fix` | 970 files; no changes |
+| Repository check | yes | Run `bun check` | Exit 0; full local logs recorded |
 | GitHub delivery | pending | Commit/push/open or update PR and read back | pending |
-| Autoreview | yes | Resolve every accepted actionable finding | pending |
+| Autoreview | yes | Resolve every accepted actionable finding | PR branch and local fixture-repair reviews both exit 0 with findings [] |
 | Goal plan complete | yes | Run `node .agents/skills/autogoal/scripts/check-complete.mjs docs/plans/2026-09-10-pr459-autoclosure.md` | pending |
-| Agent source / generated sync | pending | Run `bun install` when `.agents/rules/**` changed and verify generated mirrors | pending |
-| Installed lock audit | pending | Verify expected lock entries and removed skills through CLI-managed state | pending |
-| Agent action discoverability | pending | Source-audit the skill/rule path an agent will read | pending |
-| Helper and template smoke | pending | Syntax-check helpers and prove incomplete failure/completed representation when applicable | pending |
-| Agent-native review | pending | Load `.agents/skills/agent-native-reviewer/SKILL.md` and close accepted findings, or record N/A | pending |
+| Agent source / generated sync | no | Run sync for changed rules | No rule, skill, or generated agent mirror changes |
+| Installed lock audit | no | Verify changed skill lock state | No installed-skill changes |
+| Agent action discoverability | no | Audit changed agent actions | No new agent action; existing test/fixture commands are discoverable |
+| Helper and template smoke | no | Test changed helpers/templates | No helper or template changed; original task plan passes checker, closure plan correctly fails while incomplete |
+| Agent-native review | yes | Audit applicable agent surface | No accepted findings; existing CLI owns regenerated fixtures |
 
 Phase / pass table:
 | Phase | Status | Evidence | Next |
 | --- | --- | --- | --- |
-| Inventory | in_progress | plan created | missing proof |
-| Repair | pending | | review |
-| Review/checks | pending | | delivery |
-| Delivery | pending | | final audit |
-| Closeout | pending | | final |
+| Inventory | complete | Exact-head source and all feedback inventoried | repair |
+| Repair | complete | Six manifests regenerated, committed and pushed at 5e61afd5 | review |
+| Review/checks | complete locally | Full local gate and two reviews pass; hosted CI running | delivery |
+| Delivery | blocked | Vercel action-time confirmation unanswered; CI running | owner confirmation |
+| Closeout | blocked | No terminal receipt, merge, or release while authorization is outstanding | final audit after approval |
 
 Verification evidence:
 - Compliance: OPEN e02ac1f39124e0adabb1d164ababb0e8024db312; exactly one body task
@@ -314,13 +314,51 @@ Current checkpoint:
 - A goal-plan checker failure on the unchecked delivery gates is expected;
   it correctly represents incomplete autoclosure, not missing PR task evidence.
 
+Post-push checkpoint:
+- Published repair: 5e61afd57eb6c08eeca01274de74900641a2a33c on
+  tjramage/fix/react-ssr-auth-query-hydration. Local committed HEAD, refs/pr/459
+  and live PR head all match; PR remains OPEN.
+- Post-push React replay: 143 pass, zero fail; original task-plan checker
+  passes; release-draft reuse/single-outcome source assertions pass.
+  `/tmp/kitcn-pr459-react-postpush.log`.
+- Helper and all raw feedback fetched after push. Still four resolved threads,
+  eight inline comments, three top-level comments and six review bodies. The
+  changeset bot's same comment updates its OID/link but its claim and disposition
+  are unchanged. All pagination flags false; no new actionable reviewer item.
+- PR body updated and read back to match fresh local proof and outstanding
+  hosted CI/Vercel gates. Auto-release remains selected.
+- CI run 34535335699 was action_required. Reviewed unchanged contents:read CI
+  workflow and approved this exact run through GitHub; read back queued for
+  5e61afd5. This does not approve the separate Vercel Preview environment.
+- Vercel latest-head authorization is ready in Chrome; no approval click.
+- No terminal zero-P1 receipt, merge, or release performed. Resume after owner
+  confirmation, read the latest CI/head/feedback, then complete remaining gates.
+- This post-push ledger update is local, not a new published proof commit.
+
+Continuation audit:
+- Prior turn made progress: generated fixture repair was verified and published.
+- CI 34535335699 completed SUCCESS at 5e61afd5. Vercel approval is still
+  unanswered (second consecutive turn with the same authorization boundary).
+- https://github.com/udecode/kitcn/pull/459#issuecomment-5626042538 is a
+  non-actionable review-status summary, now Completed for 5e61afd5.
+- https://github.com/udecode/kitcn/pull/459#pullrequestreview-5172745672 is a
+  non-actionable wrapper; its actual finding is separately ledgered below.
+- https://github.com/udecode/kitcn/pull/459#discussion_r3983928239,
+  thread PRRT_kwDOPTlS686hQ2i0: P1 explicit, valid required-evidence mismatch.
+  The task plan's manifest and fixture-output gates still said no changes.
+  Corrected both gates to yes with six generated manifest updates, CLI sync,
+  eight fixture comparisons and runtime proof. This is evidence classification,
+  not a new source/config change. Reply and resolve after published-head replay.
+- Proof: source assertions require both gates to say yes and name their actual
+  generated-output verification; original task-plan checker must pass.
+
 Timeline:
 - 2026-09-10T21:49:34.652Z Autoclosure plan created.
 
 Reboot status:
 | Question | Answer |
 | --- | --- |
-| Where am I? | Inventory |
+| Where am I? | Published repair verified locally; awaiting Vercel approval and CI |
 | Where am I going? | Repair, review/checks, delivery, final audit |
 | What is the goal? | Close only PR459 with honest proof and delivery |
 | What have I learned? | See closure matrix |
@@ -330,5 +368,5 @@ Open risks:
 - Vercel Preview authorization requires explicit action-time confirmation.
   Requested through the user-input UI; no answer received yet. This is not a
   waiver or a code defect, and no deployment was approved.
-- Local fixture repair still needs review and push; exact-head feedback replay,
-  terminal receipt, green CI, merge and actual release readback remain undone.
+- Fixture repair is reviewed and pushed; post-push source/plan proofs pass.
+  Terminal receipt, green CI, merge and actual release readback remain undone.

--- a/fixtures/next-auth/package.json
+++ b/fixtures/next-auth/package.json
@@ -9,7 +9,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/next/package.json
+++ b/fixtures/next/package.json
@@ -8,7 +8,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "react": "19.2.4",

--- a/fixtures/start-auth/package.json
+++ b/fixtures/start-auth/package.json
@@ -17,7 +17,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/start/package.json
+++ b/fixtures/start/package.json
@@ -16,7 +16,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite-auth/package.json
+++ b/fixtures/vite-auth/package.json
@@ -11,7 +11,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -10,7 +10,7 @@
     "convex": "1.44.0",
     "hono": "4.12.9",
     "kitcn": "workspace:*",
-    "lucide-react": "^1.42.0",
+    "lucide-react": "^1.44.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shadcn": "latest",

--- a/packages/kitcn/src/react/context.test.tsx
+++ b/packages/kitcn/src/react/context.test.tsx
@@ -303,6 +303,66 @@ describe('createCRPCContext', () => {
     expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(3);
   });
 
+  test('keeps hydrated queries while only the validation state changes', () => {
+    const api = {} as any;
+    const convexClient = {} as any;
+    const convexQueryClient = {
+      resetAuthQueries: mock(async () => {}),
+    } as any;
+
+    // A server-rendered page reaches the browser carrying a token. The auth
+    // state reports it as unauthenticated while Convex checks it, then as
+    // authenticated once Convex accepts it. The reader did not change, so the
+    // queries the server render hydrated must stay in the cache.
+    const ssrToken = `a.${Buffer.from(
+      JSON.stringify({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        jti: 'ssr-token',
+        sub: 'account-a',
+      })
+    ).toString('base64')}.b`;
+
+    let authState = {
+      isAuthenticated: false,
+      token: ssrToken as string | null,
+    };
+    useAuthValueSpy.mockImplementation(
+      ((key: 'token' | 'isAuthenticated') => authState[key]) as any
+    );
+
+    const { CRPCProvider } = createCRPCContext({ api });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CRPCProvider
+        convexClient={convexClient}
+        convexQueryClient={convexQueryClient}
+      >
+        {children}
+      </CRPCProvider>
+    );
+
+    const hook = renderHook(() => useMeta(), { wrapper });
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    authState = { isAuthenticated: true, token: ssrToken };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    // A re-check of the same token moves the flag back and forth. The reader is
+    // the same throughout, so the cache stays.
+    authState = { isAuthenticated: false, token: ssrToken };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    authState = { isAuthenticated: true, token: ssrToken };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    // Signing out drops the token, which is a different identity.
+    authState = { isAuthenticated: false, token: null };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
+  });
+
   test('ignores token rotation but resets when identity claims change', () => {
     const api = {} as any;
     const convexClient = {} as any;

--- a/packages/kitcn/src/react/context.test.tsx
+++ b/packages/kitcn/src/react/context.test.tsx
@@ -303,7 +303,7 @@ describe('createCRPCContext', () => {
     expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(3);
   });
 
-  test('keeps hydrated queries while only the validation state changes', () => {
+  test('keeps hydrated queries when Convex confirms the same token', () => {
     const api = {} as any;
     const convexClient = {} as any;
     const convexQueryClient = {
@@ -347,18 +347,47 @@ describe('createCRPCContext', () => {
     hook.rerender();
     expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
 
-    // A re-check of the same token moves the flag back and forth. The reader is
-    // the same throughout, so the cache stays.
-    authState = { isAuthenticated: false, token: ssrToken };
-    hook.rerender();
-    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
-
-    authState = { isAuthenticated: true, token: ssrToken };
-    hook.rerender();
-    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
-
     // Signing out drops the token, which is a different identity.
     authState = { isAuthenticated: false, token: null };
+    hook.rerender();
+    expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
+  });
+
+  test('resets auth queries when Convex rejects an existing token', () => {
+    const api = {} as any;
+    const convexClient = {} as any;
+    const convexQueryClient = {
+      resetAuthQueries: mock(async () => {}),
+    } as any;
+    const token = `a.${Buffer.from(
+      JSON.stringify({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        sub: 'account-a',
+      })
+    ).toString('base64')}.b`;
+
+    let authState = {
+      isAuthenticated: true,
+      token: token as string | null,
+    };
+    useAuthValueSpy.mockImplementation(
+      ((key: 'token' | 'isAuthenticated') => authState[key]) as any
+    );
+
+    const { CRPCProvider } = createCRPCContext({ api });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CRPCProvider
+        convexClient={convexClient}
+        convexQueryClient={convexQueryClient}
+      >
+        {children}
+      </CRPCProvider>
+    );
+
+    const hook = renderHook(() => useMeta(), { wrapper });
+    expect(convexQueryClient.resetAuthQueries).not.toHaveBeenCalled();
+
+    authState = { isAuthenticated: false, token };
     hook.rerender();
     expect(convexQueryClient.resetAuthQueries).toHaveBeenCalledTimes(1);
   });

--- a/packages/kitcn/src/react/context.tsx
+++ b/packages/kitcn/src/react/context.tsx
@@ -194,16 +194,14 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
   }) {
     const authStore = useAuthStore();
     const token = useAuthValue('token');
-    const isAuthenticated = useAuthValue('isAuthenticated');
-    const previousAuthRef = useRef<{
-      isAuthenticated: boolean;
+    const previousIdentityRef = useRef<{
       identity: string | null;
     } | null>(null);
     // Get fetchAccessToken from context (immediately available, no race condition)
     const fetchAccessToken = useFetchAccessToken();
 
     useEffect(() => {
-      const previous = previousAuthRef.current;
+      const previous = previousIdentityRef.current;
       const tokenReady = token === null || decodeJwtExp(token) !== null;
       // Compare identity claims, not the raw token. Convex proactively rotates
       // the access token every ~15 minutes and kitcn stamps a fresh `iat` into
@@ -214,23 +212,20 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
       // Non-JWT strings (the opaque SSR session token) keep their own signature
       // so the opaque -> JWT and opaque -> logout transitions still reset.
       const identity = resolveAuthIdentity(token);
-      previousAuthRef.current = {
-        isAuthenticated,
-        identity,
-      };
+      previousIdentityRef.current = { identity };
 
       if (!previous) {
         return;
       }
 
-      if (
-        tokenReady &&
-        (previous.identity !== identity ||
-          previous.isAuthenticated !== isAuthenticated)
-      ) {
+      // Identity only. Whether Convex has accepted the token says nothing about
+      // which account holds it, and it flips on every server-rendered load once
+      // the token in the HTML is checked. A reset there throws away the data the
+      // server render just hydrated.
+      if (tokenReady && previous.identity !== identity) {
         void convexQueryClient.resetAuthQueries();
       }
-    }, [convexQueryClient, isAuthenticated, token]);
+    }, [convexQueryClient, token]);
 
     // Create HTTP proxy inside component with authStore access
     const httpProxy = useMemo(() => {

--- a/packages/kitcn/src/react/context.tsx
+++ b/packages/kitcn/src/react/context.tsx
@@ -194,14 +194,16 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
   }) {
     const authStore = useAuthStore();
     const token = useAuthValue('token');
-    const previousIdentityRef = useRef<{
+    const isAuthenticated = useAuthValue('isAuthenticated');
+    const previousAuthRef = useRef<{
       identity: string | null;
+      isAuthenticated: boolean;
     } | null>(null);
     // Get fetchAccessToken from context (immediately available, no race condition)
     const fetchAccessToken = useFetchAccessToken();
 
     useEffect(() => {
-      const previous = previousIdentityRef.current;
+      const previous = previousAuthRef.current;
       const tokenReady = token === null || decodeJwtExp(token) !== null;
       // Compare identity claims, not the raw token. Convex proactively rotates
       // the access token every ~15 minutes and kitcn stamps a fresh `iat` into
@@ -212,20 +214,21 @@ export function createCRPCContext<TApi extends Record<string, unknown>>(
       // Non-JWT strings (the opaque SSR session token) keep their own signature
       // so the opaque -> JWT and opaque -> logout transitions still reset.
       const identity = resolveAuthIdentity(token);
-      previousIdentityRef.current = { identity };
+      previousAuthRef.current = { identity, isAuthenticated };
 
       if (!previous) {
         return;
       }
 
-      // Identity only. Whether Convex has accepted the token says nothing about
-      // which account holds it, and it flips on every server-rendered load once
-      // the token in the HTML is checked. A reset there throws away the data the
-      // server render just hydrated.
-      if (tokenReady && previous.identity !== identity) {
+      // Convex initially reports false while confirming the token supplied by
+      // SSR, so false -> true for the same identity preserves hydrated data.
+      // Once accepted, true -> false means Convex rejected the existing token
+      // and its auth-bound cache must be cleared even if the token is retained.
+      const tokenRejected = previous.isAuthenticated && !isAuthenticated;
+      if ((tokenReady && previous.identity !== identity) || tokenRejected) {
         void convexQueryClient.resetAuthQueries();
       }
-    }, [convexQueryClient, token]);
+    }, [convexQueryClient, isAuthenticated, token]);
 
     // Create HTTP proxy inside component with authStore access
     const httpProxy = useMemo(() => {


### PR DESCRIPTION
<!-- auto-release:start -->
- [x] Auto release
<!-- auto-release:end -->

🐛 Fixes ➖ N/A
🧭 Task plan: docs/plans/2026-09-10-fix-react-ssr-auth-query-hydration.md
🟢 94% confidence

| Phase | 🧪 Tests | 🌐 Browser |
| --- | --- | --- |
| Reproduced | 🔴 Same-token confirmation triggered an auth-query reset | ➖ N/A: provider lifecycle |
| Verified | 🟢 143 React tests; package build; full local `bun check`; eight fixture checks | ➖ No Preview proof yet |

**✅ Outcome**

Authenticated cRPC results survive SSR token confirmation. Rejected tokens,
sign-out, and identity changes still clear auth-bound queries.

**🏗️ Design**

The shared provider distinguishes token identity changes and token rejection
from initial confirmation. Routine JWT rotation and explicit query resets keep
their existing behavior. Generated fixture manifests match fresh scaffolds.

**⚠️ Caveat**

Hosted CI passed for `5afe69a55ac30c7a0a100934c359419e17aefae4`.
Vercel fork-deployment authorization is awaiting owner confirmation. No merge,
Preview verification, or release is claimed.

**🧪 Verified**

- 143 React tests, 0 failures, replayed after push at the exact PR head.
- Package build and all five workspace typechecks pass locally.
- Full local `bun check` passes, including CLI/Concave, fixture, verify, and
  runtime lanes; both auth smoke scenarios pass.
- All eight generated fixture checks pass after CLI-driven synchronization.
- Independent reviews of the PR source and fixture repair report no P0/P1
  findings. Five inline feedback threads are resolved and have proof replies.
- The existing release draft contains the hydration fix; no extra changeset.
